### PR TITLE
Psr7 Uploaded File: use stateless properties to cache already done moves

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="4.6.1@e93e532e4eaad6d68c4d7b606853800eaceccc72">
+<files psalm-version="4.6.3@f1a840727dd756899eee2f1f9ea443e265a4763f">
   <file src="src/AbstractDateDropdown.php">
     <InvalidArgument occurrences="1">
       <code>$options</code>
@@ -988,9 +988,7 @@
     <MixedArrayAccess occurrences="1">
       <code>$target[strlen($target) - 1]</code>
     </MixedArrayAccess>
-    <MixedArrayOffset occurrences="5">
-      <code>$this-&gt;alreadyFiltered[$sourceFile]</code>
-      <code>$this-&gt;alreadyFiltered[$sourceFile]</code>
+    <MixedArrayOffset occurrences="3">
       <code>$this-&gt;alreadyFiltered[$sourceFile]</code>
       <code>$this-&gt;alreadyFiltered[$sourceFile]</code>
       <code>$this-&gt;alreadyFiltered[$sourceFile]</code>
@@ -1020,8 +1018,8 @@
       <code>$targetDir</code>
     </MixedOperand>
     <MixedReturnStatement occurrences="10">
+      <code>$this-&gt;alreadyFiltered[$alreadyFilteredKey]</code>
       <code>$this-&gt;alreadyFiltered[$fileName]</code>
-      <code>$this-&gt;alreadyFiltered[$sourceFile]</code>
       <code>$this-&gt;alreadyFiltered[$sourceFile]</code>
       <code>$this-&gt;options['overwrite']</code>
       <code>$this-&gt;options['randomize']</code>
@@ -1041,9 +1039,6 @@
     <PossiblyInvalidArgument occurrences="1">
       <code>$sourceFile</code>
     </PossiblyInvalidArgument>
-    <PossiblyNullArrayOffset occurrences="1">
-      <code>$this-&gt;alreadyFiltered</code>
-    </PossiblyNullArrayOffset>
     <RedundantCastGivenDocblockType occurrences="4">
       <code>(bool) $flag</code>
       <code>(bool) $flag</code>
@@ -1589,9 +1584,6 @@
     <MissingReturnType occurrences="1">
       <code>enforceScheme</code>
     </MissingReturnType>
-    <MixedInferredReturnType occurrences="1">
-      <code>string</code>
-    </MixedInferredReturnType>
     <MixedReturnStatement occurrences="1">
       <code>$value</code>
     </MixedReturnStatement>
@@ -2350,6 +2342,13 @@
     <MissingReturnType occurrences="1">
       <code>testWrongSizeVector</code>
     </MissingReturnType>
+    <MixedArgument occurrences="1">
+      <code>$input</code>
+    </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$input</code>
+      <code>$output</code>
+    </MixedAssignment>
     <UndefinedMethod occurrences="2">
       <code>fail</code>
       <code>fail</code>
@@ -2363,9 +2362,14 @@
     <MissingReturnType occurrences="1">
       <code>testPassCompressionConfigWillBeUnsetCorrectly</code>
     </MissingReturnType>
-    <MixedArgument occurrences="1">
+    <MixedArgument occurrences="2">
+      <code>$input</code>
       <code>$r-&gt;getValue($filter)</code>
     </MixedArgument>
+    <MixedAssignment occurrences="2">
+      <code>$input</code>
+      <code>$output</code>
+    </MixedAssignment>
   </file>
   <file src="test/EncryptTest.php">
     <ArgumentTypeCoercion occurrences="2">
@@ -2496,8 +2500,10 @@
     <InvalidScalarArgument occurrences="1">
       <code>1234</code>
     </InvalidScalarArgument>
-    <MissingClosureParamType occurrences="1">
+    <MissingClosureParamType occurrences="3">
       <code>$args</code>
+      <code>$args</code>
+      <code>$mock</code>
     </MissingClosureParamType>
     <MissingParamType occurrences="2">
       <code>$dir</code>
@@ -2527,6 +2533,10 @@
       <code>$firstResult</code>
       <code>$targetFile</code>
     </MixedAssignment>
+    <MixedMethodCall occurrences="2">
+      <code>getStream</code>
+      <code>willThrow</code>
+    </MixedMethodCall>
     <MixedOperand occurrences="1">
       <code>$dir</code>
     </MixedOperand>

--- a/src/File/RenameUpload.php
+++ b/src/File/RenameUpload.php
@@ -394,12 +394,13 @@ class RenameUpload extends AbstractFilter
      */
     private function filterPsr7UploadedFile(UploadedFileInterface $uploadedFile)
     {
-        $sourceFile = $uploadedFile->getStream()->getMetadata('uri');
+        $alreadyFilteredKey = spl_object_hash($uploadedFile);
 
-        if (isset($this->alreadyFiltered[$sourceFile])) {
-            return $this->alreadyFiltered[$sourceFile];
+        if (isset($this->alreadyFiltered[$alreadyFilteredKey])) {
+            return $this->alreadyFiltered[$alreadyFilteredKey];
         }
 
+        $sourceFile = $uploadedFile->getStream()->getMetadata('uri');
         $clientFilename = $uploadedFile->getClientFilename();
         $targetFile     = $this->getFinalTarget($sourceFile, $clientFilename);
 
@@ -432,7 +433,7 @@ class RenameUpload extends AbstractFilter
             ));
         }
 
-        $this->alreadyFiltered[$sourceFile] = $uploadedFileFactory->createUploadedFile(
+        $this->alreadyFiltered[$alreadyFilteredKey] = $uploadedFileFactory->createUploadedFile(
             $stream,
             filesize($targetFile),
             UPLOAD_ERR_OK,
@@ -440,6 +441,6 @@ class RenameUpload extends AbstractFilter
             $uploadedFile->getClientMediaType()
         );
 
-        return $this->alreadyFiltered[$sourceFile];
+        return $this->alreadyFiltered[$alreadyFilteredKey];
     }
 }

--- a/test/File/RenameUploadTest.php
+++ b/test/File/RenameUploadTest.php
@@ -188,7 +188,11 @@ class RenameUploadTest extends TestCase
         $originalStream->getMetadata('uri')->willReturn($this->sourceFile);
 
         $originalFile = $this->prophesize(UploadedFileInterface::class);
-        $originalFile->getStream()->will([$originalStream, 'reveal']);
+        $originalFile->getStream()->will(function ($args, $mock) use ($originalStream) {
+            $mock->getStream()->willThrow(new \RuntimeException('Cannot call getStream() more than once'));
+
+            return $originalStream->reveal();
+        });
         $originalFile->getClientFilename()->willReturn($targetFile);
         $originalFile
             ->moveTo($targetFile)
@@ -227,6 +231,10 @@ class RenameUploadTest extends TestCase
         $moved = $filter($originalFile->reveal());
 
         $this->assertSame($renamedFile->reveal(), $moved);
+
+        $secondResult = $filter($originalFile->reveal());
+
+        $this->assertSame($moved, $secondResult);
     }
 
     /**


### PR DESCRIPTION
Hi, I'm the author of the original PR that allowed filtering multiple times: https://github.com/zendframework/zendframework/pull/3749

I'm using PSR7 now, and I am unable to call both `$form->isValid();` and `$form->getData();` consequentially, because the filter attempts to call `\Psr\Http\Message\UploadedFileInterface::getStream` twice:

https://github.com/laminas/laminas-filter/blob/76a81282404795302c188ed25a5b7afcc8b7a889/src/File/RenameUpload.php#L389-L395

This is an issue since `\Psr\Http\Message\UploadedFileInterface` may be stateful, like the Diactoros one: you can only call `getStream` before the `moveTo`; after that an exception is raised:

https://github.com/laminas/laminas-diactoros/blob/bcb2daf4201fb2a1090522e42b163429c5be7b99/src/UploadedFile.php#L139-L141

So the `uri` cannot be used as a key for the internal cache.

`spl_object_hash` is good though.