### PR TITLE
Fix fatal errors due to strict types in string filters

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,11 @@
         "forum": "https://discourse.laminas.dev"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "composer/package-versions-deprecated": true
+        }
     },
     "extra": {
         "laminas": {

--- a/src/AbstractFilter.php
+++ b/src/AbstractFilter.php
@@ -107,6 +107,8 @@ abstract class AbstractFilter implements FilterInterface
     }
 
     /**
+     * @internal
+     *
      * @param  mixed $value
      * @return mixed
      */

--- a/src/AbstractFilter.php
+++ b/src/AbstractFilter.php
@@ -8,10 +8,12 @@ use Laminas\Stdlib\StringUtils;
 use Traversable;
 
 use function array_key_exists;
+use function array_map;
 use function get_class;
 use function gettype;
 use function is_array;
 use function is_object;
+use function is_scalar;
 use function method_exists;
 use function sprintf;
 use function str_replace;
@@ -102,5 +104,20 @@ abstract class AbstractFilter implements FilterInterface
     protected static function isOptions($options)
     {
         return is_array($options) || $options instanceof Traversable;
+    }
+
+    /**
+     * @param  mixed $value
+     * @return mixed
+     */
+    protected static function applyFilterOnlyToStringableValuesAndStringableArrayValues($value, callable $callback)
+    {
+        if (! is_array($value)) {
+            if (! is_scalar($value)) {
+                return $value;
+            }
+            return $callback((string) $value);
+        }
+        return $callback(array_map(fn($item) => is_scalar($item) ? (string) $item : $item, $value));
     }
 }

--- a/src/Encrypt/Openssl.php
+++ b/src/Encrypt/Openssl.php
@@ -503,6 +503,7 @@ class Openssl implements EncryptionAlgorithmInterface
     {
         if (PHP_VERSION_ID < 80000) {
             foreach ($keys as $key) {
+                // phpcs:ignore Generic.PHP.DeprecatedFunctions.Deprecated
                 openssl_free_key($key);
             }
         }

--- a/src/PregReplace.php
+++ b/src/PregReplace.php
@@ -137,8 +137,13 @@ class PregReplace extends AbstractFilter
      */
     public function filter($value)
     {
-        if (! is_scalar($value) && ! is_array($value)) {
-            return $value;
+        if (! is_array($value)) {
+            if (! is_scalar($value)) {
+                return $value;
+            }
+            if (! is_string($value)) {
+                $value = (string) $value;
+            }
         }
 
         if ($this->options['pattern'] === null) {

--- a/src/StripNewlines.php
+++ b/src/StripNewlines.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use function is_array;
-use function is_scalar;
-use function is_string;
+use Closure;
+
 use function str_replace;
 
 class StripNewlines extends AbstractFilter
@@ -21,14 +20,18 @@ class StripNewlines extends AbstractFilter
      */
     public function filter($value)
     {
-        if (! is_array($value)) {
-            if (! is_scalar($value)) {
-                return $value;
-            }
-            if (! is_string($value)) {
-                $value = (string) $value;
-            }
-        }
+        return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
+            $value,
+            Closure::fromCallable([$this, 'filterNormalizedValue'])
+        );
+    }
+
+    /**
+     * @param  string|string[] $value
+     * @return string|string[]
+     */
+    private function filterNormalizedValue($value)
+    {
         return str_replace(["\n", "\r"], '', $value);
     }
 }

--- a/src/StripNewlines.php
+++ b/src/StripNewlines.php
@@ -6,6 +6,7 @@ namespace Laminas\Filter;
 
 use function is_array;
 use function is_scalar;
+use function is_string;
 use function str_replace;
 
 class StripNewlines extends AbstractFilter
@@ -15,13 +16,18 @@ class StripNewlines extends AbstractFilter
      *
      * Returns $value without newline control characters
      *
-     * @param  string|array $value
-     * @return string|array
+     * @param  mixed $value
+     * @return mixed
      */
     public function filter($value)
     {
-        if (! is_scalar($value) && ! is_array($value)) {
-            return $value;
+        if (! is_array($value)) {
+            if (! is_scalar($value)) {
+                return $value;
+            }
+            if (! is_string($value)) {
+                $value = (string) $value;
+            }
         }
         return str_replace(["\n", "\r"], '', $value);
     }

--- a/src/Word/CamelCaseToSeparator.php
+++ b/src/Word/CamelCaseToSeparator.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Laminas\Filter\Word;
 
+use Closure;
 use Laminas\Stdlib\StringUtils;
 
-use function is_array;
-use function is_scalar;
-use function is_string;
 use function preg_replace;
 
 class CamelCaseToSeparator extends AbstractSeparator
@@ -21,15 +19,18 @@ class CamelCaseToSeparator extends AbstractSeparator
      */
     public function filter($value)
     {
-        if (! is_array($value)) {
-            if (! is_scalar($value)) {
-                return $value;
-            }
-            if (! is_string($value)) {
-                $value = (string) $value;
-            }
-        }
+        return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
+            $value,
+            Closure::fromCallable([$this, 'filterNormalizedValue'])
+        );
+    }
 
+    /**
+     * @param  string|string[] $value
+     * @return string|string[]
+     */
+    private function filterNormalizedValue($value)
+    {
         if (StringUtils::hasPcreUnicodeSupport()) {
             $pattern     = ['#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#'];
             $replacement = [$this->separator . '\1', $this->separator . '\1'];

--- a/src/Word/CamelCaseToSeparator.php
+++ b/src/Word/CamelCaseToSeparator.php
@@ -8,6 +8,7 @@ use Laminas\Stdlib\StringUtils;
 
 use function is_array;
 use function is_scalar;
+use function is_string;
 use function preg_replace;
 
 class CamelCaseToSeparator extends AbstractSeparator
@@ -15,13 +16,18 @@ class CamelCaseToSeparator extends AbstractSeparator
     /**
      * Defined by Laminas\Filter\Filter
      *
-     * @param  string|array $value
-     * @return string|array
+     * @param  mixed $value
+     * @return mixed
      */
     public function filter($value)
     {
-        if (! is_scalar($value) && ! is_array($value)) {
-            return $value;
+        if (! is_array($value)) {
+            if (! is_scalar($value)) {
+                return $value;
+            }
+            if (! is_string($value)) {
+                $value = (string) $value;
+            }
         }
 
         if (StringUtils::hasPcreUnicodeSupport()) {

--- a/src/Word/DashToSeparator.php
+++ b/src/Word/DashToSeparator.php
@@ -6,6 +6,7 @@ namespace Laminas\Filter\Word;
 
 use function is_array;
 use function is_scalar;
+use function is_string;
 use function str_replace;
 
 class DashToSeparator extends AbstractSeparator
@@ -13,13 +14,18 @@ class DashToSeparator extends AbstractSeparator
     /**
      * Defined by Laminas\Filter\Filter
      *
-     * @param  string|array $value
-     * @return string|array
+     * @param mixed $value
+     * @return mixed
      */
     public function filter($value)
     {
-        if (! is_scalar($value) && ! is_array($value)) {
-            return $value;
+        if (! is_array($value)) {
+            if (! is_scalar($value)) {
+                return $value;
+            }
+            if (! is_string($value)) {
+                $value = (string) $value;
+            }
         }
 
         return str_replace('-', $this->separator, $value);

--- a/src/Word/DashToSeparator.php
+++ b/src/Word/DashToSeparator.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Laminas\Filter\Word;
 
-use function is_array;
-use function is_scalar;
-use function is_string;
+use Closure;
+
 use function str_replace;
 
 class DashToSeparator extends AbstractSeparator
@@ -14,20 +13,23 @@ class DashToSeparator extends AbstractSeparator
     /**
      * Defined by Laminas\Filter\Filter
      *
-     * @param mixed $value
+     * @param  mixed $value
      * @return mixed
      */
     public function filter($value)
     {
-        if (! is_array($value)) {
-            if (! is_scalar($value)) {
-                return $value;
-            }
-            if (! is_string($value)) {
-                $value = (string) $value;
-            }
-        }
+        return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
+            $value,
+            Closure::fromCallable([$this, 'filterNormalizedValue'])
+        );
+    }
 
+    /**
+     * @param  string|string[] $value
+     * @return string|string[]
+     */
+    private function filterNormalizedValue($value)
+    {
         return str_replace('-', $this->separator, $value);
     }
 }

--- a/src/Word/SeparatorToCamelCase.php
+++ b/src/Word/SeparatorToCamelCase.php
@@ -9,6 +9,7 @@ use Laminas\Stdlib\StringUtils;
 use function extension_loaded;
 use function is_array;
 use function is_scalar;
+use function is_string;
 use function preg_quote;
 use function preg_replace_callback;
 
@@ -17,13 +18,18 @@ class SeparatorToCamelCase extends AbstractSeparator
     /**
      * Defined by Laminas\Filter\Filter
      *
-     * @param  string|array $value
-     * @return string|array
+     * @param  mixed $value
+     * @return mixed
      */
     public function filter($value)
     {
-        if (! is_scalar($value) && ! is_array($value)) {
-            return $value;
+        if (! is_array($value)) {
+            if (! is_scalar($value)) {
+                return $value;
+            }
+            if (! is_string($value)) {
+                $value = (string) $value;
+            }
         }
 
         // a unicode safe way of converting characters to \x00\x00 notation

--- a/src/Word/SeparatorToCamelCase.php
+++ b/src/Word/SeparatorToCamelCase.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Filter\Word;
 
+use Closure;
 use Laminas\Stdlib\StringUtils;
 
 use function extension_loaded;
-use function is_array;
-use function is_scalar;
-use function is_string;
 use function preg_quote;
 use function preg_replace_callback;
 
@@ -23,15 +21,18 @@ class SeparatorToCamelCase extends AbstractSeparator
      */
     public function filter($value)
     {
-        if (! is_array($value)) {
-            if (! is_scalar($value)) {
-                return $value;
-            }
-            if (! is_string($value)) {
-                $value = (string) $value;
-            }
-        }
+        return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
+            $value,
+            Closure::fromCallable([$this, 'filterNormalizedValue'])
+        );
+    }
 
+    /**
+     * @param  string|string[] $value
+     * @return string|string[]
+     */
+    private function filterNormalizedValue($value)
+    {
         // a unicode safe way of converting characters to \x00\x00 notation
         $pregQuotedSeparator = preg_quote($this->separator, '#');
 

--- a/src/Word/SeparatorToSeparator.php
+++ b/src/Word/SeparatorToSeparator.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Laminas\Filter\Word;
 
+use Closure;
 use Laminas\Filter\AbstractFilter;
 use Laminas\Filter\Exception;
 
-use function is_array;
-use function is_scalar;
-use function is_string;
 use function preg_quote;
 use function preg_replace;
 
@@ -84,20 +82,26 @@ class SeparatorToSeparator extends AbstractFilter
      */
     public function filter($value)
     {
-        if (! is_array($value)) {
-            if (! is_scalar($value)) {
-                return $value;
-            }
-            if (! is_string($value)) {
-                $value = (string) $value;
-            }
-        }
+        return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
+            $value,
+            Closure::fromCallable([$this, 'filterNormalizedValue'])
+        );
+    }
 
+    /**
+     * @param  string|string[] $value
+     * @return string|string[]
+     */
+    private function filterNormalizedValue($value)
+    {
         if ($this->searchSeparator === null) {
             throw new Exception\RuntimeException('You must provide a search separator for this filter to work.');
         }
 
-        $pattern = '#' . preg_quote($this->searchSeparator, '#') . '#';
-        return preg_replace($pattern, $this->replacementSeparator, $value);
+        return preg_replace(
+            '#' . preg_quote($this->searchSeparator, '#') . '#',
+            $this->replacementSeparator,
+            $value
+        );
     }
 }

--- a/src/Word/SeparatorToSeparator.php
+++ b/src/Word/SeparatorToSeparator.php
@@ -9,6 +9,7 @@ use Laminas\Filter\Exception;
 
 use function is_array;
 use function is_scalar;
+use function is_string;
 use function preg_quote;
 use function preg_replace;
 
@@ -78,13 +79,18 @@ class SeparatorToSeparator extends AbstractFilter
      *
      * Returns the string $value, replacing the searched separators with the defined ones
      *
-     * @param  string|array $value
-     * @return string|array
+     * @param  mixed $value
+     * @return mixed
      */
     public function filter($value)
     {
-        if (! is_scalar($value) && ! is_array($value)) {
-            return $value;
+        if (! is_array($value)) {
+            if (! is_scalar($value)) {
+                return $value;
+            }
+            if (! is_string($value)) {
+                $value = (string) $value;
+            }
         }
 
         if ($this->searchSeparator === null) {

--- a/src/Word/UnderscoreToStudlyCase.php
+++ b/src/Word/UnderscoreToStudlyCase.php
@@ -28,6 +28,7 @@ class UnderscoreToStudlyCase extends UnderscoreToCamelCase
             return $value;
         }
 
+        /** @var string|array $value */
         $value          = parent::filter($value);
         $lowerCaseFirst = 'lcfirst';
 

--- a/test/AllowListTest.php
+++ b/test/AllowListTest.php
@@ -24,16 +24,16 @@ class AllowListTest extends TestCase
             'strict' => true,
         ]);
 
-        $this->assertEquals(true, $filter->getStrict());
-        $this->assertEquals(['test', 1], $filter->getList());
+        $this->assertSame(true, $filter->getStrict());
+        $this->assertSame(['test', 1], $filter->getList());
     }
 
     public function testConstructorDefaults(): void
     {
         $filter = new AllowListFilter();
 
-        $this->assertEquals(false, $filter->getStrict());
-        $this->assertEquals([], $filter->getList());
+        $this->assertSame(false, $filter->getStrict());
+        $this->assertSame([], $filter->getList());
     }
 
     public function testWithPluginManager(): void
@@ -59,7 +59,7 @@ class AllowListTest extends TestCase
         $filter = new AllowListFilter([
             'list' => $obj,
         ]);
-        $this->assertEquals($array, $filter->getList());
+        $this->assertSame($array, $filter->getList());
     }
 
     public function testSetStrictShouldCastToBoolean(): void

--- a/test/BaseNameTest.php
+++ b/test/BaseNameTest.php
@@ -12,10 +12,8 @@ class BaseNameTest extends TestCase
 {
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter         = new BaseNameFilter();
         $valuesExpected = [
@@ -23,7 +21,7 @@ class BaseNameTest extends TestCase
             '/path/to/filename.ext' => 'filename.ext',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
@@ -43,12 +41,11 @@ class BaseNameTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new BaseNameFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/BooleanTest.php
+++ b/test/BooleanTest.php
@@ -14,22 +14,22 @@ use function var_export;
 
 class BooleanTest extends TestCase
 {
-    public function testConstructorOptions()
+    public function testConstructorOptions(): void
     {
         $filter = new BooleanFilter([
             'type'    => BooleanFilter::TYPE_INTEGER,
             'casting' => false,
         ]);
 
-        $this->assertEquals(BooleanFilter::TYPE_INTEGER, $filter->getType());
+        $this->assertSame(BooleanFilter::TYPE_INTEGER, $filter->getType());
         $this->assertFalse($filter->getCasting());
     }
 
-    public function testConstructorParams()
+    public function testConstructorParams(): void
     {
         $filter = new BooleanFilter(BooleanFilter::TYPE_INTEGER, false);
 
-        $this->assertEquals(BooleanFilter::TYPE_INTEGER, $filter->getType());
+        $this->assertSame(BooleanFilter::TYPE_INTEGER, $filter->getType());
         $this->assertFalse($filter->getCasting());
     }
 
@@ -38,7 +38,7 @@ class BooleanTest extends TestCase
      * @param bool  $expected
      * @dataProvider defaultTestProvider
      */
-    public function testDefault($value, $expected)
+    public function testDefault($value, $expected): void
     {
         $filter = new BooleanFilter();
         $this->assertSame($expected, $filter->filter($value));
@@ -49,10 +49,10 @@ class BooleanTest extends TestCase
      * @param bool  $expected
      * @dataProvider noCastingTestProvider
      */
-    public function testNoCasting($value, $expected)
+    public function testNoCasting($value, $expected): void
     {
         $filter = new BooleanFilter('all', false);
-        $this->assertEquals($expected, $filter->filter($value));
+        $this->assertSame($expected, $filter->filter($value));
     }
 
     /**
@@ -60,7 +60,7 @@ class BooleanTest extends TestCase
      * @param array $testData
      * @dataProvider typeTestProvider
      */
-    public function testTypes($type, $testData)
+    public function testTypes($type, $testData): void
     {
         $filter = new BooleanFilter($type);
         foreach ($testData as $data) {
@@ -81,7 +81,7 @@ class BooleanTest extends TestCase
      * @param array $testData
      * @dataProvider combinedTypeTestProvider
      */
-    public function testCombinedTypes($typeData, $testData)
+    public function testCombinedTypes($typeData, $testData): void
     {
         foreach ($typeData as $type) {
             $filter = new BooleanFilter(['type' => $type]);
@@ -99,7 +99,7 @@ class BooleanTest extends TestCase
         }
     }
 
-    public function testLocalized()
+    public function testLocalized(): void
     {
         $filter = new BooleanFilter([
             'type'         => BooleanFilter::TYPE_LOCALIZED,
@@ -119,7 +119,7 @@ class BooleanTest extends TestCase
         $this->assertFalse($filter->filter('nay'));
     }
 
-    public function testSettingFalseType()
+    public function testSettingFalseType(): void
     {
         $filter = new BooleanFilter();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -127,10 +127,10 @@ class BooleanTest extends TestCase
         $filter->setType(true);
     }
 
-    public function testGettingDefaultType()
+    public function testGettingDefaultType(): void
     {
         $filter = new BooleanFilter();
-        $this->assertEquals(127, $filter->getType());
+        $this->assertSame(127, $filter->getType());
     }
 
     /**
@@ -140,10 +140,10 @@ class BooleanTest extends TestCase
      * @param mixed $type Type to double initialize
      * @dataProvider duplicateProvider
      */
-    public function testDuplicateTypesWorkProperly($type, $expected)
+    public function testDuplicateTypesWorkProperly($type, $expected): void
     {
         $filter = new BooleanFilter([$type, $type]);
-        $this->assertEquals($expected, $filter->getType());
+        $this->assertSame($expected, $filter->getType());
     }
 
     public static function defaultTestProvider()
@@ -187,7 +187,7 @@ class BooleanTest extends TestCase
             ['2', '2'],
             [[], false],
             [[0], [0]],
-            [null, null],
+            [null, false],
             ['false', false],
             ['true', true],
         ];

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -9,61 +9,61 @@ use PHPUnit\Framework\TestCase;
 
 class CallbackTest extends TestCase
 {
-    public function testObjectCallback()
+    public function testObjectCallback(): void
     {
         $filter = new CallbackFilter([$this, 'objectCallback']);
-        $this->assertEquals('objectCallback-test', $filter('test'));
+        $this->assertSame('objectCallback-test', $filter('test'));
     }
 
-    public function testConstructorWithOptions()
+    public function testConstructorWithOptions(): void
     {
         $filter = new CallbackFilter([
             'callback'        => [$this, 'objectCallbackWithParams'],
             'callback_params' => 0,
         ]);
 
-        $this->assertEquals('objectCallbackWithParams-test-0', $filter('test'));
+        $this->assertSame('objectCallbackWithParams-test-0', $filter('test'));
     }
 
-    public function testStaticCallback()
+    public function testStaticCallback(): void
     {
         $filter = new CallbackFilter(
             [self::class, 'staticCallback']
         );
-        $this->assertEquals('staticCallback-test', $filter('test'));
+        $this->assertSame('staticCallback-test', $filter('test'));
     }
 
-    public function testStringClassCallback()
+    public function testStringClassCallback(): void
     {
         $filter = new CallbackFilter(self::class);
-        $this->assertEquals('stringClassCallback-test', $filter('test'));
+        $this->assertSame('stringClassCallback-test', $filter('test'));
     }
 
-    public function testSettingDefaultOptions()
+    public function testSettingDefaultOptions(): void
     {
         $filter = new CallbackFilter([$this, 'objectCallback'], 'param');
-        $this->assertEquals(['param'], $filter->getCallbackParams());
-        $this->assertEquals('objectCallback-test', $filter('test'));
+        $this->assertSame(['param'], $filter->getCallbackParams());
+        $this->assertSame('objectCallback-test', $filter('test'));
     }
 
-    public function testSettingDefaultOptionsAfterwards()
+    public function testSettingDefaultOptionsAfterwards(): void
     {
         $filter = new CallbackFilter([$this, 'objectCallback']);
         $filter->setCallbackParams('param');
-        $this->assertEquals(['param'], $filter->getCallbackParams());
-        $this->assertEquals('objectCallback-test', $filter('test'));
+        $this->assertSame(['param'], $filter->getCallbackParams());
+        $this->assertSame('objectCallback-test', $filter('test'));
     }
 
-    public function testCallbackWithStringParameter()
+    public function testCallbackWithStringParameter(): void
     {
         $filter = new CallbackFilter('strrev');
-        $this->assertEquals('!olleH', $filter('Hello!'));
+        $this->assertSame('!olleH', $filter('Hello!'));
     }
 
-    public function testCallbackWithArrayParameters()
+    public function testCallbackWithArrayParameters(): void
     {
         $filter = new CallbackFilter('strrev');
-        $this->assertEquals('!olleH', $filter('Hello!'));
+        $this->assertSame('!olleH', $filter('Hello!'));
     }
 
     public function objectCallback($value)

--- a/test/Compress/Bz2Test.php
+++ b/test/Compress/Bz2Test.php
@@ -37,10 +37,8 @@ class Bz2Test extends TestCase
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         $filter = new Bz2Compression();
 
@@ -48,7 +46,7 @@ class Bz2Test extends TestCase
         $this->assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
@@ -59,17 +57,17 @@ class Bz2Test extends TestCase
     public function testBz2GetSetOptions()
     {
         $filter = new Bz2Compression();
-        $this->assertEquals(['blocksize' => 4, 'archive' => null], $filter->getOptions());
+        $this->assertSame(['blocksize' => 4, 'archive' => null], $filter->getOptions());
 
-        $this->assertEquals(4, $filter->getOptions('blocksize'));
+        $this->assertSame(4, $filter->getOptions('blocksize'));
 
         $this->assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['blocksize' => 6]);
-        $this->assertEquals(6, $filter->getOptions('blocksize'));
+        $this->assertSame(6, $filter->getOptions('blocksize'));
 
         $filter->setOptions(['archive' => 'test.txt']);
-        $this->assertEquals('test.txt', $filter->getOptions('archive'));
+        $this->assertSame('test.txt', $filter->getOptions('archive'));
 
         $filter->setOptions(['nooption' => 0]);
         $this->assertNull($filter->getOptions('nooption'));
@@ -83,7 +81,7 @@ class Bz2Test extends TestCase
     public function testBz2GetSetOptionsInConstructor()
     {
         $filter2 = new Bz2Compression(['blocksize' => 8]);
-        $this->assertEquals(['blocksize' => 8, 'archive' => null], $filter2->getOptions());
+        $this->assertSame(['blocksize' => 8, 'archive' => null], $filter2->getOptions());
     }
 
     /**
@@ -94,9 +92,9 @@ class Bz2Test extends TestCase
     public function testBz2GetSetBlocksize()
     {
         $filter = new Bz2Compression();
-        $this->assertEquals(4, $filter->getBlocksize());
+        $this->assertSame(4, $filter->getBlocksize());
         $filter->setBlocksize(6);
-        $this->assertEquals(6, $filter->getOptions('blocksize'));
+        $this->assertSame(6, $filter->getOptions('blocksize'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('must be between');
@@ -111,10 +109,10 @@ class Bz2Test extends TestCase
     public function testBz2GetSetArchive()
     {
         $filter = new Bz2Compression();
-        $this->assertEquals(null, $filter->getArchive());
+        $this->assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getArchive());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('archive'));
+        $this->assertSame('Testfile.txt', $filter->getArchive());
+        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -133,12 +131,12 @@ class Bz2Test extends TestCase
 
         $filter2  = new Bz2Compression();
         $content2 = $filter2->decompress($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
 
         $filter3 = new Bz2Compression();
         $filter3->setArchive($archive);
         $content3 = $filter3->decompress(null);
-        $this->assertEquals('compress me', $content3);
+        $this->assertSame('compress me', $content3);
     }
 
     /**
@@ -149,7 +147,7 @@ class Bz2Test extends TestCase
     public function testBz2ToString()
     {
         $filter = new Bz2Compression();
-        $this->assertEquals('Bz2', $filter->toString());
+        $this->assertSame('Bz2', $filter->toString());
     }
 
     /**
@@ -168,7 +166,7 @@ class Bz2Test extends TestCase
 
         $filter2  = new Bz2Compression();
         $content2 = $filter2->decompress($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
     }
 
     public function testBz2DecompressNullValueIsAccepted()

--- a/test/Compress/GzTest.php
+++ b/test/Compress/GzTest.php
@@ -37,10 +37,8 @@ class GzTest extends TestCase
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         $filter = new GzCompression();
 
@@ -48,57 +46,51 @@ class GzTest extends TestCase
         $this->assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Setting Options
-     *
-     * @return void
      */
-    public function testGzGetSetOptions()
+    public function testGzGetSetOptions(): void
     {
         $filter = new GzCompression();
-        $this->assertEquals(['mode' => 'compress', 'level' => 9, 'archive' => null], $filter->getOptions());
+        $this->assertSame(['level' => 9, 'mode' => 'compress', 'archive' => null], $filter->getOptions());
 
-        $this->assertEquals(9, $filter->getOptions('level'));
+        $this->assertSame(9, $filter->getOptions('level'));
 
         $this->assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooption' => 'foo']);
         $this->assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['level' => 6]);
-        $this->assertEquals(6, $filter->getOptions('level'));
+        $this->assertSame(6, $filter->getOptions('level'));
 
         $filter->setOptions(['mode' => 'deflate']);
-        $this->assertEquals('deflate', $filter->getOptions('mode'));
+        $this->assertSame('deflate', $filter->getOptions('mode'));
 
         $filter->setOptions(['archive' => 'test.txt']);
-        $this->assertEquals('test.txt', $filter->getOptions('archive'));
+        $this->assertSame('test.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Options through constructor
-     *
-     * @return void
      */
-    public function testGzGetSetOptionsInConstructor()
+    public function testGzGetSetOptionsInConstructor(): void
     {
         $filter2 = new GzCompression(['level' => 8]);
-        $this->assertEquals(['mode' => 'compress', 'level' => 8, 'archive' => null], $filter2->getOptions());
+        $this->assertSame(['level' => 8, 'mode' => 'compress', 'archive' => null], $filter2->getOptions());
     }
 
     /**
      * Setting Level
-     *
-     * @return void
      */
-    public function testGzGetSetLevel()
+    public function testGzGetSetLevel(): void
     {
         $filter = new GzCompression();
-        $this->assertEquals(9, $filter->getLevel());
+        $this->assertSame(9, $filter->getLevel());
         $filter->setLevel(6);
-        $this->assertEquals(6, $filter->getOptions('level'));
+        $this->assertSame(6, $filter->getOptions('level'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('must be between');
@@ -107,15 +99,13 @@ class GzTest extends TestCase
 
     /**
      * Setting Mode
-     *
-     * @return void
      */
-    public function testGzGetSetMode()
+    public function testGzGetSetMode(): void
     {
         $filter = new GzCompression();
-        $this->assertEquals('compress', $filter->getMode());
+        $this->assertSame('compress', $filter->getMode());
         $filter->setMode('deflate');
-        $this->assertEquals('deflate', $filter->getOptions('mode'));
+        $this->assertSame('deflate', $filter->getOptions('mode'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('mode not supported');
@@ -124,24 +114,20 @@ class GzTest extends TestCase
 
     /**
      * Setting Archive
-     *
-     * @return void
      */
-    public function testGzGetSetArchive()
+    public function testGzGetSetArchive(): void
     {
         $filter = new GzCompression();
-        $this->assertEquals(null, $filter->getArchive());
+        $this->assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getArchive());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('archive'));
+        $this->assertSame('Testfile.txt', $filter->getArchive());
+        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Archive
-     *
-     * @return void
      */
-    public function testGzCompressToFile()
+    public function testGzCompressToFile(): void
     {
         $filter  = new GzCompression();
         $archive = $this->target;
@@ -152,20 +138,18 @@ class GzTest extends TestCase
 
         $filter2  = new GzCompression();
         $content2 = $filter2->decompress($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
 
         $filter3 = new GzCompression();
         $filter3->setArchive($archive);
         $content3 = $filter3->decompress(null);
-        $this->assertEquals('compress me', $content3);
+        $this->assertSame('compress me', $content3);
     }
 
     /**
      * Test deflate
-     *
-     * @return void
      */
-    public function testGzDeflate()
+    public function testGzDeflate(): void
     {
         $filter = new GzCompression(['mode' => 'deflate']);
 
@@ -173,21 +157,19 @@ class GzTest extends TestCase
         $this->assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * testing toString
-     *
-     * @return void
      */
-    public function testGzToString()
+    public function testGzToString(): void
     {
         $filter = new GzCompression();
-        $this->assertEquals('Gz', $filter->toString());
+        $this->assertSame('Gz', $filter->toString());
     }
 
-    public function testGzDecompressNullThrowsRuntimeException()
+    public function testGzDecompressNullThrowsRuntimeException(): void
     {
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('Error during decompression');

--- a/test/Compress/LzfTest.php
+++ b/test/Compress/LzfTest.php
@@ -20,10 +20,8 @@ class LzfTest extends TestCase
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         $filter = new LlaminasCompression();
 
@@ -32,17 +30,15 @@ class LzfTest extends TestCase
         $this->assertNotEquals($text, $compressed);
 
         $decompressed = $filter->decompress($compressed);
-        $this->assertEquals($text, $decompressed);
+        $this->assertSame($text, $decompressed);
     }
 
     /**
      * testing toString
-     *
-     * @return void
      */
-    public function testLlaminasToString()
+    public function testLlaminasToString(): void
     {
         $filter = new LlaminasCompression();
-        $this->assertEquals('Llaminas', $filter->toString());
+        $this->assertSame('Llaminas', $filter->toString());
     }
 }

--- a/test/Compress/RarTest.php
+++ b/test/Compress/RarTest.php
@@ -85,10 +85,8 @@ class RarTest extends TestCase
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         $filter = new RarCompression(
             [
@@ -99,7 +97,7 @@ class RarTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertEquals(
+        $this->assertSame(
             dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'compressed.rar',
             $content
         );
@@ -107,18 +105,16 @@ class RarTest extends TestCase
         $content = $filter->decompress($content);
         $this->assertTrue($content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Setting Options
-     *
-     * @return void
      */
-    public function testRarGetSetOptions()
+    public function testRarGetSetOptions(): void
     {
         $filter = new RarCompression();
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'archive'  => null,
                 'callback' => null,
@@ -128,59 +124,53 @@ class RarTest extends TestCase
             $filter->getOptions()
         );
 
-        $this->assertEquals(null, $filter->getOptions('archive'));
+        $this->assertSame(null, $filter->getOptions('archive'));
 
         $this->assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooption' => 'foo']);
         $this->assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['archive' => 'temp.txt']);
-        $this->assertEquals('temp.txt', $filter->getOptions('archive'));
+        $this->assertSame('temp.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Archive
-     *
-     * @return void
      */
-    public function testRarGetSetArchive()
+    public function testRarGetSetArchive(): void
     {
         $filter = new RarCompression();
-        $this->assertEquals(null, $filter->getArchive());
+        $this->assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getArchive());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('archive'));
+        $this->assertSame('Testfile.txt', $filter->getArchive());
+        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Password
-     *
-     * @return void
      */
-    public function testRarGetSetPassword()
+    public function testRarGetSetPassword(): void
     {
         $filter = new RarCompression();
-        $this->assertEquals(null, $filter->getPassword());
+        $this->assertSame(null, $filter->getPassword());
         $filter->setPassword('test');
-        $this->assertEquals('test', $filter->getPassword());
-        $this->assertEquals('test', $filter->getOptions('password'));
+        $this->assertSame('test', $filter->getPassword());
+        $this->assertSame('test', $filter->getOptions('password'));
         $filter->setOptions(['password' => 'test2']);
-        $this->assertEquals('test2', $filter->getPassword());
-        $this->assertEquals('test2', $filter->getOptions('password'));
+        $this->assertSame('test2', $filter->getPassword());
+        $this->assertSame('test2', $filter->getOptions('password'));
     }
 
     /**
      * Setting Target
-     *
-     * @return void
      */
-    public function testRarGetSetTarget()
+    public function testRarGetSetTarget(): void
     {
         $filter = new RarCompression();
-        $this->assertEquals('.', $filter->getTarget());
+        $this->assertSame('.', $filter->getTarget());
         $filter->setTarget('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getTarget());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('target'));
+        $this->assertSame('Testfile.txt', $filter->getTarget());
+        $this->assertSame('Testfile.txt', $filter->getOptions('target'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not exist');
@@ -189,19 +179,17 @@ class RarTest extends TestCase
 
     /**
      * Setting Callback
-     *
-     * @return void
      */
-    public function testSettingCallback()
+    public function testSettingCallback(): void
     {
         $filter = new RarCompression();
 
         $callback = [self::class, 'rarCompress'];
         $filter->setCallback($callback);
-        $this->assertEquals($callback, $filter->getCallback());
+        $this->assertSame($callback, $filter->getCallback());
     }
 
-    public function testSettingCallbackThrowsExceptionOnMissingCallback()
+    public function testSettingCallbackThrowsExceptionOnMissingCallback(): void
     {
         $filter = new RarCompression();
 
@@ -210,7 +198,7 @@ class RarTest extends TestCase
         $filter->compress('test.txt');
     }
 
-    public function testSettingCallbackThrowsExceptionOnInvalidCallback()
+    public function testSettingCallbackThrowsExceptionOnInvalidCallback(): void
     {
         $filter = new RarCompression();
 
@@ -221,10 +209,8 @@ class RarTest extends TestCase
 
     /**
      * Compress to Archive
-     *
-     * @return void
      */
-    public function testRarCompressFile()
+    public function testRarCompressFile(): void
     {
         $filter = new RarCompression(
             [
@@ -236,7 +222,7 @@ class RarTest extends TestCase
         file_put_contents($this->tmp . '/zipextracted.txt', 'compress me');
 
         $content = $filter->compress($this->tmp . '/zipextracted.txt');
-        $this->assertEquals(
+        $this->assertSame(
             dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'compressed.rar',
             $content
         );
@@ -244,15 +230,13 @@ class RarTest extends TestCase
         $content = $filter->decompress($content);
         $this->assertTrue($content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Compress directory to Filename
-     *
-     * @return void
      */
-    public function testRarCompressDirectory()
+    public function testRarCompressDirectory(): void
     {
         $filter  = new RarCompression(
             [
@@ -262,7 +246,7 @@ class RarTest extends TestCase
             ]
         );
         $content = $filter->compress(dirname(__DIR__) . '/_files/Compress');
-        $this->assertEquals(
+        $this->assertSame(
             dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'compressed.rar',
             $content
         );
@@ -287,13 +271,11 @@ class RarTest extends TestCase
 
     /**
      * testing toString
-     *
-     * @return void
      */
-    public function testRarToString()
+    public function testRarToString(): void
     {
         $filter = new RarCompression();
-        $this->assertEquals('Rar', $filter->toString());
+        $this->assertSame('Rar', $filter->toString());
     }
 
     /**

--- a/test/Compress/SnappyTest.php
+++ b/test/Compress/SnappyTest.php
@@ -25,10 +25,8 @@ class SnappyTest extends TestCase
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         $filter = new SnappyCompression();
 
@@ -36,15 +34,13 @@ class SnappyTest extends TestCase
         $this->assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Snappy should return NULL on invalid arguments.
-     *
-     * @return void
      */
-    public function testNonScalarInput()
+    public function testNonScalarInput(): void
     {
         $filter = new SnappyCompression();
 
@@ -59,24 +55,20 @@ class SnappyTest extends TestCase
 
     /**
      * Snappy should handle empty input data correctly.
-     *
-     * @return void
      */
-    public function testEmptyString()
+    public function testEmptyString(): void
     {
         $filter = new SnappyCompression();
 
         $content = $filter->compress(false);
         $content = $filter->decompress($content);
-        $this->assertEquals('', $content, 'Snappy failed to decompress empty string.');
+        $this->assertSame('', $content, 'Snappy failed to decompress empty string.');
     }
 
     /**
      * Snappy should throw an exception when decompressing invalid data.
-     *
-     * @return void
      */
-    public function testInvalidData()
+    public function testInvalidData(): void
     {
         $filter = new SnappyCompression();
 
@@ -92,13 +84,11 @@ class SnappyTest extends TestCase
 
     /**
      * testing toString
-     *
-     * @return void
      */
-    public function testSnappyToString()
+    public function testSnappyToString(): void
     {
         $filter = new SnappyCompression();
-        $this->assertEquals('Snappy', $filter->toString());
+        $this->assertSame('Snappy', $filter->toString());
     }
 
     /**

--- a/test/Compress/TarLoadArchiveTarTest.php
+++ b/test/Compress/TarLoadArchiveTarTest.php
@@ -16,7 +16,7 @@ use const E_DEPRECATED;
 
 class TarLoadArchiveTarTest extends TestCase
 {
-    public function testArchiveTarNotLoaded()
+    public function testArchiveTarNotLoaded(): void
     {
         set_error_handler(function ($errno, $errstr) {
             // PEAR class uses deprecated constructor, which emits a deprecation error

--- a/test/Compress/TarTest.php
+++ b/test/Compress/TarTest.php
@@ -65,10 +65,8 @@ class TarTest extends TestCase
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         $filter = new TarCompression(
             [
@@ -78,26 +76,24 @@ class TarTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertEquals(
+        $this->assertSame(
             $this->tmp . DIRECTORY_SEPARATOR . 'compressed.tar',
             $content
         );
 
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Setting Options
-     *
-     * @return void
      */
-    public function testTarGetSetOptions()
+    public function testTarGetSetOptions(): void
     {
         $filter = new TarCompression();
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'archive' => null,
                 'target'  => '.',
@@ -106,42 +102,38 @@ class TarTest extends TestCase
             $filter->getOptions()
         );
 
-        $this->assertEquals(null, $filter->getOptions('archive'));
+        $this->assertSame(null, $filter->getOptions('archive'));
 
         $this->assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooptions' => 'foo']);
         $this->assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['archive' => 'temp.txt']);
-        $this->assertEquals('temp.txt', $filter->getOptions('archive'));
+        $this->assertSame('temp.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Archive
-     *
-     * @return void
      */
-    public function testTarGetSetArchive()
+    public function testTarGetSetArchive(): void
     {
         $filter = new TarCompression();
-        $this->assertEquals(null, $filter->getArchive());
+        $this->assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getArchive());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('archive'));
+        $this->assertSame('Testfile.txt', $filter->getArchive());
+        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Target
-     *
-     * @return void
      */
-    public function testTarGetSetTarget()
+    public function testTarGetSetTarget(): void
     {
         $filter = new TarCompression();
-        $this->assertEquals('.', $filter->getTarget());
+        $this->assertSame('.', $filter->getTarget());
         $filter->setTarget('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getTarget());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('target'));
+        $this->assertSame('Testfile.txt', $filter->getTarget());
+        $this->assertSame('Testfile.txt', $filter->getOptions('target'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not exist');
@@ -150,10 +142,8 @@ class TarTest extends TestCase
 
     /**
      * Setting Archive
-     *
-     * @return void
      */
-    public function testTarCompressToFile()
+    public function testTarCompressToFile(): void
     {
         $filter = new TarCompression(
             [
@@ -164,23 +154,21 @@ class TarTest extends TestCase
         file_put_contents($this->tmp . '/zipextracted.txt', 'compress me');
 
         $content = $filter->compress($this->tmp . '/zipextracted.txt');
-        $this->assertEquals(
+        $this->assertSame(
             $this->tmp . DIRECTORY_SEPARATOR . 'compressed.tar',
             $content
         );
 
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Compress directory to Filename
-     *
-     * @return void
      */
-    public function testTarCompressDirectory()
+    public function testTarCompressDirectory(): void
     {
         $filter  = new TarCompression(
             [
@@ -189,13 +177,13 @@ class TarTest extends TestCase
             ]
         );
         $content = $filter->compress(dirname(__DIR__) . '/_files/Compress');
-        $this->assertEquals(
+        $this->assertSame(
             $this->tmp . DIRECTORY_SEPARATOR . 'compressed.tar',
             $content
         );
     }
 
-    public function testSetModeShouldWorkWithCaseInsensitive()
+    public function testSetModeShouldWorkWithCaseInsensitive(): void
     {
         $filter = new TarCompression();
         $filter->setTarget($this->tmp . '/zipextracted.txt');
@@ -208,25 +196,23 @@ class TarTest extends TestCase
             $filter->setArchive($archive);
             $filter->setMode($mode);
             $content = $filter->compress('compress me');
-            $this->assertEquals($archive, $content);
+            $this->assertSame($archive, $content);
         }
     }
 
     /**
      * testing toString
-     *
-     * @return void
      */
-    public function testTarToString()
+    public function testTarToString(): void
     {
         $filter = new TarCompression();
-        $this->assertEquals('Tar', $filter->toString());
+        $this->assertSame('Tar', $filter->toString());
     }
 
     /**
      * @see https://github.com/zendframework/zend-filter/issues/41
      */
-    public function testDecompressionDoesNotRequireArchive()
+    public function testDecompressionDoesNotRequireArchive(): void
     {
         $filter = new TarCompression([
             'archive' => $this->tmp . '/compressed.tar',

--- a/test/Compress/ZipTest.php
+++ b/test/Compress/ZipTest.php
@@ -100,10 +100,8 @@ class ZipTest extends TestCase
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testBasicUsage()
+    public function testBasicUsage(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
             $this->markTestSkipped('ZIP compression tests are currently disabled');
@@ -117,60 +115,54 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Setting Options
-     *
-     * @return void
      */
-    public function testZipGetSetOptions()
+    public function testZipGetSetOptions(): void
     {
         $filter = new ZipCompression();
-        $this->assertEquals(['archive' => null, 'target' => null], $filter->getOptions());
+        $this->assertSame(['archive' => null, 'target' => null], $filter->getOptions());
 
-        $this->assertEquals(null, $filter->getOptions('archive'));
+        $this->assertSame(null, $filter->getOptions('archive'));
 
         $this->assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooption' => 'foo']);
         $this->assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['archive' => 'temp.txt']);
-        $this->assertEquals('temp.txt', $filter->getOptions('archive'));
+        $this->assertSame('temp.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Archive
-     *
-     * @return void
      */
-    public function testZipGetSetArchive()
+    public function testZipGetSetArchive(): void
     {
         $filter = new ZipCompression();
-        $this->assertEquals(null, $filter->getArchive());
+        $this->assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getArchive());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('archive'));
+        $this->assertSame('Testfile.txt', $filter->getArchive());
+        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Target
-     *
-     * @return void
      */
-    public function testZipGetSetTarget()
+    public function testZipGetSetTarget(): void
     {
         $filter = new ZipCompression();
         $this->assertNull($filter->getTarget());
         $filter->setTarget('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getTarget());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('target'));
+        $this->assertSame('Testfile.txt', $filter->getTarget());
+        $this->assertSame('Testfile.txt', $filter->getOptions('target'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not exist');
@@ -179,10 +171,8 @@ class ZipTest extends TestCase
 
     /**
      * Compress to Archive
-     *
-     * @return void
      */
-    public function testZipCompressFile()
+    public function testZipCompressFile(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
             $this->markTestSkipped('ZIP compression tests are currently disabled');
@@ -197,20 +187,18 @@ class ZipTest extends TestCase
         file_put_contents($this->tmp . '/zipextracted.txt', 'compress me');
 
         $content = $filter->compress($this->tmp . '/zipextracted.txt');
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Basic usage
-     *
-     * @return void
      */
-    public function testCompressNonExistingTargetFile()
+    public function testCompressNonExistingTargetFile(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
             $this->markTestSkipped('ZIP compression tests are currently disabled');
@@ -224,20 +212,18 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zip.tmp');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * Compress directory to Archive
-     *
-     * @return void
      */
-    public function testZipCompressDirectory()
+    public function testZipCompressDirectory(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
             $this->markTestSkipped('ZIP compression tests are currently disabled');
@@ -250,11 +236,11 @@ class ZipTest extends TestCase
             ]
         );
         $content = $filter->compress($this->tmp . '/Compress');
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         mkdir($this->tmp . DIRECTORY_SEPARATOR . '_compress');
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . '_compress'
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . '_compress'
                             . DIRECTORY_SEPARATOR, $content);
 
         $base = $this->tmp . DIRECTORY_SEPARATOR . '_compress' . DIRECTORY_SEPARATOR . 'Compress' . DIRECTORY_SEPARATOR;
@@ -264,21 +250,19 @@ class ZipTest extends TestCase
         $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR
                           . 'Second' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
         $content = file_get_contents($this->tmp . '/Compress/zipextracted.txt');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * testing toString
-     *
-     * @return void
      */
-    public function testZipToString()
+    public function testZipToString(): void
     {
         $filter = new ZipCompression();
-        $this->assertEquals('Zip', $filter->toString());
+        $this->assertSame('Zip', $filter->toString());
     }
 
-    public function testDecompressWillThrowExceptionWhenDecompressingWithNoTarget()
+    public function testDecompressWillThrowExceptionWhenDecompressingWithNoTarget(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
             $this->markTestSkipped('ZIP compression tests are currently disabled');
@@ -292,7 +276,7 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $filter  = new ZipCompression(
             [
@@ -301,16 +285,16 @@ class ZipTest extends TestCase
             ]
         );
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/_compress');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 
     /**
      * @group 6026
      * @covers \Laminas\Filter\Compress\Zip::decompress
      */
-    public function testDecompressWhenNoArchieveInClass()
+    public function testDecompressWhenNoArchieveInClass(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
             $this->markTestSkipped('ZIP compression tests are currently disabled');
@@ -324,7 +308,7 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $filter  = new ZipCompression(
             [
@@ -332,8 +316,8 @@ class ZipTest extends TestCase
             ]
         );
         $content = $filter->decompress($content);
-        $this->assertEquals($this->tmp . DIRECTORY_SEPARATOR, $content);
+        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/_compress');
-        $this->assertEquals('compress me', $content);
+        $this->assertSame('compress me', $content);
     }
 }

--- a/test/CompressTest.php
+++ b/test/CompressTest.php
@@ -61,9 +61,8 @@ class CompressTest extends TestCase
      * Basic usage
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testBasicUsage($filterType)
+    public function testBasicUsage($filterType): void
     {
         $filter = new CompressFilter($filterType);
 
@@ -72,16 +71,15 @@ class CompressTest extends TestCase
         $this->assertNotEquals($text, $compressed);
 
         $decompressed = $filter->decompress($compressed);
-        $this->assertEquals($text, $decompressed);
+        $this->assertSame($text, $decompressed);
     }
 
     /**
      * Setting Options
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testGetSetAdapterOptionsInConstructor($filterType)
+    public function testGetSetAdapterOptionsInConstructor($filterType): void
     {
         $filter = new CompressFilter([
             'adapter' => $filterType,
@@ -90,50 +88,47 @@ class CompressTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             ['archive' => 'test.txt'],
             $filter->getAdapterOptions()
         );
 
         $adapter = $filter->getAdapter();
-        $this->assertEquals('test.txt', $adapter->getArchive());
+        $this->assertSame('test.txt', $adapter->getArchive());
     }
 
     /**
      * Setting Options through constructor
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testGetSetAdapterOptions($filterType)
+    public function testGetSetAdapterOptions($filterType): void
     {
         $filter = new CompressFilter($filterType);
         $filter->setAdapterOptions([
             'archive' => 'test.txt',
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             ['archive' => 'test.txt'],
             $filter->getAdapterOptions()
         );
         $adapter = $filter->getAdapter();
-        $this->assertEquals('test.txt', $adapter->getArchive());
+        $this->assertSame('test.txt', $adapter->getArchive());
     }
 
     /**
      * Setting Blocksize (works only for bz2)
-     *
-     * @return void
      */
-    public function testGetSetBlocksize()
+    public function testGetSetBlocksize(): void
     {
         if (! extension_loaded('bz2')) {
             $this->markTestSkipped('Extension bz2 is required for this test');
         }
 
         $filter = new CompressFilter('bz2');
-        $this->assertEquals(4, $filter->getBlocksize());
+        $this->assertSame(4, $filter->getBlocksize());
         $filter->setBlocksize(6);
-        $this->assertEquals(6, $filter->getOptions('blocksize'));
+        $this->assertSame(6, $filter->getOptions('blocksize'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('must be between');
@@ -144,24 +139,22 @@ class CompressTest extends TestCase
      * Setting Archive
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testGetSetArchive($filterType)
+    public function testGetSetArchive($filterType): void
     {
         $filter = new CompressFilter($filterType);
-        $this->assertEquals(null, $filter->getArchive());
+        $this->assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertEquals('Testfile.txt', $filter->getArchive());
-        $this->assertEquals('Testfile.txt', $filter->getOptions('archive'));
+        $this->assertSame('Testfile.txt', $filter->getArchive());
+        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
      * Setting Archive
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testCompressToFile($filterType)
+    public function testCompressToFile($filterType): void
     {
         $filter  = new CompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
@@ -172,21 +165,20 @@ class CompressTest extends TestCase
 
         $filter2  = new CompressFilter($filterType);
         $content2 = $filter2->decompress($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
 
         $filter3 = new CompressFilter($filterType);
         $filter3->setArchive($archive);
         $content3 = $filter3->decompress(null);
-        $this->assertEquals('compress me', $content3);
+        $this->assertSame('compress me', $content3);
     }
 
     /**
      * testing toString
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testToString($filterType)
+    public function testToString($filterType): void
     {
         $filter = new CompressFilter($filterType);
         $this->assertEqualsIgnoringCase($filterType, $filter->toString());
@@ -196,9 +188,8 @@ class CompressTest extends TestCase
      * testing getAdapter
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testGetAdapter($filterType)
+    public function testGetAdapter($filterType): void
     {
         $filter  = new CompressFilter($filterType);
         $adapter = $filter->getAdapter();
@@ -208,17 +199,15 @@ class CompressTest extends TestCase
 
     /**
      * Setting Adapter
-     *
-     * @return void
      */
-    public function testSetAdapter()
+    public function testSetAdapter(): void
     {
         if (! extension_loaded('zlib')) {
             $this->markTestSkipped('This filter is tested with the zlib extension');
         }
 
         $filter = new CompressFilter();
-        $this->assertEquals('Gz', $filter->getAdapterName());
+        $this->assertSame('Gz', $filter->getAdapterName());
 
         $filter->setAdapter(Boolean::class);
 
@@ -231,9 +220,8 @@ class CompressTest extends TestCase
      * Decompress archiv
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testDecompressArchive($filterType)
+    public function testDecompressArchive($filterType): void
     {
         $filter  = new CompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
@@ -244,15 +232,13 @@ class CompressTest extends TestCase
 
         $filter2  = new CompressFilter($filterType);
         $content2 = $filter2->decompress($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
     }
 
     /**
      * Setting invalid method
-     *
-     * @return void
      */
-    public function testInvalidMethod()
+    public function testInvalidMethod(): void
     {
         $filter = new CompressFilter();
 
@@ -278,12 +264,11 @@ class CompressTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($filterType, $input)
+    public function testReturnUnfiltered($filterType, $input): void
     {
         $filter = new CompressFilter($filterType);
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/DataUnitFormatterTest.php
+++ b/test/DataUnitFormatterTest.php
@@ -17,13 +17,13 @@ class DataUnitFormatterTest extends TestCase
      * @param string $expected
      * @dataProvider decimalBytesTestProvider
      */
-    public function testDecimalBytes($value, $expected)
+    public function testDecimalBytes($value, $expected): void
     {
         $filter = new DataUnitFormatterFilter([
             'mode' => DataUnitFormatterFilter::MODE_DECIMAL,
             'unit' => 'B',
         ]);
-        $this->assertEquals($expected, $filter->filter($value));
+        $this->assertSame($expected, $filter->filter($value));
     }
 
     /**
@@ -31,48 +31,48 @@ class DataUnitFormatterTest extends TestCase
      * @param string $expected
      * @dataProvider binaryBytesTestProvider
      */
-    public function testBinaryBytes($value, $expected)
+    public function testBinaryBytes($value, $expected): void
     {
         $filter = new DataUnitFormatterFilter([
             'mode' => DataUnitFormatterFilter::MODE_BINARY,
             'unit' => 'B',
         ]);
-        $this->assertEquals($expected, $filter->filter($value));
+        $this->assertSame($expected, $filter->filter($value));
     }
 
-    public function testPrecision()
+    public function testPrecision(): void
     {
         $filter = new DataUnitFormatterFilter([
             'unit'      => 'B',
             'precision' => 3,
         ]);
 
-        $this->assertEquals('1.500 kB', $filter->filter(1500));
+        $this->assertSame('1.500 kB', $filter->filter(1500));
     }
 
-    public function testCustomPrefixes()
+    public function testCustomPrefixes(): void
     {
         $filter = new DataUnitFormatterFilter([
             'unit'     => 'B',
             'prefixes' => ['', 'kilos'],
         ]);
 
-        $this->assertEquals('1.50 kilosB', $filter->filter(1500));
+        $this->assertSame('1.50 kilosB', $filter->filter(1500));
     }
 
-    public function testSettingNoOptions()
+    public function testSettingNoOptions(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $filter = new DataUnitFormatterFilter();
     }
 
-    public function testSettingNoUnit()
+    public function testSettingNoUnit(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $filter = new DataUnitFormatterFilter([]);
     }
 
-    public function testSettingFalseMode()
+    public function testSettingFalseMode(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $filter = new DataUnitFormatterFilter([

--- a/test/DateSelectTest.php
+++ b/test/DateSelectTest.php
@@ -16,11 +16,11 @@ class DateSelectTest extends TestCase
      * @param array|mixed|null|string $input input provided to the filter
      * @param array|mixed|null|string $expected expected output
      */
-    public function testFilter($options, $input, $expected)
+    public function testFilter($options, $input, $expected): void
     {
         $sut = new DateSelectFilter();
         $sut->setOptions($options);
-        $this->assertEquals($expected, $sut->filter($input));
+        $this->assertSame($expected, $sut->filter($input));
     }
 
     public function provideFilter()
@@ -34,7 +34,7 @@ class DateSelectTest extends TestCase
         ];
     }
 
-    public function testInvalidInput()
+    public function testInvalidInput(): void
     {
         $this->expectException(RuntimeException::class);
         $sut = new DateSelectFilter();

--- a/test/DateTimeFormatterTest.php
+++ b/test/DateTimeFormatterTest.php
@@ -45,79 +45,78 @@ class DateTimeFormatterTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 
-    public function testFormatterFormatsZero()
+    public function testFormatterFormatsZero(): void
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter(0);
-        $this->assertEquals('1970-01-01T00:00:00+0000', $result);
+        $this->assertSame('1970-01-01T00:00:00+0000', $result);
     }
 
-    public function testDateTimeFormatted()
+    public function testDateTimeFormatted(): void
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter('2012-01-01');
-        $this->assertEquals('2012-01-01T00:00:00+0000', $result);
+        $this->assertSame('2012-01-01T00:00:00+0000', $result);
     }
 
-    public function testDateTimeFormattedWithAlternateTimezones()
+    public function testDateTimeFormattedWithAlternateTimezones(): void
     {
         $filter = new DateTimeFormatter();
 
         date_default_timezone_set('Europe/Paris');
 
         $resultParis = $filter->filter('2012-01-01');
-        $this->assertEquals('2012-01-01T00:00:00+0100', $resultParis);
+        $this->assertSame('2012-01-01T00:00:00+0100', $resultParis);
 
         date_default_timezone_set('America/New_York');
 
         $resultNewYork = $filter->filter('2012-01-01');
-        $this->assertEquals('2012-01-01T00:00:00-0500', $resultNewYork);
+        $this->assertSame('2012-01-01T00:00:00-0500', $resultNewYork);
     }
 
-    public function testSetFormat()
+    public function testSetFormat(): void
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
         $filter->setFormat(DateTime::RFC1036);
         $result = $filter->filter('2012-01-01');
-        $this->assertEquals('Sun, 01 Jan 12 00:00:00 +0000', $result);
+        $this->assertSame('Sun, 01 Jan 12 00:00:00 +0000', $result);
     }
 
-    public function testFormatDateTimeFromTimestamp()
+    public function testFormatDateTimeFromTimestamp(): void
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter(1359739801);
-        $this->assertEquals('2013-02-01T17:30:01+0000', $result);
+        $this->assertSame('2013-02-01T17:30:01+0000', $result);
     }
 
-    public function testAcceptDateTimeValue()
+    public function testAcceptDateTimeValue(): void
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter(new DateTime('2012-01-01'));
-        $this->assertEquals('2012-01-01T00:00:00+0000', $result);
+        $this->assertSame('2012-01-01T00:00:00+0000', $result);
     }
 
-    public function testInvalidArgumentExceptionThrownOnInvalidInput()
+    public function testInvalidArgumentExceptionThrownOnInvalidInput(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
 

--- a/test/DateTimeSelectTest.php
+++ b/test/DateTimeSelectTest.php
@@ -16,11 +16,11 @@ class DateTimeSelectTest extends TestCase
      * @param array|mixed|null|string $input input provided to the filter
      * @param array|mixed|null|string $expected expected output
      */
-    public function testFilter($options, $input, $expected)
+    public function testFilter($options, $input, $expected): void
     {
         $sut = new DateTimeSelectFilter();
         $sut->setOptions($options);
-        $this->assertEquals($expected, $sut->filter($input));
+        $this->assertSame($expected, $sut->filter($input));
     }
 
     public function provideFilter()
@@ -54,7 +54,7 @@ class DateTimeSelectTest extends TestCase
         ];
     }
 
-    public function testInvalidInput()
+    public function testInvalidInput(): void
     {
         $this->expectException(RuntimeException::class);
         $sut = new DateTimeSelectFilter();

--- a/test/DecompressTest.php
+++ b/test/DecompressTest.php
@@ -58,9 +58,8 @@ class DecompressTest extends TestCase
      * Basic usage
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testBasicUsage($filterType)
+    public function testBasicUsage($filterType): void
     {
         $filter = new DecompressFilter($filterType);
 
@@ -69,16 +68,15 @@ class DecompressTest extends TestCase
         $this->assertNotEquals($text, $compressed);
 
         $decompressed = $filter($compressed);
-        $this->assertEquals($text, $decompressed);
+        $this->assertSame($text, $decompressed);
     }
 
     /**
      * Setting Archive
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testCompressToFile($filterType)
+    public function testCompressToFile($filterType): void
     {
         $filter  = new DecompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
@@ -89,21 +87,20 @@ class DecompressTest extends TestCase
 
         $filter2  = new DecompressFilter($filterType);
         $content2 = $filter2($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
 
         $filter3 = new DecompressFilter($filterType);
         $filter3->setArchive($archive);
         $content3 = $filter3(null);
-        $this->assertEquals('compress me', $content3);
+        $this->assertSame('compress me', $content3);
     }
 
     /**
      * Basic usage
      *
      * @dataProvider returnFilterType
-     * @return void
      */
-    public function testDecompressArchive($filterType)
+    public function testDecompressArchive($filterType): void
     {
         $filter  = new DecompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
@@ -114,13 +111,13 @@ class DecompressTest extends TestCase
 
         $filter2  = new DecompressFilter($filterType);
         $content2 = $filter2($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
     }
 
     /**
      * @dataProvider returnFilterType
      */
-    public function testFilterMethodProxiesToDecompress($filterType)
+    public function testFilterMethodProxiesToDecompress($filterType): void
     {
         $filter  = new DecompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
@@ -131,7 +128,7 @@ class DecompressTest extends TestCase
 
         $filter2  = new DecompressFilter($filterType);
         $content2 = $filter2->filter($archive);
-        $this->assertEquals('compress me', $content2);
+        $this->assertSame('compress me', $content2);
     }
 
     public function returnUnfilteredDataProvider(): iterable
@@ -150,12 +147,11 @@ class DecompressTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($filterType, $input)
+    public function testReturnUnfiltered($filterType, $input): void
     {
         $filter = new DecompressFilter($filterType);
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/DecryptTest.php
+++ b/test/DecryptTest.php
@@ -23,10 +23,8 @@ class DecryptTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasicMcrypt()
+    public function testBasicMcrypt(): void
     {
         $filter         = new DecryptFilter(['adapter' => 'BlockCipher']);
         $valuesExpected = [
@@ -45,22 +43,20 @@ class DecryptTest extends TestCase
     /**
      * Ensures that the encryption works fine
      */
-    public function testDecryptBlockCipher()
+    public function testDecryptBlockCipher(): void
     {
         $decrypt = new DecryptFilter(['adapter' => 'BlockCipher', 'key' => 'testkey']);
         $decrypt->setVector('1234567890123456890');
         // @codingStandardsIgnoreStart
         $decrypted = $decrypt->filter('ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
         // @codingStandardsIgnoreEnd
-        $this->assertEquals($decrypted, 'test');
+        $this->assertSame($decrypted, 'test');
     }
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasicOpenssl()
+    public function testBasicOpenssl(): void
     {
         if (! extension_loaded('openssl')) {
             $this->markTestSkipped('Openssl extension not installed');
@@ -76,7 +72,7 @@ bK22CwD/l7SMBOz4M9XH0Jb0OhNxLza4XMDu0ANMIpnkn1KOcmQ4gB8fmAbBt');
         $filter->setPrivateKey(__DIR__ . '/_files/privatekey.pem');
 
         $key = $filter->getPrivateKey();
-        $this->assertEquals(
+        $this->assertSame(
             [
                 __DIR__ . '/_files/privatekey.pem'
                   => '-----BEGIN RSA PRIVATE KEY-----
@@ -100,10 +96,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testSettingAdapterManually()
+    public function testSettingAdapterManually(): void
     {
         if (! extension_loaded('openssl')) {
             $this->markTestSkipped('Openssl extension not installed');
@@ -111,11 +104,11 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
 
         $filter = new DecryptFilter();
         $filter->setAdapter('Openssl');
-        $this->assertEquals('Openssl', $filter->getAdapter());
+        $this->assertSame('Openssl', $filter->getAdapter());
         $this->assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
 
         $filter->setAdapter('BlockCipher');
-        $this->assertEquals('BlockCipher', $filter->getAdapter());
+        $this->assertSame('BlockCipher', $filter->getAdapter());
         $this->assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
 
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -123,10 +116,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter->setAdapter(stdClass::class);
     }
 
-    /**
-     * @return void
-     */
-    public function testCallingUnknownMethod()
+    public function testCallingUnknownMethod(): void
     {
         $this->expectException(Exception\BadMethodCallException::class);
         $this->expectExceptionMessage('Unknown method');
@@ -150,14 +140,13 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $decrypt = new DecryptFilter(['adapter' => 'BlockCipher', 'key' => 'testkey']);
         $decrypt->setVector('1234567890123456890');
 
         $decrypted = $decrypt->filter($input);
-        $this->assertEquals($input, $decrypted);
+        $this->assertSame($input, $decrypted);
     }
 }

--- a/test/DenyListTest.php
+++ b/test/DenyListTest.php
@@ -24,16 +24,16 @@ class DenyListTest extends TestCase
             'strict' => true,
         ]);
 
-        $this->assertEquals(true, $filter->getStrict());
-        $this->assertEquals(['test', 1], $filter->getList());
+        $this->assertSame(true, $filter->getStrict());
+        $this->assertSame(['test', 1], $filter->getList());
     }
 
     public function testConstructorDefaults(): void
     {
         $filter = new DenyListFilter();
 
-        $this->assertEquals(false, $filter->getStrict());
-        $this->assertEquals([], $filter->getList());
+        $this->assertSame(false, $filter->getStrict());
+        $this->assertSame([], $filter->getList());
     }
 
     public function testWithPluginManager(): void
@@ -59,7 +59,7 @@ class DenyListTest extends TestCase
         $filter = new DenyListFilter([
             'list' => $obj,
         ]);
-        $this->assertEquals($array, $filter->getList());
+        $this->assertSame($array, $filter->getList());
     }
 
     public function testSetStrictShouldCastToBoolean(): void

--- a/test/DigitsTest.php
+++ b/test/DigitsTest.php
@@ -34,10 +34,8 @@ class DigitsTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter = new DigitsFilter();
 
@@ -71,7 +69,7 @@ class DigitsTest extends TestCase
         }
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals(
+            $this->assertSame(
                 $output,
                 $result = $filter($input),
                 "Expected '$input' to filter to '$output', but received '$result' instead"
@@ -97,9 +95,8 @@ class DigitsTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new DigitsFilter();
 

--- a/test/DirTest.php
+++ b/test/DirTest.php
@@ -12,10 +12,8 @@ class DirTest extends TestCase
 {
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter         = new DirFilter();
         $valuesExpected = [
@@ -24,7 +22,7 @@ class DirTest extends TestCase
             '/path/to/filename.ext' => '/path/to',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
@@ -44,12 +42,11 @@ class DirTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new DirFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/Encrypt/BlockCipherTest.php
+++ b/test/Encrypt/BlockCipherTest.php
@@ -23,10 +23,8 @@ class BlockCipherTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasicBlockCipher()
+    public function testBasicBlockCipher(): void
     {
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
         // @codingStandardsIgnoreStart
@@ -38,25 +36,23 @@ class BlockCipherTest extends TestCase
         // @codingStandardsIgnoreEnd
         $filter->setVector('Laminas__Project');
         $enc = $filter->getEncryption();
-        $this->assertEquals('testkey', $enc['key']);
+        $this->assertSame('testkey', $enc['key']);
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter->encrypt($input));
+            $this->assertSame($output, $filter->encrypt($input));
         }
     }
 
     /**
      * Ensures that the vector can be set / returned
-     *
-     * @return void
      */
-    public function testGetSetVector()
+    public function testGetSetVector(): void
     {
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
         $filter->setVector('1234567890123456');
-        $this->assertEquals('1234567890123456', $filter->getVector());
+        $this->assertSame('1234567890123456', $filter->getVector());
     }
 
-    public function testWrongSizeVector()
+    public function testWrongSizeVector(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
@@ -65,20 +61,18 @@ class BlockCipherTest extends TestCase
 
     /**
      * Ensures that the filter allows default encryption
-     *
-     * @return void
      */
-    public function testDefaultEncryption()
+    public function testDefaultEncryption(): void
     {
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
         $filter->setVector('1234567890123456');
-        $this->assertEquals(
+        $this->assertSame(
             [
                 'key'           => 'testkey',
-                'algorithm'     => 'aes',
-                'vector'        => '1234567890123456',
                 'key_iteration' => 5000,
+                'algorithm'     => 'aes',
                 'hash'          => 'sha256',
+                'vector'        => '1234567890123456',
             ],
             $filter->getEncryption()
         );
@@ -86,23 +80,21 @@ class BlockCipherTest extends TestCase
 
     /**
      * Ensures that the filter allows setting options de/encryption
-     *
-     * @return void
      */
-    public function testGetSetEncryption()
+    public function testGetSetEncryption(): void
     {
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
         $filter->setVector('1234567890123456');
         $filter->setEncryption(
             ['algorithm' => 'blowfish']
         );
-        $this->assertEquals(
+        $this->assertSame(
             [
-                'key'           => 'testkey',
                 'algorithm'     => 'blowfish',
-                'vector'        => '1234567890123456',
+                'key'           => 'testkey',
                 'key_iteration' => 5000,
                 'hash'          => 'sha256',
+                'vector'        => '1234567890123456',
             ],
             $filter->getEncryption()
         );
@@ -110,10 +102,8 @@ class BlockCipherTest extends TestCase
 
     /**
      * Ensures that the filter allows de/encryption
-     *
-     * @return void
      */
-    public function testEncryptionWithDecryption()
+    public function testEncryptionWithDecryption(): void
     {
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
         $filter->setVector('1234567890123456');
@@ -122,47 +112,35 @@ class BlockCipherTest extends TestCase
         $this->assertNotEquals('teststring', $output);
 
         $input = $filter->decrypt($output);
-        $this->assertEquals('teststring', trim($input));
+        $this->assertSame('teststring', trim($input));
     }
 
-    /**
-     * @return void
-     */
-    public function testConstructionWithStringKey()
+    public function testConstructionWithStringKey(): void
     {
         $filter = new BlockCipherEncryption('testkey');
         $data   = $filter->getEncryption();
-        $this->assertEquals('testkey', $data['key']);
+        $this->assertSame('testkey', $data['key']);
     }
 
-    /**
-     * @return void
-     */
-    public function testConstructionWithInteger()
+    public function testConstructionWithInteger(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid options argument');
         $filter = new BlockCipherEncryption(1234);
     }
 
-    /**
-     * @return void
-     */
-    public function testToString()
+    public function testToString(): void
     {
         $filter = new BlockCipherEncryption('testkey');
-        $this->assertEquals('BlockCipher', $filter->toString());
+        $this->assertSame('BlockCipher', $filter->toString());
     }
 
-    /**
-     * @return void
-     */
-    public function testSettingEncryptionOptions()
+    public function testSettingEncryptionOptions(): void
     {
         $filter = new BlockCipherEncryption('testkey');
         $filter->setEncryption('newkey');
         $test = $filter->getEncryption();
-        $this->assertEquals('newkey', $test['key']);
+        $this->assertSame('newkey', $test['key']);
 
         try {
             $filter->setEncryption(1234);
@@ -185,10 +163,7 @@ class BlockCipherTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testSettingEmptyVector()
+    public function testSettingEmptyVector(): void
     {
         $filter = new BlockCipherEncryption('newkey');
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -198,10 +173,8 @@ class BlockCipherTest extends TestCase
 
     /**
      * Ensures that the filter allows de/encryption with compression
-     *
-     * @return void
      */
-    public function testEncryptionWithDecryptionAndCompression()
+    public function testEncryptionWithDecryptionAndCompression(): void
     {
         if (! extension_loaded('bz2')) {
             $this->markTestSkipped('This adapter needs the bz2 extension');
@@ -215,6 +188,6 @@ class BlockCipherTest extends TestCase
         $this->assertNotEquals('teststring', $output);
 
         $input = $filter->decrypt($output);
-        $this->assertEquals('teststring', trim($input));
+        $this->assertSame('teststring', trim($input));
     }
 }

--- a/test/Encrypt/OpensslTest.php
+++ b/test/Encrypt/OpensslTest.php
@@ -26,10 +26,8 @@ class OpensslTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasicOpenssl()
+    public function testBasicOpenssl(): void
     {
         $filter         = new OpensslEncryption(__DIR__ . '/../_files/publickey.pem');
         $valuesExpected = [
@@ -39,7 +37,7 @@ class OpensslTest extends TestCase
         ];
 
         $key = $filter->getPublicKey();
-        $this->assertEquals(
+        $this->assertSame(
             [
                 __DIR__ . '/../_files/publickey.pem'
                   => '-----BEGIN CERTIFICATE-----
@@ -71,10 +69,8 @@ PIDs9E7uuizAKDhRRRvho8BS
 
     /**
      * Ensures that the filter allows de/encryption
-     *
-     * @return void
      */
-    public function testEncryptionWithDecryptionOpenssl()
+    public function testEncryptionWithDecryptionOpenssl(): void
     {
         if (version_compare(phpversion(), '5.4', '>=')) {
             $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
@@ -95,15 +91,13 @@ bK22CwD/l7SMBOz4M9XH0Jb0OhNxLza4XMDu0ANMIpnkn1KOcmQ4gB8fmAbBt');
         $filter->setPrivateKey(__DIR__ . '/../_files/privatekey.pem');
         $filter->setEnvelopeKey($envelopekeys);
         $input = $filter->decrypt($output);
-        $this->assertEquals('teststring', trim($input));
+        $this->assertSame('teststring', trim($input));
     }
 
     /**
      * Ensures that the filter allows de/encryption
-     *
-     * @return void
      */
-    public function testEncryptionWithDecryptionSingleOptionOpenssl()
+    public function testEncryptionWithDecryptionSingleOptionOpenssl(): void
     {
         if (version_compare(phpversion(), '5.4', '>=')) {
             $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
@@ -124,13 +118,10 @@ bK22CwD/l7SMBOz4M9XH0Jb0OhNxLza4XMDu0ANMIpnkn1KOcmQ4gB8fmAbBt';
         $filter->setPrivateKey(__DIR__ . '/../_files/privatekey.pem', $phrase);
         $filter->setEnvelopeKey($envelopekeys);
         $input = $filter->decrypt($output);
-        $this->assertEquals('teststring', trim($input));
+        $this->assertSame('teststring', trim($input));
     }
 
-    /**
-     * @return void
-     */
-    public function testSetPublicKey()
+    public function testSetPublicKey(): void
     {
         $filter = new OpensslEncryption();
 
@@ -142,16 +133,13 @@ bK22CwD/l7SMBOz4M9XH0Jb0OhNxLza4XMDu0ANMIpnkn1KOcmQ4gB8fmAbBt';
         $filter->setPublicKey(123);
     }
 
-    /**
-     * @return void
-     */
-    public function testSetPrivateKey()
+    public function testSetPrivateKey(): void
     {
         $filter = new OpensslEncryption();
 
         $filter->setPrivateKey(['public' => __DIR__ . '/../_files/privatekey.pem']);
         $test = $filter->getPrivateKey();
-        $this->assertEquals([
+        $this->assertSame([
             __DIR__ . '/../_files/privatekey.pem' => '-----BEGIN RSA PRIVATE KEY-----
 MIICXgIBAAKBgQDKTIp7FntJt1BioBZ0lmWBE8CyzngeGCHNMcAC4JLbi1Y0LwT4
 CSaQarbvAqBRmc+joHX+rcURm89wOibRaThrrZcvgl2pomzu7shJc0ObiRZC8H7p
@@ -175,19 +163,13 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter->setPrivateKey(123);
     }
 
-    /**
-     * @return void
-     */
-    public function testToString()
+    public function testToString(): void
     {
         $filter = new OpensslEncryption();
-        $this->assertEquals('Openssl', $filter->toString());
+        $this->assertSame('Openssl', $filter->toString());
     }
 
-    /**
-     * @return void
-     */
-    public function testInvalidDecryption()
+    public function testInvalidDecryption(): void
     {
         $filter = new OpensslEncryption();
         try {
@@ -214,10 +196,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testEncryptionWithoutPublicKey()
+    public function testEncryptionWithoutPublicKey(): void
     {
         $filter = new OpensslEncryption();
 
@@ -226,10 +205,7 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $filter->encrypt('unknown');
     }
 
-    /**
-     * @return void
-     */
-    public function testMultipleOptionsAtInitiation()
+    public function testMultipleOptionsAtInitiation(): void
     {
         $passphrase = 'test';
         $filter     = new OpensslEncryption([
@@ -239,15 +215,13 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         ]);
         $public     = $filter->getPublicKey();
         $this->assertNotEmpty($public);
-        $this->assertEquals($passphrase, $filter->getPassphrase());
+        $this->assertSame($passphrase, $filter->getPassphrase());
     }
 
     /**
      * Ensures that the filter allows de/encryption
-     *
-     * @return void
      */
-    public function testEncryptionWithDecryptionWithPackagedKeys()
+    public function testEncryptionWithDecryptionWithPackagedKeys(): void
     {
         $filter = new OpensslEncryption();
         $filter->setPublicKey(__DIR__ . '/../_files/publickey_pass.pem');
@@ -258,15 +232,13 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $phrase = 'test';
         $filter->setPrivateKey(__DIR__ . '/../_files/privatekey_pass.pem', $phrase);
         $input = $filter->decrypt($output);
-        $this->assertEquals('teststring', trim($input));
+        $this->assertSame('teststring', trim($input));
     }
 
     /**
      * Ensures that the filter allows de/encryption
-     *
-     * @return void
      */
-    public function testEncryptionWithDecryptionAndCompressionWithPackagedKeys()
+    public function testEncryptionWithDecryptionAndCompressionWithPackagedKeys(): void
     {
         if (! extension_loaded('bz2')) {
             $this->markTestSkipped('Bz2 extension for compression test needed');
@@ -282,10 +254,10 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $phrase = 'test';
         $filter->setPrivateKey(__DIR__ . '/../_files/privatekey_pass.pem', $phrase);
         $input = $filter->decrypt($output);
-        $this->assertEquals('teststring', trim($input));
+        $this->assertSame('teststring', trim($input));
     }
 
-    public function testPassCompressionConfigWillBeUnsetCorrectly()
+    public function testPassCompressionConfigWillBeUnsetCorrectly(): void
     {
         $filter = new OpensslEncryption([
             'compression' => 'bz2',

--- a/test/EncryptTest.php
+++ b/test/EncryptTest.php
@@ -23,10 +23,8 @@ class EncryptTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasicBlockCipher()
+    public function testBasicBlockCipher(): void
     {
         $filter         = new EncryptFilter(['adapter' => 'BlockCipher', 'key' => 'testkey']);
         $valuesExpected = [
@@ -41,7 +39,7 @@ class EncryptTest extends TestCase
 
         $enc = $filter->getEncryption();
         $filter->setVector('1234567890123456');
-        $this->assertEquals('testkey', $enc['key']);
+        $this->assertSame('testkey', $enc['key']);
         foreach ($valuesExpected as $input => $output) {
             $this->assertNotEquals($output, $filter($input));
         }
@@ -50,22 +48,20 @@ class EncryptTest extends TestCase
     /**
      * Ensures that the encryption works fine
      */
-    public function testEncryptBlockCipher()
+    public function testEncryptBlockCipher(): void
     {
         $encrypt = new EncryptFilter(['adapter' => 'BlockCipher', 'key' => 'testkey']);
         $encrypt->setVector('1234567890123456890');
         $encrypted = $encrypt->filter('test');
         // @codingStandardsIgnoreStart
-        $this->assertEquals($encrypted, 'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
+        $this->assertSame($encrypted, 'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
         // @codingStandardsIgnoreEnd
     }
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasicOpenssl()
+    public function testBasicOpenssl(): void
     {
         if (! extension_loaded('openssl')) {
             $this->markTestSkipped('Openssl extension not installed');
@@ -80,7 +76,7 @@ class EncryptTest extends TestCase
 
         $filter->setPublicKey(__DIR__ . '/_files/publickey.pem');
         $key = $filter->getPublicKey();
-        $this->assertEquals(
+        $this->assertSame(
             [
                 __DIR__ . '/_files/publickey.pem'
                   => '-----BEGIN CERTIFICATE-----
@@ -110,10 +106,7 @@ PIDs9E7uuizAKDhRRRvho8BS
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testSettingAdapterManually()
+    public function testSettingAdapterManually(): void
     {
         if (! extension_loaded('openssl')) {
             $this->markTestSkipped('Openssl extension not installed');
@@ -121,11 +114,11 @@ PIDs9E7uuizAKDhRRRvho8BS
 
         $filter = new EncryptFilter();
         $filter->setAdapter('Openssl');
-        $this->assertEquals('Openssl', $filter->getAdapter());
+        $this->assertSame('Openssl', $filter->getAdapter());
         $this->assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
 
         $filter->setAdapter('BlockCipher');
-        $this->assertEquals('BlockCipher', $filter->getAdapter());
+        $this->assertSame('BlockCipher', $filter->getAdapter());
         $this->assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
 
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -133,10 +126,7 @@ PIDs9E7uuizAKDhRRRvho8BS
         $filter->setAdapter(stdClass::class);
     }
 
-    /**
-     * @return void
-     */
-    public function testCallingUnknownMethod()
+    public function testCallingUnknownMethod(): void
     {
         $this->expectException(Exception\BadMethodCallException::class);
         $this->expectExceptionMessage('Unknown method');
@@ -160,14 +150,13 @@ PIDs9E7uuizAKDhRRRvho8BS
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $encrypt = new EncryptFilter(['adapter' => 'BlockCipher', 'key' => 'testkey']);
         $encrypt->setVector('1234567890123456890');
 
         $encrypted = $encrypt->filter($input);
-        $this->assertEquals($input, $encrypted);
+        $this->assertSame($input, $encrypted);
     }
 }

--- a/test/File/DecryptTest.php
+++ b/test/File/DecryptTest.php
@@ -58,15 +58,13 @@ class DecryptTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter = new FileEncrypt();
         $filter->setFilename($this->tmpDir . '/newencryption.txt');
 
-        $this->assertEquals(
+        $this->assertSame(
             $this->tmpDir . '/newencryption.txt',
             $filter->getFilename()
         );
@@ -82,23 +80,23 @@ class DecryptTest extends TestCase
         );
 
         $filter->setKey('1234567890123456');
-        $this->assertEquals(
+        $this->assertSame(
             $this->tmpDir . '/newencryption.txt',
             $filter->filter($this->tmpDir . '/newencryption.txt')
         );
 
-        $this->assertEquals(
+        $this->assertSame(
             'Encryption',
             trim(file_get_contents($this->tmpDir . '/newencryption.txt'))
         );
     }
 
-    public function testEncryptionWithDecryption()
+    public function testEncryptionWithDecryption(): void
     {
         $filter = new FileEncrypt();
         $filter->setFilename($this->tmpDir . '/newencryption.txt');
         $filter->setKey('1234567890123456');
-        $this->assertEquals(
+        $this->assertSame(
             $this->tmpDir . '/newencryption.txt',
             $filter->filter($this->fileToEncrypt)
         );
@@ -111,25 +109,22 @@ class DecryptTest extends TestCase
         $filter = new FileDecrypt();
         $filter->setFilename($this->tmpDir . '/newencryption2.txt');
 
-        $this->assertEquals(
+        $this->assertSame(
             $this->tmpDir . '/newencryption2.txt',
             $filter->getFilename()
         );
 
         $filter->setKey('1234567890123456');
         $input = $filter->filter($this->tmpDir . '/newencryption.txt');
-        $this->assertEquals($this->tmpDir . '/newencryption2.txt', $input);
+        $this->assertSame($this->tmpDir . '/newencryption2.txt', $input);
 
-        $this->assertEquals(
+        $this->assertSame(
             'Encryption',
             trim(file_get_contents($this->tmpDir . '/newencryption2.txt'))
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testNonExistingFile()
+    public function testNonExistingFile(): void
     {
         $filter = new FileDecrypt();
         $filter->setVector('1234567890123456');
@@ -155,13 +150,12 @@ class DecryptTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/File/EncryptTest.php
+++ b/test/File/EncryptTest.php
@@ -47,45 +47,40 @@ class EncryptTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter = new FileEncrypt();
         $filter->setFilename($this->testFile);
 
-        $this->assertEquals($this->testFile, $filter->getFilename());
+        $this->assertSame($this->testFile, $filter->getFilename());
 
         $filter->setKey('1234567890123456');
-        $this->assertEquals($this->testFile, $filter->filter($this->fileToEncrypt));
+        $this->assertSame($this->testFile, $filter->filter($this->fileToEncrypt));
 
-        $this->assertEquals('Encryption', file_get_contents($this->fileToEncrypt));
+        $this->assertSame('Encryption', file_get_contents($this->fileToEncrypt));
 
         $this->assertNotEquals('Encryption', file_get_contents($this->testFile));
     }
 
-    public function testEncryptionWithDecryption()
+    public function testEncryptionWithDecryption(): void
     {
         $filter = new FileEncrypt();
         $filter->setFilename($this->testFile);
         $filter->setKey('1234567890123456');
-        $this->assertEquals($this->testFile, $filter->filter($this->fileToEncrypt));
+        $this->assertSame($this->testFile, $filter->filter($this->fileToEncrypt));
 
         $this->assertNotEquals('Encryption', file_get_contents($this->testFile));
 
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
         $input = $filter->filter($this->testFile);
-        $this->assertEquals($this->testFile, $input);
+        $this->assertSame($this->testFile, $input);
 
-        $this->assertEquals('Encryption', trim(file_get_contents($this->testFile)));
+        $this->assertSame('Encryption', trim(file_get_contents($this->testFile)));
     }
 
-    /**
-     * @return void
-     */
-    public function testNonExistingFile()
+    public function testNonExistingFile(): void
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
@@ -95,10 +90,7 @@ class EncryptTest extends TestCase
         $filter->filter(sprintf('%s/%s.txt', $this->testDir, uniqid()));
     }
 
-    /**
-     * @return void
-     */
-    public function testEncryptionInSameFile()
+    public function testEncryptionInSameFile(): void
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
@@ -125,13 +117,12 @@ class EncryptTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/File/LowerCaseTest.php
+++ b/test/File/LowerCaseTest.php
@@ -51,10 +51,7 @@ class LowerCaseTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testInstanceCreationAndNormalWorkflow()
+    public function testInstanceCreationAndNormalWorkflow(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileLowerCase();
@@ -62,10 +59,7 @@ class LowerCaseTest extends TestCase
         $this->assertStringContainsString('this is a file', file_get_contents($this->testFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testNormalWorkflowWithFilesArray()
+    public function testNormalWorkflowWithFilesArray(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileLowerCase();
@@ -73,10 +67,7 @@ class LowerCaseTest extends TestCase
         $this->assertStringContainsString('this is a file', file_get_contents($this->testFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testFileNotFoundException()
+    public function testFileNotFoundException(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('not found');
@@ -84,10 +75,7 @@ class LowerCaseTest extends TestCase
         $filter($this->testFile . 'unknown');
     }
 
-    /**
-     * @return void
-     */
-    public function testCheckSettingOfEncodingInIstance()
+    public function testCheckSettingOfEncodingInIstance(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
@@ -99,10 +87,7 @@ class LowerCaseTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testCheckSettingOfEncodingWithMethod()
+    public function testCheckSettingOfEncodingWithMethod(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
@@ -131,12 +116,11 @@ class LowerCaseTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new FileLowerCase();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/File/RenameTest.php
+++ b/test/File/RenameTest.php
@@ -114,68 +114,62 @@ class RenameTest extends TestCase
 
     /**
      * Test single parameter filter
-     *
-     * @return void
      */
-    public function testConstructSingleValue()
+    public function testConstructSingleValue(): void
     {
         $filter = new FileRename($this->newFile);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
-                    'source'    => '*',
                     'target'    => $this->newFile,
+                    'source'    => '*',
                     'overwrite' => false,
                     'randomize' => false,
                 ],
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single parameter filter
-     *
-     * @return void
      */
-    public function testConstructSingleValueWithFilesArray()
+    public function testConstructSingleValueWithFilesArray(): void
     {
         $filter = new FileRename($this->newFile);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
-                    'source'    => '*',
                     'target'    => $this->newFile,
+                    'source'    => '*',
                     'overwrite' => false,
                     'randomize' => false,
                 ],
             ],
             $filter->getFile()
         );
-        $this->assertEquals(
+        $this->assertSame(
             ['tmp_name' => $this->newFile],
             $filter(['tmp_name' => $this->oldFile])
         );
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single array parameter filter
-     *
-     * @return void
      */
-    public function testConstructSingleArray()
+    public function testConstructSingleArray(): void
     {
         $filter = new FileRename([
             'source' => $this->oldFile,
             'target' => $this->newFile,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -186,16 +180,14 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test full array parameter filter
-     *
-     * @return void
      */
-    public function testConstructFullOptionsArray()
+    public function testConstructFullOptionsArray(): void
     {
         $filter = new FileRename([
             'source'    => $this->oldFile,
@@ -205,7 +197,7 @@ class RenameTest extends TestCase
             'unknown'   => false,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -216,16 +208,14 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single array parameter filter
-     *
-     * @return void
      */
-    public function testConstructDoubleArray()
+    public function testConstructDoubleArray(): void
     {
         $filter = new FileRename([
             0 => [
@@ -234,7 +224,7 @@ class RenameTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -245,22 +235,20 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single array parameter filter
-     *
-     * @return void
      */
-    public function testConstructTruncatedTarget()
+    public function testConstructTruncatedTarget(): void
     {
         $filter = new FileRename([
             'source' => $this->oldFile,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -271,73 +259,67 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->oldFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->oldFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single array parameter filter
-     *
-     * @return void
      */
-    public function testConstructTruncatedSource()
+    public function testConstructTruncatedSource(): void
     {
         $filter = new FileRename([
             'target' => $this->newFile,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
-                    'source'    => '*',
                     'target'    => $this->newFile,
+                    'source'    => '*',
                     'overwrite' => false,
                     'randomize' => false,
                 ],
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single parameter filter by using directory only
-     *
-     * @return void
      */
-    public function testConstructSingleDirectory()
+    public function testConstructSingleDirectory(): void
     {
         $filter = new FileRename($this->newDir);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
-                    'source'    => '*',
                     'target'    => $this->newDir,
+                    'source'    => '*',
                     'overwrite' => false,
                     'randomize' => false,
                 ],
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newDirFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newDirFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single array parameter filter by using directory only
-     *
-     * @return void
      */
-    public function testConstructSingleArrayDirectory()
+    public function testConstructSingleArrayDirectory(): void
     {
         $filter = new FileRename([
             'source' => $this->oldFile,
             'target' => $this->newDir,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -348,16 +330,14 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newDirFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newDirFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single array parameter filter by using directory only
-     *
-     * @return void
      */
-    public function testConstructDoubleArrayDirectory()
+    public function testConstructDoubleArrayDirectory(): void
     {
         $filter = new FileRename([
             0 => [
@@ -366,7 +346,7 @@ class RenameTest extends TestCase
             ],
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -377,40 +357,35 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newDirFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newDirFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * Test single array parameter filter by using directory only
-     *
-     * @return void
      */
-    public function testConstructTruncatedSourceDirectory()
+    public function testConstructTruncatedSourceDirectory(): void
     {
         $filter = new FileRename([
             'target' => $this->newDir,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
-                    'source'    => '*',
                     'target'    => $this->newDir,
+                    'source'    => '*',
                     'overwrite' => false,
                     'randomize' => false,
                 ],
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newDirFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newDirFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
-    /**
-     * @return void
-     */
-    public function testAddSameFileAgainAndOverwriteExistingTarget()
+    public function testAddSameFileAgainAndOverwriteExistingTarget(): void
     {
         $filter = new FileRename([
             'source' => $this->oldFile,
@@ -422,7 +397,7 @@ class RenameTest extends TestCase
             'target' => $this->newFile,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -433,21 +408,18 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
-    /**
-     * @return void
-     */
-    public function testGetNewName()
+    public function testGetNewName(): void
     {
         $filter = new FileRename([
             'source' => $this->oldFile,
             'target' => $this->newDir,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -458,13 +430,10 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newDirFile, $filter->getNewName($this->oldFile));
+        $this->assertSame($this->newDirFile, $filter->getNewName($this->oldFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testGetNewNameExceptionWithExistingFile()
+    public function testGetNewNameExceptionWithExistingFile(): void
     {
         $filter = new FileRename([
             'source' => $this->oldFile,
@@ -473,7 +442,7 @@ class RenameTest extends TestCase
 
         copy($this->oldFile, $this->newFile);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -486,13 +455,10 @@ class RenameTest extends TestCase
         );
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('could not be renamed');
-        $this->assertEquals($this->newFile, $filter->getNewName($this->oldFile));
+        $this->assertSame($this->newFile, $filter->getNewName($this->oldFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testGetNewNameOverwriteWithExistingFile()
+    public function testGetNewNameOverwriteWithExistingFile(): void
     {
         $filter = new FileRename([
             'source'    => $this->oldFile,
@@ -502,7 +468,7 @@ class RenameTest extends TestCase
 
         copy($this->oldFile, $this->newFile);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -513,13 +479,10 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter->getNewName($this->oldFile));
+        $this->assertSame($this->newFile, $filter->getNewName($this->oldFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testGetRandomizedFile()
+    public function testGetRandomizedFile(): void
     {
         $filter = new FileRename([
             'source'    => $this->oldFile,
@@ -527,13 +490,13 @@ class RenameTest extends TestCase
             'randomize' => true,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
                     'target'    => $this->newFile,
-                    'overwrite' => false,
                     'randomize' => true,
+                    'overwrite' => false,
                 ],
             ],
             $filter->getFile()
@@ -545,10 +508,7 @@ class RenameTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testGetRandomizedFileWithoutExtension()
+    public function testGetRandomizedFileWithoutExtension(): void
     {
         $fileNoExt = $this->tmpPath . DIRECTORY_SEPARATOR . 'newfile';
         $filter    = new FileRename([
@@ -557,13 +517,13 @@ class RenameTest extends TestCase
             'randomize' => true,
         ]);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
                     'target'    => $fileNoExt,
-                    'overwrite' => false,
                     'randomize' => true,
+                    'overwrite' => false,
                 ],
             ],
             $filter->getFile()
@@ -574,33 +534,27 @@ class RenameTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testAddFileWithString()
+    public function testAddFileWithString(): void
     {
         $filter = new FileRename($this->oldFile);
         $filter->addFile($this->newFile);
 
-        $this->assertEquals(
+        $this->assertSame(
             [
                 0 => [
-                    'source'    => '*',
                     'target'    => $this->newFile,
+                    'source'    => '*',
                     'overwrite' => false,
                     'randomize' => false,
                 ],
             ],
             $filter->getFile()
         );
-        $this->assertEquals($this->newFile, $filter($this->oldFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->newFile, $filter($this->oldFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
-    /**
-     * @return void
-     */
-    public function testAddFileWithInvalidOption()
+    public function testAddFileWithInvalidOption(): void
     {
         $filter = new FileRename($this->oldFile);
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -608,10 +562,7 @@ class RenameTest extends TestCase
         $filter->addFile(1234);
     }
 
-    /**
-     * @return void
-     */
-    public function testInvalidConstruction()
+    public function testInvalidConstruction(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid options');
@@ -634,12 +585,11 @@ class RenameTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new FileRename($this->newFile);
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/File/RenameUploadTest.php
+++ b/test/File/RenameUploadTest.php
@@ -121,26 +121,21 @@ class RenameUploadTest extends TestCase
 
     /**
      * Test single parameter filter
-     *
-     * @return void
      */
-    public function testThrowsExceptionWithNonUploadedFile()
+    public function testThrowsExceptionWithNonUploadedFile(): void
     {
         $filter = new FileRenameUpload($this->targetFile);
-        $this->assertEquals($this->targetFile, $filter->getTarget());
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->targetFile, $filter->getTarget());
+        $this->assertSame('falsefile', $filter('falsefile'));
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('could not be renamed');
-        $this->assertEquals($this->targetFile, $filter($this->sourceFile));
+        $this->assertSame($this->targetFile, $filter($this->sourceFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testOptions()
+    public function testOptions(): void
     {
         $filter = new FileRenameUpload($this->targetFile);
-        $this->assertEquals($this->targetFile, $filter->getTarget());
+        $this->assertSame($this->targetFile, $filter->getTarget());
         $this->assertFalse($filter->getUseUploadName());
         $this->assertFalse($filter->getOverwrite());
         $this->assertFalse($filter->getRandomize());
@@ -151,31 +146,25 @@ class RenameUploadTest extends TestCase
             'overwrite'       => true,
             'randomize'       => true,
         ]);
-        $this->assertEquals($this->sourceFile, $filter->getTarget());
+        $this->assertSame($this->sourceFile, $filter->getTarget());
         $this->assertTrue($filter->getUseUploadName());
         $this->assertTrue($filter->getOverwrite());
         $this->assertTrue($filter->getRandomize());
     }
 
-    /**
-     * @return void
-     */
-    public function testStringConstructorParam()
+    public function testStringConstructorParam(): void
     {
         $filter = new RenameUploadMock($this->targetFile);
-        $this->assertEquals($this->targetFile, $filter->getTarget());
-        $this->assertEquals($this->targetFile, $filter($this->sourceFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->targetFile, $filter->getTarget());
+        $this->assertSame($this->targetFile, $filter($this->sourceFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
-    /**
-     * @return void
-     */
-    public function testStringConstructorWithFilesArray()
+    public function testStringConstructorWithFilesArray(): void
     {
         $filter = new RenameUploadMock($this->targetFile);
-        $this->assertEquals($this->targetFile, $filter->getTarget());
-        $this->assertEquals(
+        $this->assertSame($this->targetFile, $filter->getTarget());
+        $this->assertSame(
             [
                 'tmp_name' => $this->targetFile,
                 'name'     => $this->targetFile,
@@ -185,14 +174,13 @@ class RenameUploadTest extends TestCase
                 'name'     => $this->targetFile,
             ])
         );
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
      * @requires PHP 7
-     * @return void
      */
-    public function testStringConstructorWithPsrFile()
+    public function testStringConstructorWithPsrFile(): void
     {
         $sourceFile = $this->sourceFile;
         $targetFile = $this->targetFile;
@@ -236,7 +224,7 @@ class RenameUploadTest extends TestCase
             ->will([$renamedFile, 'reveal']);
 
         $filter = new RenameUploadMock($targetFile);
-        $this->assertEquals($targetFile, $filter->getTarget());
+        $this->assertSame($targetFile, $filter->getTarget());
 
         $filter->setStreamFactory($streamFactory->reveal());
         $filter->setUploadFileFactory($fileFactory->reveal());
@@ -250,45 +238,33 @@ class RenameUploadTest extends TestCase
         $this->assertSame($moved, $secondResult);
     }
 
-    /**
-     * @return void
-     */
-    public function testArrayConstructorParam()
+    public function testArrayConstructorParam(): void
     {
         $filter = new RenameUploadMock([
             'target' => $this->targetFile,
         ]);
-        $this->assertEquals($this->targetFile, $filter->getTarget());
-        $this->assertEquals($this->targetFile, $filter($this->sourceFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->targetFile, $filter->getTarget());
+        $this->assertSame($this->targetFile, $filter($this->sourceFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
-    /**
-     * @return void
-     */
-    public function testConstructTruncatedTarget()
+    public function testConstructTruncatedTarget(): void
     {
         $filter = new FileRenameUpload('*');
-        $this->assertEquals('*', $filter->getTarget());
-        $this->assertEquals($this->sourceFile, $filter($this->sourceFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame('*', $filter->getTarget());
+        $this->assertSame($this->sourceFile, $filter($this->sourceFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
-    /**
-     * @return void
-     */
-    public function testTargetDirectory()
+    public function testTargetDirectory(): void
     {
         $filter = new RenameUploadMock($this->targetPath);
-        $this->assertEquals($this->targetPath, $filter->getTarget());
-        $this->assertEquals($this->targetPathFile, $filter($this->sourceFile));
-        $this->assertEquals('falsefile', $filter('falsefile'));
+        $this->assertSame($this->targetPath, $filter->getTarget());
+        $this->assertSame($this->targetPathFile, $filter($this->sourceFile));
+        $this->assertSame('falsefile', $filter('falsefile'));
     }
 
-    /**
-     * @return void
-     */
-    public function testOverwriteWithExistingFile()
+    public function testOverwriteWithExistingFile(): void
     {
         $filter = new RenameUploadMock([
             'target'    => $this->targetFile,
@@ -297,14 +273,11 @@ class RenameUploadTest extends TestCase
 
         copy($this->sourceFile, $this->targetFile);
 
-        $this->assertEquals($this->targetFile, $filter->getTarget());
-        $this->assertEquals($this->targetFile, $filter($this->sourceFile));
+        $this->assertSame($this->targetFile, $filter->getTarget());
+        $this->assertSame($this->targetFile, $filter($this->sourceFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testCannotOverwriteExistingFile()
+    public function testCannotOverwriteExistingFile(): void
     {
         $filter = new RenameUploadMock([
             'target'    => $this->targetFile,
@@ -313,17 +286,14 @@ class RenameUploadTest extends TestCase
 
         copy($this->sourceFile, $this->targetFile);
 
-        $this->assertEquals($this->targetFile, $filter->getTarget());
+        $this->assertSame($this->targetFile, $filter->getTarget());
         $this->assertFalse($filter->getOverwrite());
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('already exists');
-        $this->assertEquals($this->targetFile, $filter($this->sourceFile));
+        $this->assertSame($this->targetFile, $filter($this->sourceFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testGetRandomizedFile()
+    public function testGetRandomizedFile(): void
     {
         $fileNoExt = $this->filesPath . DIRECTORY_SEPARATOR . 'newfile';
         $filter    = new RenameUploadMock([
@@ -337,7 +307,7 @@ class RenameUploadTest extends TestCase
         );
     }
 
-    public function testGetFileWithOriginalExtension()
+    public function testGetFileWithOriginalExtension(): void
     {
         $fileNoExt = $this->filesPath . DIRECTORY_SEPARATOR . 'newfile';
         $filter    = new RenameUploadMock([
@@ -354,7 +324,7 @@ class RenameUploadTest extends TestCase
         );
     }
 
-    public function testGetRandomizedFileWithOriginalExtension()
+    public function testGetRandomizedFileWithOriginalExtension(): void
     {
         $fileNoExt = $this->filesPath . DIRECTORY_SEPARATOR . 'newfile';
         $filter    = new RenameUploadMock([
@@ -371,10 +341,7 @@ class RenameUploadTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testGetRandomizedFileWithoutExtension()
+    public function testGetRandomizedFileWithoutExtension(): void
     {
         $fileNoExt = $this->filesPath . DIRECTORY_SEPARATOR . 'newfile';
         $filter    = new RenameUploadMock([
@@ -388,20 +355,14 @@ class RenameUploadTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
-    public function testInvalidConstruction()
+    public function testInvalidConstruction(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid target');
         $filter = new FileRenameUpload(1234);
     }
 
-    /**
-     * @return void
-     */
-    public function testCanFilterMultipleTimesWithSameResult()
+    public function testCanFilterMultipleTimesWithSameResult(): void
     {
         $filter = new RenameUploadMock([
             'target'    => $this->targetFile,
@@ -433,24 +394,21 @@ class RenameUploadTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new RenameUploadMock([
             'target'    => $this->targetFile,
             'randomize' => true,
         ]);
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 
     /**
      * @see https://github.com/zendframework/zend-filter/issues/77
-     *
-     * @return void
      */
-    public function testFilterDoesNotAlterUnknownFileDataAndCachesResultsOfFilteringSAPIUploads()
+    public function testFilterDoesNotAlterUnknownFileDataAndCachesResultsOfFilteringSAPIUploads(): void
     {
         $filter = new RenameUploadMock($this->targetPath);
 
@@ -472,16 +430,14 @@ class RenameUploadTest extends TestCase
         ];
 
         // Check the result twice for the `alreadyFiltered` cache path
-        $this->assertEquals($sapiTarget, $filter($sapiSource));
-        $this->assertEquals($sapiTarget, $filter($sapiSource));
+        $this->assertSame($sapiTarget, $filter($sapiSource));
+        $this->assertSame($sapiTarget, $filter($sapiSource));
     }
 
     /**
      * @see https://github.com/zendframework/zend-filter/issues/76
-     *
-     * @return void
      */
-    public function testFilterReturnsFileDataVerbatimUnderSAPIWhenTargetPathIsUnspecified()
+    public function testFilterReturnsFileDataVerbatimUnderSAPIWhenTargetPathIsUnspecified(): void
     {
         $filter = new RenameUploadMock();
 
@@ -490,6 +446,6 @@ class RenameUploadTest extends TestCase
             'name'     => basename($this->targetFile),
         ];
 
-        $this->assertEquals($source, $filter($source));
+        $this->assertSame($source, $filter($source));
     }
 }

--- a/test/File/UpperCaseTest.php
+++ b/test/File/UpperCaseTest.php
@@ -52,10 +52,7 @@ class UpperCaseTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testInstanceCreationAndNormalWorkflow()
+    public function testInstanceCreationAndNormalWorkflow(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileUpperCase();
@@ -63,10 +60,7 @@ class UpperCaseTest extends TestCase
         $this->assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testNormalWorkflowWithFilesArray()
+    public function testNormalWorkflowWithFilesArray(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileUpperCase();
@@ -74,10 +68,7 @@ class UpperCaseTest extends TestCase
         $this->assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
     }
 
-    /**
-     * @return void
-     */
-    public function testFileNotFoundException()
+    public function testFileNotFoundException(): void
     {
         $filter = new FileUpperCase();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -85,10 +76,7 @@ class UpperCaseTest extends TestCase
         $filter($this->testFile . 'unknown');
     }
 
-    /**
-     * @return void
-     */
-    public function testCheckSettingOfEncodingInIstance()
+    public function testCheckSettingOfEncodingInIstance(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
@@ -100,10 +88,7 @@ class UpperCaseTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testCheckSettingOfEncodingWithMethod()
+    public function testCheckSettingOfEncodingWithMethod(): void
     {
         $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
@@ -132,13 +117,12 @@ class UpperCaseTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new FileUpperCase();
         $filter->setEncoding('ISO-8859-1');
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/FilterChainTest.php
+++ b/test/FilterChainTest.php
@@ -22,44 +22,44 @@ use function unserialize;
 
 class FilterChainTest extends TestCase
 {
-    public function testEmptyFilterChainReturnsOriginalValue()
+    public function testEmptyFilterChainReturnsOriginalValue(): void
     {
         $chain = new FilterChain();
         $value = 'something';
-        $this->assertEquals($value, $chain->filter($value));
+        $this->assertSame($value, $chain->filter($value));
     }
 
-    public function testFiltersAreExecutedInFifoOrder()
+    public function testFiltersAreExecutedInFifoOrder(): void
     {
         $chain = new FilterChain();
         $chain->attach(new TestAsset\LowerCase())
             ->attach(new TestAsset\StripUpperCase());
         $value         = 'AbC';
         $valueExpected = 'abc';
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
     }
 
-    public function testFiltersAreExecutedAccordingToPriority()
+    public function testFiltersAreExecutedAccordingToPriority(): void
     {
         $chain = new FilterChain();
         $chain->attach(new TestAsset\StripUpperCase())
             ->attach(new TestAsset\LowerCase(), 100);
         $value         = 'AbC';
         $valueExpected = 'b';
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
     }
 
-    public function testAllowsConnectingArbitraryCallbacks()
+    public function testAllowsConnectingArbitraryCallbacks(): void
     {
         $chain = new FilterChain();
         $chain->attach(function ($value) {
             return strtolower($value);
         });
         $value = 'AbC';
-        $this->assertEquals('abc', $chain->filter($value));
+        $this->assertSame('abc', $chain->filter($value));
     }
 
-    public function testAllowsConnectingViaClassShortName()
+    public function testAllowsConnectingViaClassShortName(): void
     {
         if (! function_exists('mb_strtolower')) {
             $this->markTestSkipped('mbstring required');
@@ -72,39 +72,39 @@ class FilterChainTest extends TestCase
 
         $value         = '<a name="foo"> ABC </a>';
         $valueExpected = 'abc';
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
     }
 
-    public function testAllowsConfiguringFilters()
+    public function testAllowsConfiguringFilters(): void
     {
         $config = $this->getChainConfig();
         $chain  = new FilterChain();
         $chain->setOptions($config);
         $value         = '<a name="foo"> abc </a><img id="bar" />';
         $valueExpected = 'ABC <IMG ID="BAR" />';
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
     }
 
-    public function testAllowsConfiguringFiltersViaConstructor()
+    public function testAllowsConfiguringFiltersViaConstructor(): void
     {
         $config        = $this->getChainConfig();
         $chain         = new FilterChain($config);
         $value         = '<a name="foo"> abc </a>';
         $valueExpected = 'ABC';
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
     }
 
-    public function testConfigurationAllowsTraversableObjects()
+    public function testConfigurationAllowsTraversableObjects(): void
     {
         $config        = $this->getChainConfig();
         $config        = new ArrayIterator($config);
         $chain         = new FilterChain($config);
         $value         = '<a name="foo"> abc </a>';
         $valueExpected = 'ABC';
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
     }
 
-    public function testCanRetrieveFilterWithUndefinedConstructor()
+    public function testCanRetrieveFilterWithUndefinedConstructor(): void
     {
         $chain    = new FilterChain([
             'filters' => [
@@ -112,7 +112,7 @@ class FilterChainTest extends TestCase
             ],
         ]);
         $filtered = $chain->filter('127.1');
-        $this->assertEquals(127, $filtered);
+        $this->assertSame(127, $filtered);
     }
 
     protected function getChainConfig()
@@ -145,7 +145,7 @@ class FilterChainTest extends TestCase
     /**
      * @group Laminas-412
      */
-    public function testCanAttachMultipleFiltersOfTheSameTypeAsDiscreteInstances()
+    public function testCanAttachMultipleFiltersOfTheSameTypeAsDiscreteInstances(): void
     {
         $chain = new FilterChain();
         $chain->attachByName(PregReplace::class, [
@@ -157,7 +157,7 @@ class FilterChainTest extends TestCase
             'replacement' => 'PARTY',
         ]);
 
-        $this->assertEquals(2, count($chain));
+        $this->assertSame(2, count($chain));
         $filters = $chain->getFilters();
         $compare = null;
         foreach ($filters as $filter) {
@@ -165,10 +165,10 @@ class FilterChainTest extends TestCase
             $compare = $filter;
         }
 
-        $this->assertEquals('Tu et PARTY', $chain->filter('Tu et Foo'));
+        $this->assertSame('Tu et PARTY', $chain->filter('Tu et Foo'));
     }
 
-    public function testClone()
+    public function testClone(): void
     {
         $chain = new FilterChain();
         $clone = clone $chain;
@@ -178,7 +178,7 @@ class FilterChainTest extends TestCase
         $this->assertCount(0, $clone);
     }
 
-    public function testCanSerializeFilterChain()
+    public function testCanSerializeFilterChain(): void
     {
         $chain = new FilterChain();
         $chain->attach(new TestAsset\LowerCase())
@@ -187,13 +187,13 @@ class FilterChainTest extends TestCase
 
         $unserialized = unserialize($serialized);
         $this->assertInstanceOf(FilterChain::class, $unserialized);
-        $this->assertEquals(2, count($unserialized));
+        $this->assertSame(2, count($unserialized));
         $value         = 'AbC';
         $valueExpected = 'abc';
-        $this->assertEquals($valueExpected, $unserialized->filter($value));
+        $this->assertSame($valueExpected, $unserialized->filter($value));
     }
 
-    public function testMergingTwoFilterChainsKeepFiltersPriority()
+    public function testMergingTwoFilterChainsKeepFiltersPriority(): void
     {
         $value         = 'AbC';
         $valueExpected = 'abc';
@@ -201,27 +201,27 @@ class FilterChainTest extends TestCase
         $chain = new FilterChain();
         $chain->attach(new TestAsset\StripUpperCase())
             ->attach(new TestAsset\LowerCase(), 1001);
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
 
         $chain = new FilterChain();
         $chain->attach(new TestAsset\LowerCase(), 1001)
             ->attach(new TestAsset\StripUpperCase());
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame($valueExpected, $chain->filter($value));
 
         $chain = new FilterChain();
         $chain->attach(new TestAsset\LowerCase(), 1001);
         $chainToMerge = new FilterChain();
         $chainToMerge->attach(new TestAsset\StripUpperCase());
         $chain->merge($chainToMerge);
-        $this->assertEquals(2, $chain->count());
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame(2, $chain->count());
+        $this->assertSame($valueExpected, $chain->filter($value));
 
         $chain = new FilterChain();
         $chain->attach(new TestAsset\StripUpperCase());
         $chainToMerge = new FilterChain();
         $chainToMerge->attach(new TestAsset\LowerCase(), 1001);
         $chain->merge($chainToMerge);
-        $this->assertEquals(2, $chain->count());
-        $this->assertEquals($valueExpected, $chain->filter($value));
+        $this->assertSame(2, $chain->count());
+        $this->assertSame($valueExpected, $chain->filter($value));
     }
 }

--- a/test/FilterPluginManagerFactoryTest.php
+++ b/test/FilterPluginManagerFactoryTest.php
@@ -20,7 +20,7 @@ class FilterPluginManagerFactoryTest extends TestCase
 {
     use ProphecyTrait;
 
-    public function testFactoryReturnsPluginManager()
+    public function testFactoryReturnsPluginManager(): void
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
         $factory   = new FilterPluginManagerFactory();
@@ -43,7 +43,7 @@ class FilterPluginManagerFactoryTest extends TestCase
     /**
      * @depends testFactoryReturnsPluginManager
      */
-    public function testFactoryConfiguresPluginManagerUnderContainerInterop()
+    public function testFactoryConfiguresPluginManagerUnderContainerInterop(): void
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
         $filter    = function ($value) {
@@ -82,7 +82,7 @@ class FilterPluginManagerFactoryTest extends TestCase
         $this->assertSame($filter, $filters->get('test'));
     }
 
-    public function testConfiguresFilterServicesWhenFound()
+    public function testConfiguresFilterServicesWhenFound(): void
     {
         $filter = $this->prophesize(FilterInterface::class)->reveal();
         $config = [
@@ -115,7 +115,7 @@ class FilterPluginManagerFactoryTest extends TestCase
         $this->assertSame($filter, $filters->get('test-too'));
     }
 
-    public function testDoesNotConfigureFilterServicesWhenServiceListenerPresent()
+    public function testDoesNotConfigureFilterServicesWhenServiceListenerPresent(): void
     {
         $filter = $this->prophesize(FilterInterface::class)->reveal();
         $config = [
@@ -146,7 +146,7 @@ class FilterPluginManagerFactoryTest extends TestCase
         $this->assertFalse($filters->has('test-too'));
     }
 
-    public function testDoesNotConfigureFilterServicesWhenConfigServiceNotPresent()
+    public function testDoesNotConfigureFilterServicesWhenConfigServiceNotPresent(): void
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);
@@ -161,7 +161,7 @@ class FilterPluginManagerFactoryTest extends TestCase
         $this->assertInstanceOf(FilterPluginManager::class, $filters);
     }
 
-    public function testDoesNotConfigureFilterServicesWhenConfigServiceDoesNotContainFiltersConfig()
+    public function testDoesNotConfigureFilterServicesWhenConfigServiceDoesNotContainFiltersConfig(): void
     {
         $container = $this->prophesize(ServiceLocatorInterface::class);
         $container->willImplement(ContainerInterface::class);

--- a/test/FilterPluginManagerTest.php
+++ b/test/FilterPluginManagerTest.php
@@ -24,20 +24,20 @@ class FilterPluginManagerTest extends TestCase
         $this->filters = new FilterPluginManager(new ServiceManager());
     }
 
-    public function testFilterSuccessfullyRetrieved()
+    public function testFilterSuccessfullyRetrieved(): void
     {
         $filter = $this->filters->get('int');
         $this->assertInstanceOf(ToInt::class, $filter);
     }
 
-    public function testRegisteringInvalidFilterRaisesException()
+    public function testRegisteringInvalidFilterRaisesException(): void
     {
         $this->expectException($this->getInvalidServiceException());
         $this->filters->setService('test', $this);
         $this->filters->get('test');
     }
 
-    public function testLoadingInvalidFilterRaisesException()
+    public function testLoadingInvalidFilterRaisesException(): void
     {
         $this->filters->setInvokableClass('test', static::class);
         $this->expectException($this->getInvalidServiceException());
@@ -47,7 +47,7 @@ class FilterPluginManagerTest extends TestCase
     /**
      * @group 7169
      */
-    public function testFilterSuccessfullyConstructed()
+    public function testFilterSuccessfullyConstructed(): void
     {
         $searchSeparator      = ';';
         $replacementSeparator = '|';
@@ -60,14 +60,14 @@ class FilterPluginManagerTest extends TestCase
         $filter = $this->filters->get('wordseparatortoseparator', $options);
 
         $this->assertInstanceOf(SeparatorToSeparator::class, $filter);
-        $this->assertEquals($searchSeparator, $filter->getSearchSeparator());
-        $this->assertEquals($replacementSeparator, $filter->getReplacementSeparator());
+        $this->assertSame($searchSeparator, $filter->getSearchSeparator());
+        $this->assertSame($replacementSeparator, $filter->getReplacementSeparator());
     }
 
     /**
      * @group 7169
      */
-    public function testFiltersConstructedAreDifferent()
+    public function testFiltersConstructedAreDifferent(): void
     {
         $filterOne = $this->filters->get(
             'wordseparatortoseparator',

--- a/test/HtmlEntitiesTest.php
+++ b/test/HtmlEntitiesTest.php
@@ -46,10 +46,8 @@ class HtmlEntitiesTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $valuesExpected = [
             'string' => 'string',
@@ -61,72 +59,61 @@ class HtmlEntitiesTest extends TestCase
         ];
         $filter         = $this->_filter;
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
     /**
      * Ensures that getQuoteStyle() returns expected default value
-     *
-     * @return void
      */
-    public function testGetQuoteStyle()
+    public function testGetQuoteStyle(): void
     {
-        $this->assertEquals(ENT_QUOTES, $this->_filter->getQuoteStyle());
+        $this->assertSame(ENT_QUOTES, $this->_filter->getQuoteStyle());
     }
 
     /**
      * Ensures that setQuoteStyle() follows expected behavior
-     *
-     * @return void
      */
-    public function testSetQuoteStyle()
+    public function testSetQuoteStyle(): void
     {
         $this->_filter->setQuoteStyle(ENT_QUOTES);
-        $this->assertEquals(ENT_QUOTES, $this->_filter->getQuoteStyle());
+        $this->assertSame(ENT_QUOTES, $this->_filter->getQuoteStyle());
     }
 
     /**
      * Ensures that getCharSet() returns expected default value
      *
      * @group Laminas-8715
-     * @return void
      */
-    public function testGetCharSet()
+    public function testGetCharSet(): void
     {
-        $this->assertEquals('UTF-8', $this->_filter->getCharSet());
+        $this->assertSame('UTF-8', $this->_filter->getCharSet());
     }
 
     /**
      * Ensures that setCharSet() follows expected behavior
-     *
-     * @return void
      */
-    public function testSetCharSet()
+    public function testSetCharSet(): void
     {
         $this->_filter->setCharSet('UTF-8');
-        $this->assertEquals('UTF-8', $this->_filter->getCharSet());
+        $this->assertSame('UTF-8', $this->_filter->getCharSet());
     }
 
     /**
      * Ensures that getDoubleQuote() returns expected default value
-     *
-     * @return void
      */
-    public function testGetDoubleQuote()
+    public function testGetDoubleQuote(): void
     {
-        $this->assertEquals(true, $this->_filter->getDoubleQuote());
+        $this->assertSame(true, $this->_filter->getDoubleQuote());
     }
 
     /**
      * Ensures that setDoubleQuote() follows expected behavior
-     *
-     * @return void
      */
-    public function testSetDoubleQuote()
+    public function testSetDoubleQuote(): void
     {
         $this->_filter->setDoubleQuote(false);
-        $this->assertEquals(false, $this->_filter->getDoubleQuote());
+        $this->assertSame(false, $this->_filter->getDoubleQuote());
     }
 
     /**
@@ -134,7 +121,7 @@ class HtmlEntitiesTest extends TestCase
      *
      * @group Laminas-3172
      */
-    public function testFluentInterface()
+    public function testFluentInterface(): void
     {
         $instance = $this->_filter->setCharSet('UTF-8')->setQuoteStyle(ENT_QUOTES)->setDoubleQuote(false);
         $this->assertInstanceOf(HtmlEntitiesFilter::class, $instance);
@@ -147,7 +134,7 @@ class HtmlEntitiesTest extends TestCase
      *
      * @group Laminas-8995
      */
-    public function testConfigObject()
+    public function testConfigObject(): void
     {
         $options = ['quotestyle' => 5, 'encoding' => 'ISO-8859-1'];
         $config  = new ArrayObject($options);
@@ -156,59 +143,56 @@ class HtmlEntitiesTest extends TestCase
             $config
         );
 
-        $this->assertEquals('ISO-8859-1', $filter->getEncoding());
-        $this->assertEquals(5, $filter->getQuoteStyle());
+        $this->assertSame('ISO-8859-1', $filter->getEncoding());
+        $this->assertSame(5, $filter->getQuoteStyle());
     }
 
     /**
      * Ensures that when ENT_QUOTES is set, the filtered value has both 'single' and "double" quotes encoded
      *
      * @group  Laminas-8962
-     * @return void
      */
-    public function testQuoteStyleQuotesEncodeBoth()
+    public function testQuoteStyleQuotesEncodeBoth(): void
     {
         $input  = "A 'single' and " . '"double"';
         $result = 'A &#039;single&#039; and &quot;double&quot;';
 
         $this->_filter->setQuoteStyle(ENT_QUOTES);
-        $this->assertEquals($result, $this->_filter->filter($input));
+        $this->assertSame($result, $this->_filter->filter($input));
     }
 
     /**
      * Ensures that when ENT_COMPAT is set, the filtered value has only "double" quotes encoded
      *
      * @group  Laminas-8962
-     * @return void
      */
-    public function testQuoteStyleQuotesEncodeDouble()
+    public function testQuoteStyleQuotesEncodeDouble(): void
     {
         $input  = "A 'single' and " . '"double"';
         $result = "A 'single' and &quot;double&quot;";
 
         $this->_filter->setQuoteStyle(ENT_COMPAT);
-        $this->assertEquals($result, $this->_filter->filter($input));
+        $this->assertSame($result, $this->_filter->filter($input));
     }
 
     /**
      * Ensures that when ENT_NOQUOTES is set, the filtered value leaves both "double" and 'single' quotes un-altered
      *
      * @group  Laminas-8962
-     * @return void
      */
-    public function testQuoteStyleQuotesEncodeNone()
+    public function testQuoteStyleQuotesEncodeNone(): void
     {
         $input  = "A 'single' and " . '"double"';
         $result = "A 'single' and " . '"double"';
 
         $this->_filter->setQuoteStyle(ENT_NOQUOTES);
-        $this->assertEquals($result, $this->_filter->filter($input));
+        $this->assertSame($result, $this->_filter->filter($input));
     }
 
     /**
      * @group Laminas-11344
      */
-    public function testCorrectsForEncodingMismatch()
+    public function testCorrectsForEncodingMismatch(): void
     {
         if (version_compare(phpversion(), '5.4', '>=')) {
             $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
@@ -228,7 +212,7 @@ class HtmlEntitiesTest extends TestCase
     /**
      * @group Laminas-11344
      */
-    public function testStripsUnknownCharactersWhenEncodingMismatchDetected()
+    public function testStripsUnknownCharactersWhenEncodingMismatchDetected(): void
     {
         if (version_compare(phpversion(), '5.4', '>=')) {
             $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
@@ -248,7 +232,7 @@ class HtmlEntitiesTest extends TestCase
     /**
      * @group Laminas-11344
      */
-    public function testRaisesExceptionIfEncodingMismatchDetectedAndFinalStringIsEmpty()
+    public function testRaisesExceptionIfEncodingMismatchDetectedAndFinalStringIsEmpty(): void
     {
         if (version_compare(phpversion(), '5.4', '>=')) {
             $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
@@ -284,11 +268,10 @@ class HtmlEntitiesTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
-        $this->assertEquals($input, $this->_filter->filter($input));
+        $this->assertSame($input, $this->_filter->filter($input));
     }
 
     /**

--- a/test/InflectorTest.php
+++ b/test/InflectorTest.php
@@ -42,13 +42,13 @@ class InflectorTest extends TestCase
         $this->broker    = $this->inflector->getPluginManager();
     }
 
-    public function testGetPluginManagerReturnsFilterManagerByDefault()
+    public function testGetPluginManagerReturnsFilterManagerByDefault(): void
     {
         $broker = $this->inflector->getPluginManager();
         $this->assertInstanceOf(FilterPluginManager::class, $broker);
     }
 
-    public function testSetPluginManagerAllowsSettingAlternatePluginManager()
+    public function testSetPluginManagerAllowsSettingAlternatePluginManager(): void
     {
         $defaultManager = $this->inflector->getPluginManager();
         $manager        = new FilterPluginManager(new ServiceManager());
@@ -58,138 +58,144 @@ class InflectorTest extends TestCase
         $this->assertSame($manager, $receivedManager);
     }
 
-    public function testTargetAccessorsWork()
+    public function testTargetAccessorsWork(): void
     {
         $this->inflector->setTarget('foo/:bar/:baz');
-        $this->assertEquals('foo/:bar/:baz', $this->inflector->getTarget());
+        $this->assertSame('foo/:bar/:baz', $this->inflector->getTarget());
     }
 
-    public function testTargetInitiallyNull()
+    public function testTargetInitiallyNull(): void
     {
         $this->assertNull($this->inflector->getTarget());
     }
 
-    public function testPassingTargetToConstructorSetsTarget()
+    public function testPassingTargetToConstructorSetsTarget(): void
     {
         $inflector = new InflectorFilter('foo/:bar/:baz');
-        $this->assertEquals('foo/:bar/:baz', $inflector->getTarget());
+        $this->assertSame('foo/:bar/:baz', $inflector->getTarget());
     }
 
-    public function testSetTargetByReferenceWorks()
+    public function testSetTargetByReferenceWorks(): void
     {
         $target = 'foo/:bar/:baz';
         $this->inflector->setTargetReference($target);
-        $this->assertEquals('foo/:bar/:baz', $this->inflector->getTarget());
+        $this->assertSame('foo/:bar/:baz', $this->inflector->getTarget());
         $target .= '/:bat';
-        $this->assertEquals('foo/:bar/:baz/:bat', $this->inflector->getTarget());
+        $this->assertSame('foo/:bar/:baz/:bat', $this->inflector->getTarget());
     }
 
-    public function testSetFilterRuleWithStringRuleCreatesRuleEntryAndFilterObject()
+    public function testSetFilterRuleWithStringRuleCreatesRuleEntryAndFilterObject(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $this->inflector->setFilterRule('controller', PregReplace::class);
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(1, count($rules));
+        $this->assertSame(1, count($rules));
         $filter = $rules[0];
         $this->assertInstanceOf(FilterInterface::class, $filter);
     }
 
-    public function testSetFilterRuleWithFilterObjectCreatesRuleEntryWithFilterObject()
+    public function testSetFilterRuleWithFilterObjectCreatesRuleEntryWithFilterObject(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $filter = new PregReplace();
         $this->inflector->setFilterRule('controller', $filter);
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(1, count($rules));
+        $this->assertSame(1, count($rules));
         $received = $rules[0];
         $this->assertInstanceOf(FilterInterface::class, $received);
         $this->assertSame($filter, $received);
     }
 
-    public function testAddFilterRuleAppendsRuleEntries()
+    public function testAddFilterRuleAppendsRuleEntries(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $this->inflector->setFilterRule('controller', [PregReplace::class, TestAsset\Alpha::class]);
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(2, count($rules));
+        $this->assertSame(2, count($rules));
         $this->assertInstanceOf(FilterInterface::class, $rules[0]);
         $this->assertInstanceOf(FilterInterface::class, $rules[1]);
     }
 
-    public function testSetStaticRuleCreatesScalarRuleEntry()
+    public function testSetStaticRuleCreatesScalarRuleEntry(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $this->inflector->setStaticRule('controller', 'foobar');
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals('foobar', $rules);
+        /** @psalm-suppress DocblockTypeContradiction */
+        $this->assertSame('foobar', $rules);
     }
 
-    public function testSetStaticRuleMultipleTimesOverwritesEntry()
+    public function testSetStaticRuleMultipleTimesOverwritesEntry(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $this->inflector->setStaticRule('controller', 'foobar');
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals('foobar', $rules);
+        /** @psalm-suppress DocblockTypeContradiction */
+        $this->assertSame('foobar', $rules);
         $this->inflector->setStaticRule('controller', 'bazbat');
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals('bazbat', $rules);
+        /** @psalm-suppress DocblockTypeContradiction */
+        $this->assertSame('bazbat', $rules);
     }
 
-    public function testSetStaticRuleReferenceAllowsUpdatingRuleByReference()
+    public function testSetStaticRuleReferenceAllowsUpdatingRuleByReference(): void
     {
         $rule  = 'foobar';
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $this->inflector->setStaticRuleReference('controller', $rule);
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals('foobar', $rules);
+        /** @psalm-suppress DocblockTypeContradiction */
+        $this->assertSame('foobar', $rules);
         $rule .= '/baz';
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals('foobar/baz', $rules);
+        /** @psalm-suppress DocblockTypeContradiction */
+        $this->assertSame('foobar/baz', $rules);
     }
 
-    public function testAddRulesCreatesAppropriateRuleEntries()
+    public function testAddRulesCreatesAppropriateRuleEntries(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $this->inflector->addRules([
             ':controller' => [PregReplace::class, TestAsset\Alpha::class],
             'suffix'      => 'phtml',
         ]);
         $rules = $this->inflector->getRules();
-        $this->assertEquals(2, count($rules));
-        $this->assertEquals(2, count($rules['controller']));
-        $this->assertEquals('phtml', $rules['suffix']);
+        $this->assertSame(2, count($rules));
+        $this->assertSame(2, count($rules['controller']));
+        $this->assertSame('phtml', $rules['suffix']);
     }
 
-    public function testSetRulesCreatesAppropriateRuleEntries()
+    public function testSetRulesCreatesAppropriateRuleEntries(): void
     {
         $this->inflector->setStaticRule('some-rules', 'some-value');
         $rules = $this->inflector->getRules();
-        $this->assertEquals(1, count($rules));
+        $this->assertSame(1, count($rules));
         $this->inflector->setRules([
             ':controller' => [PregReplace::class, TestAsset\Alpha::class],
             'suffix'      => 'phtml',
         ]);
         $rules = $this->inflector->getRules();
-        $this->assertEquals(2, count($rules));
-        $this->assertEquals(2, count($rules['controller']));
-        $this->assertEquals('phtml', $rules['suffix']);
+        $this->assertSame(2, count($rules));
+        $this->assertSame(2, count($rules['controller']));
+        /** @psalm-suppress PossiblyInvalidArrayAccess */
+        $this->assertSame('phtml', $rules['suffix']);
     }
 
-    public function testGetRule()
+    public function testGetRule(): void
     {
         $this->inflector->setFilterRule(':controller', [TestAsset\Alpha::class, StringToLower::class]);
         $this->assertInstanceOf(StringToLower::class, $this->inflector->getRule('controller', 1));
         $this->assertFalse($this->inflector->getRule('controller', 2));
     }
 
-    public function testFilterTransformsStringAccordingToRules()
+    public function testFilterTransformsStringAccordingToRules(): void
     {
         $this->inflector
             ->setTarget(':controller/:action.:suffix')
@@ -204,17 +210,17 @@ class InflectorTest extends TestCase
             'controller' => 'FooBar',
             'action'     => 'bazBat',
         ]);
-        $this->assertEquals('Foo-Bar/baz-Bat.phtml', $filtered);
+        $this->assertSame('Foo-Bar/baz-Bat.phtml', $filtered);
     }
 
-    public function testTargetReplacementIdentiferAccessorsWork()
+    public function testTargetReplacementIdentiferAccessorsWork(): void
     {
-        $this->assertEquals(':', $this->inflector->getTargetReplacementIdentifier());
+        $this->assertSame(':', $this->inflector->getTargetReplacementIdentifier());
         $this->inflector->setTargetReplacementIdentifier('?=');
-        $this->assertEquals('?=', $this->inflector->getTargetReplacementIdentifier());
+        $this->assertSame('?=', $this->inflector->getTargetReplacementIdentifier());
     }
 
-    public function testTargetReplacementIdentiferWorksWhenInflected()
+    public function testTargetReplacementIdentiferWorksWhenInflected(): void
     {
         $inflector = new InflectorFilter(
             '?=##controller/?=##action.?=##suffix',
@@ -232,24 +238,24 @@ class InflectorTest extends TestCase
             'action'     => 'bazBat',
         ]);
 
-        $this->assertEquals('Foo-Bar/baz-Bat.phtml', $filtered);
+        $this->assertSame('Foo-Bar/baz-Bat.phtml', $filtered);
     }
 
-    public function testThrowTargetExceptionsAccessorsWork()
+    public function testThrowTargetExceptionsAccessorsWork(): void
     {
-        $this->assertEquals(':', $this->inflector->getTargetReplacementIdentifier());
+        $this->assertSame(':', $this->inflector->getTargetReplacementIdentifier());
         $this->inflector->setTargetReplacementIdentifier('?=');
-        $this->assertEquals('?=', $this->inflector->getTargetReplacementIdentifier());
+        $this->assertSame('?=', $this->inflector->getTargetReplacementIdentifier());
     }
 
-    public function testThrowTargetExceptionsOnAccessorsWork()
+    public function testThrowTargetExceptionsOnAccessorsWork(): void
     {
         $this->assertTrue($this->inflector->isThrowTargetExceptionsOn());
         $this->inflector->setThrowTargetExceptionsOn(false);
         $this->assertFalse($this->inflector->isThrowTargetExceptionsOn());
     }
 
-    public function testTargetExceptionThrownWhenTargetSourceNotSatisfied()
+    public function testTargetExceptionThrownWhenTargetSourceNotSatisfied(): void
     {
         $inflector = new InflectorFilter(
             '?=##controller/?=##action.?=##suffix',
@@ -267,7 +273,7 @@ class InflectorTest extends TestCase
         $filtered = $inflector(['controller' => 'FooBar']);
     }
 
-    public function testTargetExceptionNotThrownOnIdentifierNotFollowedByCharacter()
+    public function testTargetExceptionNotThrownOnIdentifierNotFollowedByCharacter(): void
     {
         $inflector = new InflectorFilter(
             'e:\path\to\:controller\:action.:suffix',
@@ -281,10 +287,13 @@ class InflectorTest extends TestCase
         );
 
         $filtered = $inflector(['controller' => 'FooBar', 'action' => 'MooToo']);
-        $this->assertEquals($filtered, 'e:\path\to\foo-bar\Moo-Too.phtml');
+        $this->assertSame($filtered, 'e:\path\to\foo-bar\Moo-Too.phtml');
     }
 
-    public function getOptions()
+    /**
+     * @return array<string, mixed>
+     */
+    public function getOptions(): array
     {
         return [
             'target'                      => '$controller/$action.$suffix',
@@ -324,25 +333,28 @@ class InflectorTest extends TestCase
         // @codingStandardsIgnoreEnd
         $options = $this->getOptions();
         $broker  = $inflector->getPluginManager();
-        $this->assertEquals($options['target'], $inflector->getTarget());
+        $this->assertSame($options['target'], $inflector->getTarget());
 
         $this->assertInstanceOf(FilterPluginManager::class, $broker);
         $this->assertTrue($inflector->isThrowTargetExceptionsOn());
-        $this->assertEquals($options['targetReplacementIdentifier'], $inflector->getTargetReplacementIdentifier());
+        $this->assertSame($options['targetReplacementIdentifier'], $inflector->getTargetReplacementIdentifier());
 
         $rules = $inflector->getRules();
+        /** @psalm-suppress MixedArrayAccess */
         foreach (array_values($options['rules'][':controller']) as $key => $rule) {
             $class = get_class($rules['controller'][$key]);
             $this->assertStringContainsString($rule, $class);
         }
+        /** @psalm-suppress MixedArrayAccess */
         foreach (array_values($options['rules'][':action']) as $key => $rule) {
             $class = get_class($rules['action'][$key]);
             $this->assertStringContainsString($rule, $class);
         }
-        $this->assertEquals($options['rules']['suffix'], $rules['suffix']);
+        /** @psalm-suppress MixedArrayAccess */
+        $this->assertSame($options['rules']['suffix'], $rules['suffix']);
     }
 
-    public function testSetConfigSetsStateAndRules()
+    public function testSetConfigSetsStateAndRules(): void
     {
         $config    = $this->getConfig();
         $inflector = new InflectorFilter();
@@ -355,7 +367,7 @@ class InflectorTest extends TestCase
      *
      * @issue Laminas-2538 Laminas_Filter_Inflector::filter() fails with all numeric folder on Windows
      */
-    public function testCheckInflectorWithPregBackreferenceLikeParts()
+    public function testCheckInflectorWithPregBackreferenceLikeParts(): void
     {
         $inflector = new InflectorFilter(
             ':moduleDir' . DIRECTORY_SEPARATOR . ':controller' . DIRECTORY_SEPARATOR . ':action.:suffix',
@@ -374,7 +386,7 @@ class InflectorTest extends TestCase
             'controller' => 'FooBar',
             'action'     => 'MooToo',
         ]);
-        $this->assertEquals(
+        $this->assertSame(
             $filtered,
             'C:\htdocs\public\cache\00\01\42\app\modules'
             . DIRECTORY_SEPARATOR
@@ -387,11 +399,11 @@ class InflectorTest extends TestCase
     /**
      * @issue Laminas-2522
      */
-    public function testTestForFalseInConstructorParams()
+    public function testTestForFalseInConstructorParams(): void
     {
         $inflector = new InflectorFilter('something', [], false, false);
         $this->assertFalse($inflector->isThrowTargetExceptionsOn());
-        $this->assertEquals($inflector->getTargetReplacementIdentifier(), ':');
+        $this->assertSame($inflector->getTargetReplacementIdentifier(), ':');
 
         $inflector = new InflectorFilter('something', [], false, '#');
     }
@@ -399,37 +411,39 @@ class InflectorTest extends TestCase
     /**
      * @issue Laminas-2964
      */
-    public function testNoInflectableTarget()
+    public function testNoInflectableTarget(): void
     {
         $inflector = new InflectorFilter('abc');
         $inflector->addRules([':foo' => []]);
-        $this->assertEquals($inflector(['fo' => 'bar']), 'abc');
+        $this->assertSame($inflector(['fo' => 'bar']), 'abc');
     }
 
     /**
      * @issue Laminas-7544
      */
-    public function testAddFilterRuleMultipleTimes()
+    public function testAddFilterRuleMultipleTimes(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertEquals(0, count($rules));
+        $this->assertSame(0, count($rules));
         $this->inflector->setFilterRule('controller', PregReplace::class);
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(1, count($rules));
+        $this->assertSame(1, count($rules));
         $this->inflector->addFilterRule('controller', [TestAsset\Alpha::class, StringToLower::class]);
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(3, count($rules));
+        /** @psalm-suppress PossiblyFalseArgument */
+        $this->assertSame(3, count($rules));
         $this->_context = StringToLower::class;
         $this->inflector->setStaticRuleReference('context', $this->_context);
         $this->inflector->addFilterRule('controller', [TestAsset\Alpha::class, StringToLower::class]);
         $rules = $this->inflector->getRules('controller');
-        $this->assertEquals(5, count($rules));
+        /** @psalm-suppress PossiblyFalseArgument */
+        $this->assertSame(5, count($rules));
     }
 
     /**
      * @group Laminas-8997
      */
-    public function testPassingArrayToConstructorSetsStateAndRules()
+    public function testPassingArrayToConstructorSetsStateAndRules(): void
     {
         $options   = $this->getOptions();
         $inflector = new InflectorFilter($options);
@@ -439,7 +453,7 @@ class InflectorTest extends TestCase
     /**
      * @group Laminas-8997
      */
-    public function testPassingArrayToSetConfigSetsStateAndRules()
+    public function testPassingArrayToSetConfigSetsStateAndRules(): void
     {
         $options   = $this->getOptions();
         $inflector = new InflectorFilter();
@@ -450,7 +464,7 @@ class InflectorTest extends TestCase
     /**
      * @group Laminas-8997
      */
-    public function testPassingConfigObjectToConstructorSetsStateAndRules()
+    public function testPassingConfigObjectToConstructorSetsStateAndRules(): void
     {
         $config    = $this->getConfig();
         $inflector = new InflectorFilter($config);
@@ -460,7 +474,7 @@ class InflectorTest extends TestCase
     /**
      * @group Laminas-8997
      */
-    public function testPassingConfigObjectToSetConfigSetsStateAndRules()
+    public function testPassingConfigObjectToSetConfigSetsStateAndRules(): void
     {
         $config    = $this->getConfig();
         $inflector = new InflectorFilter();

--- a/test/IntTest.php
+++ b/test/IntTest.php
@@ -20,7 +20,7 @@ class IntTest extends TestCase
         }
     }
 
-    public function testRaisesNoticeOnInstantiation()
+    public function testRaisesNoticeOnInstantiation(): void
     {
         $this->expectException('PHPUnit_Framework_Error_Deprecated');
         new IntFilter();

--- a/test/MonthSelectTest.php
+++ b/test/MonthSelectTest.php
@@ -16,11 +16,11 @@ class MonthSelectTest extends TestCase
      * @param array|mixed|null|string $input input provided to the filter
      * @param array|mixed|null|string $expected expected output
      */
-    public function testFilter($options, $input, $expected)
+    public function testFilter($options, $input, $expected): void
     {
         $sut = new MonthSelectFilter();
         $sut->setOptions($options);
-        $this->assertEquals($expected, $sut->filter($input));
+        $this->assertSame($expected, $sut->filter($input));
     }
 
     public function provideFilter()
@@ -34,7 +34,7 @@ class MonthSelectTest extends TestCase
         ];
     }
 
-    public function testInvalidInput()
+    public function testInvalidInput(): void
     {
         $this->expectException(RuntimeException::class);
         $sut = new MonthSelectFilter();

--- a/test/NullTest.php
+++ b/test/NullTest.php
@@ -20,7 +20,7 @@ class NullTest extends TestCase
         }
     }
 
-    public function testRaisesNoticeOnInstantiation()
+    public function testRaisesNoticeOnInstantiation(): void
     {
         $this->expectException('PHPUnit_Framework_Error_Deprecated');
         new NullFilter();

--- a/test/PregReplaceTest.php
+++ b/test/PregReplaceTest.php
@@ -131,4 +131,29 @@ class PregReplaceTest extends TestCase
 
         $this->assertSame($input, $filter->filter($input));
     }
+
+    /**
+     * @return array<int|float|bool>[]
+     */
+    public function returnNonStringScalarValues(): array
+    {
+        return [
+            [1],
+            [1.0],
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider returnNonStringScalarValues
+     * @param int|float|bool $input
+     */
+    public function testShouldFilterNonStringScalarValues($input): void
+    {
+        $filter = $this->filter;
+        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+
+        $this->assertSame((string) $input, $filter($input));
+    }
 }

--- a/test/PregReplaceTest.php
+++ b/test/PregReplaceTest.php
@@ -21,52 +21,52 @@ class PregReplaceTest extends TestCase
         $this->filter = new PregReplaceFilter();
     }
 
-    public function testDetectsPcreUnicodeSupport()
+    public function testDetectsPcreUnicodeSupport(): void
     {
         $enabled = (bool) @preg_match('/\pL/u', 'a');
-        $this->assertEquals($enabled, PregReplaceFilter::hasPcreUnicodeSupport());
+        $this->assertSame($enabled, PregReplaceFilter::hasPcreUnicodeSupport());
     }
 
-    public function testPassingPatternToConstructorSetsPattern()
+    public function testPassingPatternToConstructorSetsPattern(): void
     {
         $pattern = '#^controller/(?P<action>[a-z_-]+)#';
         $filter  = new PregReplaceFilter($pattern);
-        $this->assertEquals($pattern, $filter->getPattern());
+        $this->assertSame($pattern, $filter->getPattern());
     }
 
-    public function testPassingReplacementToConstructorSetsReplacement()
+    public function testPassingReplacementToConstructorSetsReplacement(): void
     {
         $replace = 'foo/bar';
         $filter  = new PregReplaceFilter(null, $replace);
-        $this->assertEquals($replace, $filter->getReplacement());
+        $this->assertSame($replace, $filter->getReplacement());
     }
 
-    public function testPatternIsNullByDefault()
+    public function testPatternIsNullByDefault(): void
     {
         $this->assertNull($this->filter->getPattern());
     }
 
-    public function testPatternAccessorsWork()
+    public function testPatternAccessorsWork(): void
     {
         $pattern = '#^controller/(?P<action>[a-z_-]+)#';
         $this->filter->setPattern($pattern);
-        $this->assertEquals($pattern, $this->filter->getPattern());
+        $this->assertSame($pattern, $this->filter->getPattern());
     }
 
-    public function testReplacementIsEmptyByDefault()
+    public function testReplacementIsEmptyByDefault(): void
     {
         $replacement = $this->filter->getReplacement();
         $this->assertEmpty($replacement);
     }
 
-    public function testReplacementAccessorsWork()
+    public function testReplacementAccessorsWork(): void
     {
         $replacement = 'foo/bar';
         $this->filter->setReplacement($replacement);
-        $this->assertEquals($replacement, $this->filter->getReplacement());
+        $this->assertSame($replacement, $this->filter->getReplacement());
     }
 
-    public function testFilterPerformsRegexReplacement()
+    public function testFilterPerformsRegexReplacement(): void
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
@@ -74,10 +74,10 @@ class PregReplaceTest extends TestCase
         $string   = 'controller/action';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('foo/bar', $filtered);
+        $this->assertSame('foo/bar', $filtered);
     }
 
-    public function testFilterPerformsRegexReplacementWithArray()
+    public function testFilterPerformsRegexReplacementWithArray(): void
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
@@ -89,13 +89,13 @@ class PregReplaceTest extends TestCase
 
         $filtered = $filter($input);
         $this->assertNotEquals($input, $filtered);
-        $this->assertEquals([
+        $this->assertSame([
             'foo/bar',
             'This should stay the same',
         ], $filtered);
     }
 
-    public function testFilterThrowsExceptionWhenNoMatchPatternPresent()
+    public function testFilterThrowsExceptionWhenNoMatchPatternPresent(): void
     {
         $filter = $this->filter;
         $string = 'controller/action';
@@ -105,7 +105,7 @@ class PregReplaceTest extends TestCase
         $filtered = $filter($string);
     }
 
-    public function testPassingPatternWithExecModifierRaisesException()
+    public function testPassingPatternWithExecModifierRaisesException(): void
     {
         $filter = new PregReplaceFilter();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -123,13 +123,12 @@ class PregReplaceTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
 
-        $this->assertEquals($input, $filter->filter($input));
+        $this->assertSame($input, $filter->filter($input));
     }
 }

--- a/test/RealPathTest.php
+++ b/test/RealPathTest.php
@@ -42,10 +42,8 @@ class RealPathTest extends TestCase
 
     /**
      * Ensures expected behavior for existing file
-     *
-     * @return void
      */
-    public function testFileExists()
+    public function testFileExists(): void
     {
         $filter   = $this->_filter;
         $filename = 'file.1';
@@ -54,24 +52,19 @@ class RealPathTest extends TestCase
 
     /**
      * Ensures expected behavior for nonexistent file
-     *
-     * @return void
      */
-    public function testFileNonexistent()
+    public function testFileNonexistent(): void
     {
         $filter = $this->_filter;
         $path   = '/path/to/nonexistent';
         if (false !== strpos(PHP_OS, 'BSD')) {
-            $this->assertEquals($path, $filter($path));
+            $this->assertSame($path, $filter($path));
         } else {
-            $this->assertEquals(false, $filter($path));
+            $this->assertSame(false, $filter($path));
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testGetAndSetExistsParameter()
+    public function testGetAndSetExistsParameter(): void
     {
         $this->assertTrue($this->_filter->getExists());
         $this->_filter->setExists(false);
@@ -81,25 +74,22 @@ class RealPathTest extends TestCase
         $this->assertTrue($this->_filter->getExists());
     }
 
-    /**
-     * @return void
-     */
-    public function testNonExistantPath()
+    public function testNonExistantPath(): void
     {
         $filter = $this->_filter;
         $filter->setExists(false);
 
         $path = __DIR__ . DIRECTORY_SEPARATOR . '_files';
-        $this->assertEquals($path, $filter($path));
+        $this->assertSame($path, $filter($path));
 
         $path2 = __DIR__ . DIRECTORY_SEPARATOR . '_files'
                . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '_files';
-        $this->assertEquals($path, $filter($path2));
+        $this->assertSame($path, $filter($path2));
 
         $path3 = __DIR__ . DIRECTORY_SEPARATOR . '_files'
                . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '.'
                . DIRECTORY_SEPARATOR . '_files';
-        $this->assertEquals($path, $filter($path3));
+        $this->assertSame($path, $filter($path3));
     }
 
     public function returnUnfilteredDataProvider()
@@ -118,10 +108,9 @@ class RealPathTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
-        $this->assertEquals($input, $this->_filter->filter($input));
+        $this->assertSame($input, $this->_filter->filter($input));
     }
 }

--- a/test/StaticFilterTest.php
+++ b/test/StaticFilterTest.php
@@ -26,20 +26,20 @@ class StaticFilterTest extends TestCase
         StaticFilter::setPluginManager(null);
     }
 
-    public function testUsesFilterPluginManagerByDefault()
+    public function testUsesFilterPluginManagerByDefault(): void
     {
         $plugins = StaticFilter::getPluginManager();
         $this->assertInstanceOf(FilterPluginManager::class, $plugins);
     }
 
-    public function testCanSpecifyCustomPluginManager()
+    public function testCanSpecifyCustomPluginManager(): void
     {
         $plugins = new FilterPluginManager(new ServiceManager());
         StaticFilter::setPluginManager($plugins);
         $this->assertSame($plugins, StaticFilter::getPluginManager());
     }
 
-    public function testCanResetPluginManagerByPassingNull()
+    public function testCanResetPluginManagerByPassingNull(): void
     {
         $plugins = new FilterPluginManager(new ServiceManager());
         StaticFilter::setPluginManager($plugins);
@@ -55,27 +55,27 @@ class StaticFilterTest extends TestCase
      * to instantiate a named validator by its class basename
      * and it returns the result of filter() with the input.
      */
-    public function testStaticFactory()
+    public function testStaticFactory(): void
     {
         $filteredValue = StaticFilter::execute('1a2b3c4d', Digits::class);
-        $this->assertEquals('1234', $filteredValue);
+        $this->assertSame('1234', $filteredValue);
     }
 
     /**
      * Ensures that a validator with constructor arguments can be called
      * with the static method get().
      */
-    public function testStaticFactoryWithConstructorArguments()
+    public function testStaticFactoryWithConstructorArguments(): void
     {
         // Test HtmlEntities with one ctor argument.
         $filteredValue = StaticFilter::execute('"O\'Reilly"', HtmlEntities::class, ['quotestyle' => ENT_COMPAT]);
-        $this->assertEquals('&quot;O\'Reilly&quot;', $filteredValue);
+        $this->assertSame('&quot;O\'Reilly&quot;', $filteredValue);
 
         // Test HtmlEntities with a different ctor argument,
         // and make sure it gives the correct response
         // so we know it passed the arg to the ctor.
         $filteredValue = StaticFilter::execute('"O\'Reilly"', HtmlEntities::class, ['quotestyle' => ENT_QUOTES]);
-        $this->assertEquals('&quot;O&#039;Reilly&quot;', $filteredValue);
+        $this->assertSame('&quot;O&#039;Reilly&quot;', $filteredValue);
     }
 
     /**
@@ -86,13 +86,13 @@ class StaticFilterTest extends TestCase
      *
      * @group  Laminas-2724
      */
-    public function testStaticFactoryClassNotFound()
+    public function testStaticFactoryClassNotFound(): void
     {
         $this->expectException(Exception\ExceptionInterface::class);
         StaticFilter::execute('1234', 'UnknownFilter');
     }
 
-    public function testUsesDifferentConfigurationOnEachRequest()
+    public function testUsesDifferentConfigurationOnEachRequest(): void
     {
         $first  = StaticFilter::execute('foo', Callback::class, [
             'callback' => function ($value) {
@@ -105,7 +105,7 @@ class StaticFilterTest extends TestCase
             },
         ]);
         $this->assertNotSame($first, $second);
-        $this->assertEquals('FOO', $first);
-        $this->assertEquals('BAR', $second);
+        $this->assertSame('FOO', $first);
+        $this->assertSame('BAR', $second);
     }
 }

--- a/test/StringPrefixTest.php
+++ b/test/StringPrefixTest.php
@@ -23,10 +23,8 @@ class StringPrefixTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter = $this->filter;
 
@@ -36,7 +34,7 @@ class StringPrefixTest extends TestCase
         $this->assertStringStartsWith($prefix, $filter('sample'));
     }
 
-    public function testWithoutPrefix()
+    public function testWithoutPrefix(): void
     {
         $filter = $this->filter;
 
@@ -69,7 +67,7 @@ class StringPrefixTest extends TestCase
      * @dataProvider invalidPrefixesDataProvider
      * @param mixed $prefix
      */
-    public function testInvalidPrefixes($prefix)
+    public function testInvalidPrefixes($prefix): void
     {
         $filter = $this->filter;
 
@@ -80,7 +78,7 @@ class StringPrefixTest extends TestCase
         $filter('sample');
     }
 
-    public function testNonScalarInput()
+    public function testNonScalarInput(): void
     {
         $filter = $this->filter;
 

--- a/test/StringSuffixTest.php
+++ b/test/StringSuffixTest.php
@@ -23,10 +23,8 @@ class StringSuffixTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter = $this->filter;
 
@@ -36,7 +34,7 @@ class StringSuffixTest extends TestCase
         $this->assertStringEndsWith($suffix, $filter('sample'));
     }
 
-    public function testWithoutSuffix()
+    public function testWithoutSuffix(): void
     {
         $filter = $this->filter;
 
@@ -69,7 +67,7 @@ class StringSuffixTest extends TestCase
      * @dataProvider invalidSuffixesDataProvider
      * @param mixed $suffix
      */
-    public function testInvalidSuffixes($suffix)
+    public function testInvalidSuffixes($suffix): void
     {
         $filter = $this->filter;
 
@@ -80,7 +78,7 @@ class StringSuffixTest extends TestCase
         $filter('sample');
     }
 
-    public function testNonScalarInput()
+    public function testNonScalarInput(): void
     {
         $filter = $this->filter;
 

--- a/test/StringToLowerTest.php
+++ b/test/StringToLowerTest.php
@@ -33,10 +33,8 @@ class StringToLowerTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -46,17 +44,15 @@ class StringToLowerTest extends TestCase
         ];
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
     /**
      * Ensures that the filter follows expected behavior with
      * specified encoding
-     *
-     * @return void
      */
-    public function testWithEncoding()
+    public function testWithEncoding(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -68,17 +64,14 @@ class StringToLowerTest extends TestCase
         try {
             $filter->setEncoding('UTF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testFalseEncoding()
+    public function testFalseEncoding(): void
     {
         if (! function_exists('mb_strtolower')) {
             $this->markTestSkipped('mbstring required');
@@ -92,7 +85,7 @@ class StringToLowerTest extends TestCase
     /**
      * @Laminas-8989
      */
-    public function testInitiationWithEncoding()
+    public function testInitiationWithEncoding(): void
     {
         $valuesExpected = [
             'Ü'     => 'ü',
@@ -103,7 +96,7 @@ class StringToLowerTest extends TestCase
         try {
             $filter = new StringToLowerFilter(['encoding' => 'UTF-8']);
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
@@ -113,7 +106,7 @@ class StringToLowerTest extends TestCase
     /**
      * @Laminas-9058
      */
-    public function testCaseInsensitiveEncoding()
+    public function testCaseInsensitiveEncoding(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -125,17 +118,17 @@ class StringToLowerTest extends TestCase
         try {
             $filter->setEncoding('UTF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
 
             $this->_filter->setEncoding('utf-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
 
             $this->_filter->setEncoding('UtF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
@@ -145,13 +138,13 @@ class StringToLowerTest extends TestCase
     /**
      * @group Laminas-9854
      */
-    public function testDetectMbInternalEncoding()
+    public function testDetectMbInternalEncoding(): void
     {
         if (! function_exists('mb_internal_encoding')) {
             $this->markTestSkipped("Function 'mb_internal_encoding' not available");
         }
 
-        $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
+        $this->assertSame(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
     public function returnUnfilteredDataProvider()
@@ -170,17 +163,16 @@ class StringToLowerTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
-        $this->assertEquals($input, $this->_filter->filter($input));
+        $this->assertSame($input, $this->_filter->filter($input));
     }
 
     /**
      * @group 7147
      */
-    public function testFilterUsesGetEncodingMethod()
+    public function testFilterUsesGetEncodingMethod(): void
     {
         $filterMock = $this->getMockBuilder(StringToLowerFilter::class)
             ->setMethods(['getEncoding'])

--- a/test/StringToUpperTest.php
+++ b/test/StringToUpperTest.php
@@ -33,10 +33,8 @@ class StringToUpperTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -46,17 +44,15 @@ class StringToUpperTest extends TestCase
         ];
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
     /**
      * Ensures that the filter follows expected behavior with
      * specified encoding
-     *
-     * @return void
      */
-    public function testWithEncoding()
+    public function testWithEncoding(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -68,17 +64,14 @@ class StringToUpperTest extends TestCase
         try {
             $filter->setEncoding('UTF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testFalseEncoding()
+    public function testFalseEncoding(): void
     {
         if (! function_exists('mb_strtolower')) {
             $this->markTestSkipped('mbstring required');
@@ -92,7 +85,7 @@ class StringToUpperTest extends TestCase
     /**
      * @Laminas-8989
      */
-    public function testInitiationWithEncoding()
+    public function testInitiationWithEncoding(): void
     {
         $valuesExpected = [
             'ü'     => 'Ü',
@@ -103,7 +96,7 @@ class StringToUpperTest extends TestCase
         try {
             $filter = new StringToUpperFilter(['encoding' => 'UTF-8']);
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
@@ -113,7 +106,7 @@ class StringToUpperTest extends TestCase
     /**
      *  @Laminas-9058
      */
-    public function testCaseInsensitiveEncoding()
+    public function testCaseInsensitiveEncoding(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -125,17 +118,17 @@ class StringToUpperTest extends TestCase
         try {
             $filter->setEncoding('UTF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
 
             $this->_filter->setEncoding('utf-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
 
             $this->_filter->setEncoding('UtF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
@@ -145,13 +138,13 @@ class StringToUpperTest extends TestCase
     /**
      * @group Laminas-9854
      */
-    public function testDetectMbInternalEncoding()
+    public function testDetectMbInternalEncoding(): void
     {
         if (! function_exists('mb_internal_encoding')) {
             $this->markTestSkipped("Function 'mb_internal_encoding' not available");
         }
 
-        $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
+        $this->assertSame(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
     public function returnUnfilteredDataProvider()
@@ -170,17 +163,16 @@ class StringToUpperTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
-        $this->assertEquals($input, $this->_filter->filter($input));
+        $this->assertSame($input, $this->_filter->filter($input));
     }
 
     /**
      * @group 7147
      */
-    public function testFilterUsesGetEncodingMethod()
+    public function testFilterUsesGetEncodingMethod(): void
     {
         $filterMock = $this->getMockBuilder(StringToUpperFilter::class)
             ->setMethods(['getEncoding'])

--- a/test/StringTrimTest.php
+++ b/test/StringTrimTest.php
@@ -25,10 +25,8 @@ class StringTrimTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter         = $this->filter;
         $valuesExpected = [
@@ -37,7 +35,7 @@ class StringTrimTest extends TestCase
             "\ns\t"  => 's',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
@@ -48,40 +46,34 @@ class StringTrimTest extends TestCase
      */
     public function testUtf8()
     {
-        $this->assertEquals('a', $this->filter->filter(utf8_encode("\xa0a\xa0")));
+        $this->assertSame('a', $this->filter->filter(utf8_encode("\xa0a\xa0")));
     }
 
     /**
      * Ensures that getCharList() returns expected default value
-     *
-     * @return void
      */
-    public function testGetCharList()
+    public function testGetCharList(): void
     {
-        $this->assertEquals(null, $this->filter->getCharList());
+        $this->assertSame(null, $this->filter->getCharList());
     }
 
     /**
      * Ensures that setCharList() follows expected behavior
-     *
-     * @return void
      */
-    public function testSetCharList()
+    public function testSetCharList(): void
     {
         $this->filter->setCharList('&');
-        $this->assertEquals('&', $this->filter->getCharList());
+        $this->assertSame('&', $this->filter->getCharList());
     }
 
     /**
      * Ensures expected behavior under custom character list
-     *
-     * @return void
      */
-    public function testCharList()
+    public function testCharList(): void
     {
         $filter = $this->filter;
         $filter->setCharList('&');
-        $this->assertEquals('a&b', $filter('&&a&b&&'));
+        $this->assertSame('a&b', $filter('&&a&b&&'));
     }
 
     /**
@@ -90,7 +82,7 @@ class StringTrimTest extends TestCase
     public function testLaminas7183()
     {
         $filter = $this->filter;
-        $this->assertEquals('Зенд', $filter('Зенд'));
+        $this->assertSame('Зенд', $filter('Зенд'));
     }
 
     /**
@@ -99,7 +91,7 @@ class StringTrimTest extends TestCase
     public function testLaminas170()
     {
         $filter = $this->filter;
-        $this->assertEquals('Расчет', $filter('Расчет'));
+        $this->assertSame('Расчет', $filter('Расчет'));
     }
 
     /**
@@ -108,7 +100,7 @@ class StringTrimTest extends TestCase
     public function testLaminas7902()
     {
         $filter = $this->filter;
-        $this->assertEquals('/', $filter('/'));
+        $this->assertSame('/', $filter('/'));
     }
 
     /**
@@ -117,13 +109,13 @@ class StringTrimTest extends TestCase
     public function testLaminas10891()
     {
         $filter = $this->filter;
-        $this->assertEquals('Зенд', $filter('   Зенд   '));
-        $this->assertEquals('Зенд', $filter('Зенд   '));
-        $this->assertEquals('Зенд', $filter('   Зенд'));
+        $this->assertSame('Зенд', $filter('   Зенд   '));
+        $this->assertSame('Зенд', $filter('Зенд   '));
+        $this->assertSame('Зенд', $filter('   Зенд'));
 
         $trimCharlist = " \t\n\r\x0B・。";
         $filter       = new StringTrim($trimCharlist);
-        $this->assertEquals('Зенд', $filter->filter('。  Зенд  。'));
+        $this->assertSame('Зенд', $filter->filter('。  Зенд  。'));
     }
 
     public function getNonStringValues()
@@ -142,7 +134,7 @@ class StringTrimTest extends TestCase
     /**
      * @dataProvider getNonStringValues
      */
-    public function testShouldNotFilterNonStringValues($value)
+    public function testShouldNotFilterNonStringValues($value): void
     {
         $filtered = $this->filter->filter($value);
         $this->assertSame($value, $filtered);
@@ -153,13 +145,13 @@ class StringTrimTest extends TestCase
      *
      * @group 6261
      */
-    public function testEmptyCharList()
+    public function testEmptyCharList(): void
     {
         $filter = $this->filter;
         $filter->setCharList('0');
-        $this->assertEquals('a0b', $filter('00a0b00'));
+        $this->assertSame('a0b', $filter('00a0b00'));
 
         $filter->setCharList('');
-        $this->assertEquals('str', $filter(' str '));
+        $this->assertSame('str', $filter(' str '));
     }
 }

--- a/test/StripNewlinesTest.php
+++ b/test/StripNewlinesTest.php
@@ -15,10 +15,8 @@ class StripNewlinesTest extends TestCase
 {
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter         = new StripNewlinesFilter();
         $valuesExpected = [
@@ -32,21 +30,18 @@ class StripNewlinesTest extends TestCase
             "Some text\nthat we have\r\nstuff in" => 'Some textthat we havestuff in',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testArrayValues()
+    public function testArrayValues(): void
     {
         $filter   = new StripNewlinesFilter();
         $expected = [
             "Some text\nthat we have\r\nstuff in" => 'Some textthat we havestuff in',
             "Some text\n"                         => 'Some text',
         ];
-        $this->assertEquals(array_values($expected), $filter(array_keys($expected)));
+        $this->assertSame(array_values($expected), $filter(array_keys($expected)));
     }
 
     public function returnUnfilteredDataProvider()
@@ -59,12 +54,11 @@ class StripNewlinesTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new StripNewlinesFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/StripNewlinesTest.php
+++ b/test/StripNewlinesTest.php
@@ -61,4 +61,28 @@ class StripNewlinesTest extends TestCase
 
         $this->assertSame($input, $filter($input));
     }
+
+    /**
+     * @return array<int|float|bool>[]
+     */
+    public function returnNonStringScalarValues(): array
+    {
+        return [
+            [1],
+            [1.0],
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider returnNonStringScalarValues
+     * @param int|float|bool $input
+     */
+    public function testShouldFilterNonStringScalarValues($input): void
+    {
+        $filter = new StripNewlinesFilter();
+
+        $this->assertSame((string) $input, $filter($input));
+    }
 }

--- a/test/StripTagsTest.php
+++ b/test/StripTagsTest.php
@@ -31,31 +31,25 @@ class StripTagsTest extends TestCase
 
     /**
      * Ensures that getTagsAllowed() returns expected default value
-     *
-     * @return void
      */
-    public function testGetTagsAllowed()
+    public function testGetTagsAllowed(): void
     {
-        $this->assertEquals([], $this->_filter->getTagsAllowed());
+        $this->assertSame([], $this->_filter->getTagsAllowed());
     }
 
     /**
      * Ensures that setTagsAllowed() follows expected behavior when provided a single tag
-     *
-     * @return void
      */
-    public function testSetTagsAllowedString()
+    public function testSetTagsAllowedString(): void
     {
         $this->_filter->setTagsAllowed('b');
-        $this->assertEquals(['b' => []], $this->_filter->getTagsAllowed());
+        $this->assertSame(['b' => []], $this->_filter->getTagsAllowed());
     }
 
     /**
      * Ensures that setTagsAllowed() follows expected behavior when provided an array of tags
-     *
-     * @return void
      */
-    public function testSetTagsAllowedArray()
+    public function testSetTagsAllowedArray(): void
     {
         $tagsAllowed = [
             'b',
@@ -68,36 +62,30 @@ class StripTagsTest extends TestCase
             'a'   => ['href' => null],
             'div' => ['id' => null, 'class' => null],
         ];
-        $this->assertEquals($tagsAllowedExpected, $this->_filter->getTagsAllowed());
+        $this->assertSame($tagsAllowedExpected, $this->_filter->getTagsAllowed());
     }
 
     /**
      * Ensures that getAttributesAllowed() returns expected default value
-     *
-     * @return void
      */
-    public function testGetAttributesAllowed()
+    public function testGetAttributesAllowed(): void
     {
-        $this->assertEquals([], $this->_filter->getAttributesAllowed());
+        $this->assertSame([], $this->_filter->getAttributesAllowed());
     }
 
     /**
      * Ensures that setAttributesAllowed() follows expected behavior when provided a single attribute
-     *
-     * @return void
      */
-    public function testSetAttributesAllowedString()
+    public function testSetAttributesAllowedString(): void
     {
         $this->_filter->setAttributesAllowed('class');
-        $this->assertEquals(['class' => null], $this->_filter->getAttributesAllowed());
+        $this->assertSame(['class' => null], $this->_filter->getAttributesAllowed());
     }
 
     /**
      * Ensures that setAttributesAllowed() follows expected behavior when provided an array of attributes
-     *
-     * @return void
      */
-    public function testSetAttributesAllowedArray()
+    public function testSetAttributesAllowedArray(): void
     {
         $attributesAllowed = [
             'clAss',
@@ -111,7 +99,7 @@ class StripTagsTest extends TestCase
             'int'    => null,
             'string' => null,
         ];
-        $this->assertEquals($attributesAllowedExpected, $this->_filter->getAttributesAllowed());
+        $this->assertSame($attributesAllowedExpected, $this->_filter->getAttributesAllowed());
     }
 
     /**
@@ -124,7 +112,7 @@ class StripTagsTest extends TestCase
         $filter   = $this->_filter;
         $input    = '<a href="http://example.com" Some Text';
         $expected = '';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
@@ -137,7 +125,7 @@ class StripTagsTest extends TestCase
         $filter   = $this->_filter;
         $input    = '<a href="example.com">foo</a>';
         $expected = 'foo';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
@@ -150,7 +138,7 @@ class StripTagsTest extends TestCase
         $filter   = $this->_filter;
         $input    = '<a href="example.com"><b>foo</b></a>';
         $expected = 'foo';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
@@ -163,83 +151,71 @@ class StripTagsTest extends TestCase
         $filter   = $this->_filter;
         $input    = '<a href="example.com">foo</a><b>bar</b>';
         $expected = 'foobar';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that an allowed tag is returned as lowercase and with backward-compatible XHTML ending, where supplied
-     *
-     * @return void
      */
-    public function testFilterTagAllowedBackwardCompatible()
+    public function testFilterTagAllowedBackwardCompatible(): void
     {
         $filter   = $this->_filter;
         $input    = '<BR><Br><bR><br/><br  /><br / ></br></bR>';
         $expected = '<br><br><br><br /><br /><br></br></br>';
         $this->_filter->setTagsAllowed('br');
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that any greater-than symbols '>' are removed from text preceding a tag
-     *
-     * @return void
      */
-    public function testFilterTagPrefixGt()
+    public function testFilterTagPrefixGt(): void
     {
         $filter   = $this->_filter;
         $input    = '2 > 1 === true<br/>';
         $expected = '2  1 === true';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that any greater-than symbols '>' are removed from text having no tags
-     *
-     * @return void
      */
-    public function testFilterGt()
+    public function testFilterGt(): void
     {
         $filter   = $this->_filter;
         $input    = '2 > 1 === true ==> $object->property';
         $expected = '2  1 === true == $object-property';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that any greater-than symbols '>' are removed from text wrapping a tag
-     *
-     * @return void
      */
-    public function testFilterTagWrappedGt()
+    public function testFilterTagWrappedGt(): void
     {
         $filter   = $this->_filter;
         $input    = '2 > 1 === true <==> $object->property';
         $expected = '2  1 === true  $object-property';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that an attribute for an allowed tag is stripped
-     *
-     * @return void
      */
-    public function testFilterTagAllowedAttribute()
+    public function testFilterTagAllowedAttribute(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = 'img';
         $this->_filter->setTagsAllowed($tagsAllowed);
         $input    = '<IMG alt="foo" />';
         $expected = '<img />';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that an allowed tag with an allowed attribute is filtered as expected
-     *
-     * @return void
      */
-    public function testFilterTagAllowedAttributeAllowed()
+    public function testFilterTagAllowedAttributeAllowed(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = [
@@ -248,17 +224,15 @@ class StripTagsTest extends TestCase
         $this->_filter->setTagsAllowed($tagsAllowed);
         $input    = '<IMG ALT="FOO" />';
         $expected = '<img alt="FOO" />';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures expected behavior when a greater-than symbol '>' appears in an allowed attribute's value
      *
      * Currently this is not unsupported; these symbols should be escaped when used in an attribute value.
-     *
-     * @return void
      */
-    public function testFilterTagAllowedAttributeAllowedGt()
+    public function testFilterTagAllowedAttributeAllowedGt(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = [
@@ -267,15 +241,13 @@ class StripTagsTest extends TestCase
         $this->_filter->setTagsAllowed($tagsAllowed);
         $input    = '<img alt="$object->property" />';
         $expected = '<img>property" /';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures expected behavior when an escaped greater-than symbol '>' appears in an allowed attribute's value
-     *
-     * @return void
      */
-    public function testFilterTagAllowedAttributeAllowedGtEscaped()
+    public function testFilterTagAllowedAttributeAllowedGtEscaped(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = [
@@ -284,16 +256,14 @@ class StripTagsTest extends TestCase
         $this->_filter->setTagsAllowed($tagsAllowed);
         $input    = '<img alt="$object-&gt;property" />';
         $expected = '<img alt="$object-&gt;property" />';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that an unterminated attribute value does not affect other attributes but causes the corresponding
      * attribute to be removed in its entirety.
-     *
-     * @return void
      */
-    public function testFilterTagAllowedAttributeAllowedValueUnclosed()
+    public function testFilterTagAllowedAttributeAllowedValueUnclosed(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = [
@@ -302,15 +272,13 @@ class StripTagsTest extends TestCase
         $this->_filter->setTagsAllowed($tagsAllowed);
         $input    = '<img src="image.png" alt="square height="100" width="100" />';
         $expected = '<img src="image.png" alt="square height=" width="100" />';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that an allowed attribute having no value is removed (XHTML disallows attributes with no values)
-     *
-     * @return void
      */
-    public function testFilterTagAllowedAttributeAllowedValueMissing()
+    public function testFilterTagAllowedAttributeAllowedValueMissing(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = [
@@ -319,7 +287,7 @@ class StripTagsTest extends TestCase
         $this->_filter->setTagsAllowed($tagsAllowed);
         $input    = '<input name="foo" type="checkbox" checked />';
         $expected = '<input name="foo" type="checkbox" />';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
@@ -346,43 +314,37 @@ class StripTagsTest extends TestCase
                . '</param><param name="wmode" value="transparent"></param><embed '
                . 'src="http://www.example.com/path/to/movie" type="application/x-shockwave-flash" '
                . 'wmode="transparent" width="425" height="350"></embed></object>';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that a comment is stripped
-     *
-     * @return void
      */
-    public function testFilterComment()
+    public function testFilterComment(): void
     {
         $filter   = $this->_filter;
         $input    = '<!-- a comment -->';
         $expected = '';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that a comment wrapped with other strings is stripped
-     *
-     * @return void
      */
-    public function testFilterCommentWrapped()
+    public function testFilterCommentWrapped(): void
     {
         $filter   = $this->_filter;
         $input    = 'foo<!-- a comment -->bar';
         $expected = 'foobar';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that a closing angle bracket in an allowed attribute does not break the parser
      *
      * @link   https://getlaminas.org/issues/browse/Laminas-3278
-     *
-     * @return void
      */
-    public function testClosingAngleBracketInAllowedAttributeValue()
+    public function testClosingAngleBracketInAllowedAttributeValue(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = [
@@ -391,7 +353,7 @@ class StripTagsTest extends TestCase
         $filter->setTagsAllowed($tagsAllowed);
         $input    = '<a href="Some &gt; Text">';
         $expected = '<a href="Some &gt; Text">';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
@@ -400,7 +362,7 @@ class StripTagsTest extends TestCase
      * @group Laminas-3293
      * @group Laminas-5983
      */
-    public function testAllowedAttributeValueMayEndWithEquals()
+    public function testAllowedAttributeValueMayEndWithEquals(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = [
@@ -408,13 +370,13 @@ class StripTagsTest extends TestCase
         ];
         $filter->setTagsAllowed($tagsAllowed);
         $input = '<element attribute="a=">contents</element>';
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 
     /**
      * @group Laminas-5983
      */
-    public function testDisallowedAttributesSplitOverMultipleLinesShouldBeStripped()
+    public function testDisallowedAttributesSplitOverMultipleLinesShouldBeStripped(): void
     {
         $filter      = $this->_filter;
         $tagsAllowed = ['a' => 'href'];
@@ -429,12 +391,12 @@ class StripTagsTest extends TestCase
     /**
      * @Laminas-8828
      */
-    public function testFilterIsoChars()
+    public function testFilterIsoChars(): void
     {
         $filter   = $this->_filter;
         $input    = 'äöü<!-- a comment -->äöü';
         $expected = 'äöüäöü';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
 
         $input  = 'äöü<!-- a comment -->äöü';
         $input  = iconv("UTF-8", "ISO-8859-1", $input);
@@ -445,12 +407,12 @@ class StripTagsTest extends TestCase
     /**
      * @Laminas-8828
      */
-    public function testFilterIsoCharsInComment()
+    public function testFilterIsoCharsInComment(): void
     {
         $filter   = $this->_filter;
         $input    = 'äöü<!--üßüßüß-->äöü';
         $expected = 'äöüäöü';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
 
         $input  = 'äöü<!-- a comment -->äöü';
         $input  = iconv("UTF-8", "ISO-8859-1", $input);
@@ -461,41 +423,41 @@ class StripTagsTest extends TestCase
     /**
      * @Laminas-8828
      */
-    public function testFilterSplitCommentTags()
+    public function testFilterSplitCommentTags(): void
     {
         $filter   = $this->_filter;
         $input    = 'äöü<!-->üßüßüß<-->äöü';
         $expected = 'äöüäöü';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * @group Laminas-9434
      */
-    public function testCommentWithTagInSameLine()
+    public function testCommentWithTagInSameLine(): void
     {
         $filter   = $this->_filter;
         $input    = 'test <!-- testcomment --> test <div>div-content</div>';
         $expected = 'test  test div-content';
-        $this->assertEquals($expected, $filter($input));
+        $this->assertSame($expected, $filter($input));
     }
 
     /**
      * @group Laminas-9833
      */
-    public function testMultiParamArray()
+    public function testMultiParamArray(): void
     {
         $filter = new StripTagsFilter(["a", "b", "hr"], [], true);
 
         $input    = 'test <a /> test <div>div-content</div>';
         $expected = 'test <a /> test div-content';
-        $this->assertEquals($expected, $filter->filter($input));
+        $this->assertSame($expected, $filter->filter($input));
     }
 
     /**
      * @group Laminas-9828
      */
-    public function testMultiQuoteInput()
+    public function testMultiQuoteInput(): void
     {
         $filter = new StripTagsFilter(
             [
@@ -506,7 +468,7 @@ class StripTagsTest extends TestCase
 
         $input    = '<img width="10" height="10" src=\'wont_be_matched.jpg\'>';
         $expected = '<img width="10" height="10" src=\'wont_be_matched.jpg\'>';
-        $this->assertEquals($expected, $filter->filter($input));
+        $this->assertSame($expected, $filter->filter($input));
     }
 
     public function badCommentProvider()
@@ -531,25 +493,25 @@ class StripTagsTest extends TestCase
      * @param string $input
      * @param string $expected
      */
-    public function testBadCommentTags($input, $expected)
+    public function testBadCommentTags($input, $expected): void
     {
-        $this->assertEquals($expected, $this->_filter->filter($input));
+        $this->assertSame($expected, $this->_filter->filter($input));
     }
 
      /**
       * @group Laminas-10256
       */
-    public function testNotClosedHtmlCommentAtEndOfString()
+    public function testNotClosedHtmlCommentAtEndOfString(): void
     {
         $input    = 'text<!-- not closed comment at the end';
         $expected = 'text';
-        $this->assertEquals($expected, $this->_filter->filter($input));
+        $this->assertSame($expected, $this->_filter->filter($input));
     }
 
     /**
      * @group Laminas-11617
      */
-    public function testFilterCanAllowHyphenatedAttributeNames()
+    public function testFilterCanAllowHyphenatedAttributeNames(): void
     {
         $input    = '<li data-disallowed="no!" data-name="Test User" data-id="11223"></li>';
         $expected = '<li data-name="Test User" data-id="11223"></li>';
@@ -557,7 +519,7 @@ class StripTagsTest extends TestCase
         $this->_filter->setTagsAllowed('li');
         $this->_filter->setAttributesAllowed(['data-id', 'data-name']);
 
-        $this->assertEquals($expected, $this->_filter->filter($input));
+        $this->assertSame($expected, $this->_filter->filter($input));
     }
 
     public function returnUnfilteredDataProvider()
@@ -576,22 +538,21 @@ class StripTagsTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
-        $this->assertEquals($input, $this->_filter->filter($input));
+        $this->assertSame($input, $this->_filter->filter($input));
     }
 
     /**
      * @link https://github.com/zendframework/zf2/issues/5465
      */
-    public function testAttributeValueofZeroIsNotRemoved()
+    public function testAttributeValueofZeroIsNotRemoved(): void
     {
         $input    = '<div id="0" data-custom="0" class="bogus"></div>';
         $expected = '<div id="0" data-custom="0"></div>';
         $this->_filter->setTagsAllowed('div');
         $this->_filter->setAttributesAllowed(['id', 'data-custom']);
-        $this->assertEquals($expected, $this->_filter->filter($input));
+        $this->assertSame($expected, $this->_filter->filter($input));
     }
 }

--- a/test/ToFloatTest.php
+++ b/test/ToFloatTest.php
@@ -13,9 +13,9 @@ class ToFloatTest extends TestCase
     public function filterableValuesProvider()
     {
         return [
-            'string word' => ['string', 0],
-            'string 1'    => ['1', 1],
-            'string -1'   => ['-1', -1],
+            'string word' => ['string', 0.0],
+            'string 1'    => ['1', 1.0],
+            'string -1'   => ['-1', -1.0],
             'string 1.1'  => ['1.1', 1.1],
             'string -1.1' => ['-1.1', -1.1],
             'string 0.9'  => ['0.9', 0.9],
@@ -35,10 +35,10 @@ class ToFloatTest extends TestCase
      * @param mixed $input
      * @param string $expectedOutput
      */
-    public function testCanFilterScalarValuesAsExpected($input, $expectedOutput)
+    public function testCanFilterScalarValuesAsExpected($input, $expectedOutput): void
     {
         $filter = new ToFloatFilter();
-        $this->assertEquals($expectedOutput, $filter($input));
+        $this->assertSame($expectedOutput, $filter($input));
     }
 
     public function unfilterableValuesProvider()
@@ -59,9 +59,9 @@ class ToFloatTest extends TestCase
      * @dataProvider unfilterableValuesProvider
      * @param mixed $input
      */
-    public function testReturnsUnfilterableInputVerbatim($input)
+    public function testReturnsUnfilterableInputVerbatim($input): void
     {
         $filter = new ToFloatFilter();
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/ToIntTest.php
+++ b/test/ToIntTest.php
@@ -12,10 +12,8 @@ class ToIntTest extends TestCase
 {
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter = new ToIntFilter();
 
@@ -29,7 +27,7 @@ class ToIntTest extends TestCase
             '-0.9'   => 0,
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
@@ -49,12 +47,11 @@ class ToIntTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new ToIntFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/ToNullTest.php
+++ b/test/ToNullTest.php
@@ -14,20 +14,20 @@ use function var_export;
 
 class ToNullTest extends TestCase
 {
-    public function testConstructorOptions()
+    public function testConstructorOptions(): void
     {
         $filter = new ToNullFilter([
             'type' => ToNullFilter::TYPE_INTEGER,
         ]);
 
-        $this->assertEquals(ToNullFilter::TYPE_INTEGER, $filter->getType());
+        $this->assertSame(ToNullFilter::TYPE_INTEGER, $filter->getType());
     }
 
-    public function testConstructorParams()
+    public function testConstructorParams(): void
     {
         $filter = new ToNullFilter(ToNullFilter::TYPE_INTEGER);
 
-        $this->assertEquals(ToNullFilter::TYPE_INTEGER, $filter->getType());
+        $this->assertSame(ToNullFilter::TYPE_INTEGER, $filter->getType());
     }
 
     /**
@@ -35,7 +35,7 @@ class ToNullTest extends TestCase
      * @param bool  $expected
      * @dataProvider defaultTestProvider
      */
-    public function testDefault($value, $expected)
+    public function testDefault($value, $expected): void
     {
         $filter = new ToNullFilter();
         $this->assertSame($expected, $filter->filter($value));
@@ -46,7 +46,7 @@ class ToNullTest extends TestCase
      * @param array $testData
      * @dataProvider typeTestProvider
      */
-    public function testTypes($type, $testData)
+    public function testTypes($type, $testData): void
     {
         $filter = new ToNullFilter($type);
         foreach ($testData as $data) {
@@ -67,7 +67,7 @@ class ToNullTest extends TestCase
      * @param array $testData
      * @dataProvider combinedTypeTestProvider
      */
-    public function testCombinedTypes($typeData, $testData)
+    public function testCombinedTypes($typeData, $testData): void
     {
         foreach ($typeData as $type) {
             $filter = new ToNullFilter(['type' => $type]);
@@ -85,7 +85,7 @@ class ToNullTest extends TestCase
         }
     }
 
-    public function testSettingFalseType()
+    public function testSettingFalseType(): void
     {
         $filter = new ToNullFilter();
         $this->expectException(Exception\InvalidArgumentException::class);
@@ -93,10 +93,10 @@ class ToNullTest extends TestCase
         $filter->setType(true);
     }
 
-    public function testGettingDefaultType()
+    public function testGettingDefaultType(): void
     {
         $filter = new ToNullFilter();
-        $this->assertEquals(63, $filter->getType());
+        $this->assertSame(63, $filter->getType());
     }
 
     /**
@@ -106,10 +106,10 @@ class ToNullTest extends TestCase
      * @param mixed $expected Expected resulting type
      * @dataProvider duplicateTypeProvider
      */
-    public function testDuplicateInitializationResultsInCorrectType($type, $expected)
+    public function testDuplicateInitializationResultsInCorrectType($type, $expected): void
     {
         $filter = new ToNullFilter([$type, $type]);
-        $this->assertEquals($expected, $filter->getType());
+        $this->assertSame($expected, $filter->getType());
     }
 
     public static function duplicateTypeProvider()

--- a/test/UpperCaseWordsTest.php
+++ b/test/UpperCaseWordsTest.php
@@ -36,10 +36,8 @@ class UpperCaseWordsTest extends TestCase
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testBasic()
+    public function testBasic(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -49,17 +47,15 @@ class UpperCaseWordsTest extends TestCase
         ];
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertEquals($output, $filter($input));
+            $this->assertSame($output, $filter($input));
         }
     }
 
     /**
      * Ensures that the filter follows expected behavior with
      * specified encoding
-     *
-     * @return void
      */
-    public function testWithEncoding()
+    public function testWithEncoding(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -71,17 +67,14 @@ class UpperCaseWordsTest extends TestCase
         try {
             $filter->setEncoding('UTF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
         }
     }
 
-    /**
-     * @return void
-     */
-    public function testFalseEncoding()
+    public function testFalseEncoding(): void
     {
         if (! function_exists('mb_strtolower')) {
             $this->markTestSkipped('mbstring required');
@@ -95,7 +88,7 @@ class UpperCaseWordsTest extends TestCase
     /**
      * @Laminas-8989
      */
-    public function testInitiationWithEncoding()
+    public function testInitiationWithEncoding(): void
     {
         $valuesExpected = [
             '√º'      => '√º',
@@ -108,7 +101,7 @@ class UpperCaseWordsTest extends TestCase
                 'encoding' => 'UTF-8',
             ]);
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
@@ -118,7 +111,7 @@ class UpperCaseWordsTest extends TestCase
     /**
      * @Laminas-9058
      */
-    public function testCaseInsensitiveEncoding()
+    public function testCaseInsensitiveEncoding(): void
     {
         $filter         = $this->_filter;
         $valuesExpected = [
@@ -130,17 +123,17 @@ class UpperCaseWordsTest extends TestCase
         try {
             $filter->setEncoding('UTF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
 
             $this->_filter->setEncoding('utf-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
 
             $this->_filter->setEncoding('UtF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertEquals($output, $filter($input));
+                $this->assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
             $this->assertContains('mbstring is required', $e->getMessage());
@@ -150,13 +143,13 @@ class UpperCaseWordsTest extends TestCase
     /**
      * @group Laminas-9854
      */
-    public function testDetectMbInternalEncoding()
+    public function testDetectMbInternalEncoding(): void
     {
         if (! function_exists('mb_internal_encoding')) {
             $this->markTestSkipped("Function 'mb_internal_encoding' not available");
         }
 
-        $this->assertEquals(mb_internal_encoding(), $this->_filter->getEncoding());
+        $this->assertSame(mb_internal_encoding(), $this->_filter->getEncoding());
     }
 
     public function returnUnfilteredDataProvider()
@@ -179,7 +172,7 @@ class UpperCaseWordsTest extends TestCase
      * @dataProvider returnUnfilteredDataProvider
      * @param mixed $input
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $this->assertSame($input, $this->_filter->filter($input));
     }

--- a/test/UriNormalizeTest.php
+++ b/test/UriNormalizeTest.php
@@ -13,14 +13,14 @@ class UriNormalizeTest extends TestCase
     /**
      * @dataProvider abnormalUriProvider
      */
-    public function testUrisAreNormalized($url, $expected)
+    public function testUrisAreNormalized($url, $expected): void
     {
         $filter = new UriNormalize();
         $result = $filter->filter($url);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
-    public function testDefaultSchemeAffectsNormalization()
+    public function testDefaultSchemeAffectsNormalization(): void
     {
         $this->markTestIncomplete();
     }
@@ -28,11 +28,11 @@ class UriNormalizeTest extends TestCase
     /**
      * @dataProvider enforcedSchemeTestcaseProvider
      */
-    public function testEnforcedScheme($scheme, $input, $expected)
+    public function testEnforcedScheme($scheme, $input, $expected): void
     {
         $filter = new UriNormalize(['enforcedScheme' => $scheme]);
         $result = $filter->filter($input);
-        $this->assertEquals($expected, $result);
+        $this->assertSame($expected, $result);
     }
 
     public static function abnormalUriProvider()
@@ -74,12 +74,11 @@ class UriNormalizeTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new UriNormalize();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/Word/CamelCaseToDashTest.php
+++ b/test/Word/CamelCaseToDashTest.php
@@ -9,13 +9,13 @@ use PHPUnit\Framework\TestCase;
 
 class CamelCaseToDashTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithDashes()
+    public function testFilterSeparatesCamelCasedWordsWithDashes(): void
     {
         $string   = 'CamelCasedWords';
         $filter   = new CamelCaseToDashFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Camel-Cased-Words', $filtered);
+        $this->assertSame('Camel-Cased-Words', $filtered);
     }
 }

--- a/test/Word/CamelCaseToSeparatorTest.php
+++ b/test/Word/CamelCaseToSeparatorTest.php
@@ -72,4 +72,28 @@ class CamelCaseToSeparatorTest extends TestCase
 
         $this->assertSame($input, $filter($input));
     }
+
+    /**
+     * @return array<int|float|bool>[]
+     */
+    public function returnNonStringScalarValues(): array
+    {
+        return [
+            [1],
+            [1.0],
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider returnNonStringScalarValues
+     * @param int|float|bool $input
+     */
+    public function testShouldFilterNonStringScalarValues($input): void
+    {
+        $filter = new CamelCaseToSeparatorFilter();
+
+        $this->assertSame((string) $input, $filter($input));
+    }
 }

--- a/test/Word/CamelCaseToSeparatorTest.php
+++ b/test/Word/CamelCaseToSeparatorTest.php
@@ -10,40 +10,37 @@ use stdClass;
 
 class CamelCaseToSeparatorTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithSpacesByDefault()
+    public function testFilterSeparatesCamelCasedWordsWithSpacesByDefault(): void
     {
         $string   = 'CamelCasedWords';
         $filter   = new CamelCaseToSeparatorFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Camel Cased Words', $filtered);
+        $this->assertSame('Camel Cased Words', $filtered);
     }
 
-    public function testFilterSeparatesCamelCasedWordsWithProvidedSeparator()
+    public function testFilterSeparatesCamelCasedWordsWithProvidedSeparator(): void
     {
         $string   = 'CamelCasedWords';
         $filter   = new CamelCaseToSeparatorFilter(':-#');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Camel:-#Cased:-#Words', $filtered);
+        $this->assertSame('Camel:-#Cased:-#Words', $filtered);
     }
 
-    public function testFilterSeperatesMultipleUppercasedLettersAndUnderscores()
+    public function testFilterSeperatesMultipleUppercasedLettersAndUnderscores(): void
     {
         $string   = 'TheseAre_SOME_CamelCASEDWords';
         $filter   = new CamelCaseToSeparatorFilter('_');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('These_Are_SOME_Camel_CASED_Words', $filtered);
+        $this->assertSame('These_Are_SOME_Camel_CASED_Words', $filtered);
     }
 
-    /**
-     * @return void
-     */
-    public function testFilterSupportArray()
+    public function testFilterSupportArray(): void
     {
         $filter = new CamelCaseToSeparatorFilter();
 
@@ -55,7 +52,7 @@ class CamelCaseToSeparatorTest extends TestCase
         $filtered = $filter($input);
 
         $this->assertNotEquals($input, $filtered);
-        $this->assertEquals(['Camel Cased Words', 'something Different'], $filtered);
+        $this->assertSame(['Camel Cased Words', 'something Different'], $filtered);
     }
 
     public function returnUnfilteredDataProvider()
@@ -68,12 +65,11 @@ class CamelCaseToSeparatorTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new CamelCaseToSeparatorFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/Word/CamelCaseToUnderscoreTest.php
+++ b/test/Word/CamelCaseToUnderscoreTest.php
@@ -9,37 +9,37 @@ use PHPUnit\Framework\TestCase;
 
 class CamelCaseToUnderscoreTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithUnderscores()
+    public function testFilterSeparatesCamelCasedWordsWithUnderscores(): void
     {
         $string   = 'CamelCasedWords';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Camel_Cased_Words', $filtered);
+        $this->assertSame('Camel_Cased_Words', $filtered);
     }
 
-    public function testFilterSeperatingNumbersToUnterscore()
+    public function testFilterSeperatingNumbersToUnterscore(): void
     {
         $string   = 'PaTitle';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Pa_Title', $filtered);
+        $this->assertSame('Pa_Title', $filtered);
 
         $string   = 'Pa2Title';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Pa2_Title', $filtered);
+        $this->assertSame('Pa2_Title', $filtered);
 
         $string   = 'Pa2aTitle';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Pa2a_Title', $filtered);
+        $this->assertSame('Pa2a_Title', $filtered);
     }
 }

--- a/test/Word/DashToCamelCaseTest.php
+++ b/test/Word/DashToCamelCaseTest.php
@@ -9,13 +9,13 @@ use PHPUnit\Framework\TestCase;
 
 class DashToCamelCaseTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithDashes()
+    public function testFilterSeparatesCamelCasedWordsWithDashes(): void
     {
         $string   = 'camel-cased-words';
         $filter   = new DashToCamelCaseFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('CamelCasedWords', $filtered);
+        $this->assertSame('CamelCasedWords', $filtered);
     }
 }

--- a/test/Word/DashToSeparatorTest.php
+++ b/test/Word/DashToSeparatorTest.php
@@ -10,30 +10,27 @@ use stdClass;
 
 class DashToSeparatorTest extends TestCase
 {
-    public function testFilterSeparatesDashedWordsWithDefaultSpaces()
+    public function testFilterSeparatesDashedWordsWithDefaultSpaces(): void
     {
         $string   = 'dash-separated-words';
         $filter   = new DashToSeparatorFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash separated words', $filtered);
+        $this->assertSame('dash separated words', $filtered);
     }
 
-    public function testFilterSeparatesDashedWordsWithSomeString()
+    public function testFilterSeparatesDashedWordsWithSomeString(): void
     {
         $string   = 'dash-separated-words';
         $filter   = new DashToSeparatorFilter(':-:');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash:-:separated:-:words', $filtered);
+        $this->assertSame('dash:-:separated:-:words', $filtered);
     }
 
-    /**
-     * @return void
-     */
-    public function testFilterSupportArray()
+    public function testFilterSupportArray(): void
     {
         $filter = new DashToSeparatorFilter();
 
@@ -45,7 +42,7 @@ class DashToSeparatorTest extends TestCase
         $filtered = $filter($input);
 
         $this->assertNotEquals($input, $filtered);
-        $this->assertEquals(['dash separated words', 'something different'], $filtered);
+        $this->assertSame(['dash separated words', 'something different'], $filtered);
     }
 
     public function returnUnfilteredDataProvider()
@@ -58,12 +55,11 @@ class DashToSeparatorTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new DashToSeparatorFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/Word/DashToSeparatorTest.php
+++ b/test/Word/DashToSeparatorTest.php
@@ -62,4 +62,28 @@ class DashToSeparatorTest extends TestCase
 
         $this->assertSame($input, $filter($input));
     }
+
+    /**
+     * @return array<int|float|bool>[]
+     */
+    public function returnNonStringScalarValues(): array
+    {
+        return [
+            [1],
+            [1.0],
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider returnNonStringScalarValues
+     * @param int|float|bool $input
+     */
+    public function testShouldFilterNonStringScalarValues($input): void
+    {
+        $filter = new DashToSeparatorFilter();
+
+        $this->assertSame((string) $input, $filter($input));
+    }
 }

--- a/test/Word/DashToUnderscoreTest.php
+++ b/test/Word/DashToUnderscoreTest.php
@@ -9,13 +9,13 @@ use PHPUnit\Framework\TestCase;
 
 class DashToUnderscoreTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithDashes()
+    public function testFilterSeparatesCamelCasedWordsWithDashes(): void
     {
         $string   = 'dash-separated-words';
         $filter   = new DashToUnderscoreFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash_separated_words', $filtered);
+        $this->assertSame('dash_separated_words', $filtered);
     }
 }

--- a/test/Word/SeparatorToCamelCaseTest.php
+++ b/test/Word/SeparatorToCamelCaseTest.php
@@ -111,4 +111,28 @@ class SeparatorToCamelCaseTest extends TestCase
 
         $this->assertSame($input, $filter($input));
     }
+
+    /**
+     * @return array<int|float|bool>[]
+     */
+    public function returnNonStringScalarValues(): array
+    {
+        return [
+            [1],
+            [1.0],
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider returnNonStringScalarValues
+     * @param int|float|bool $input
+     */
+    public function testShouldFilterNonStringScalarValues($input): void
+    {
+        $filter = new SeparatorToCamelCaseFilter();
+
+        $this->assertSame((string) $input, $filter($input));
+    }
 }

--- a/test/Word/SeparatorToCamelCaseTest.php
+++ b/test/Word/SeparatorToCamelCaseTest.php
@@ -12,30 +12,30 @@ use function extension_loaded;
 
 class SeparatorToCamelCaseTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithSpacesByDefault()
+    public function testFilterSeparatesCamelCasedWordsWithSpacesByDefault(): void
     {
         $string   = 'camel cased words';
         $filter   = new SeparatorToCamelCaseFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('CamelCasedWords', $filtered);
+        $this->assertSame('CamelCasedWords', $filtered);
     }
 
-    public function testFilterSeparatesCamelCasedWordsWithProvidedSeparator()
+    public function testFilterSeparatesCamelCasedWordsWithProvidedSeparator(): void
     {
         $string   = 'camel:-:cased:-:Words';
         $filter   = new SeparatorToCamelCaseFilter(':-:');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('CamelCasedWords', $filtered);
+        $this->assertSame('CamelCasedWords', $filtered);
     }
 
     /**
      * @group Laminas-10517
      */
-    public function testFilterSeparatesUniCodeCamelCasedWordsWithProvidedSeparator()
+    public function testFilterSeparatesUniCodeCamelCasedWordsWithProvidedSeparator(): void
     {
         if (! extension_loaded('mbstring')) {
             $this->markTestSkipped('Extension mbstring not available');
@@ -46,13 +46,13 @@ class SeparatorToCamelCaseTest extends TestCase
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('CamelCasedWords', $filtered);
+        $this->assertSame('CamelCasedWords', $filtered);
     }
 
     /**
      * @group Laminas-10517
      */
-    public function testFilterSeparatesUniCodeCamelCasedUserWordsWithProvidedSeparator()
+    public function testFilterSeparatesUniCodeCamelCasedUserWordsWithProvidedSeparator(): void
     {
         if (! extension_loaded('mbstring')) {
             $this->markTestSkipped('Extension mbstring not available');
@@ -63,26 +63,23 @@ class SeparatorToCamelCaseTest extends TestCase
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('TestŠuma', $filtered);
+        $this->assertSame('TestŠuma', $filtered);
     }
 
     /**
      * @group 6151
      */
-    public function testFilterSeparatesCamelCasedNonAlphaWordsWithProvidedSeparator()
+    public function testFilterSeparatesCamelCasedNonAlphaWordsWithProvidedSeparator(): void
     {
         $string   = 'user_2_user';
         $filter   = new SeparatorToCamelCaseFilter('_');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('User2User', $filtered);
+        $this->assertSame('User2User', $filtered);
     }
 
-    /**
-     * @return void
-     */
-    public function testFilterSupportArray()
+    public function testFilterSupportArray(): void
     {
         $filter = new SeparatorToCamelCaseFilter();
 
@@ -94,7 +91,7 @@ class SeparatorToCamelCaseTest extends TestCase
         $filtered = $filter($input);
 
         $this->assertNotEquals($input, $filtered);
-        $this->assertEquals(['CamelCasedWords', 'SomethingDifferent'], $filtered);
+        $this->assertSame(['CamelCasedWords', 'SomethingDifferent'], $filtered);
     }
 
     public function returnUnfilteredDataProvider()
@@ -107,12 +104,11 @@ class SeparatorToCamelCaseTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new SeparatorToCamelCaseFilter();
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/Word/SeparatorToDashTest.php
+++ b/test/Word/SeparatorToDashTest.php
@@ -9,23 +9,23 @@ use PHPUnit\Framework\TestCase;
 
 class SeparatorToDashTest extends TestCase
 {
-    public function testFilterSeparatesDashedWordsWithDefaultSpaces()
+    public function testFilterSeparatesDashedWordsWithDefaultSpaces(): void
     {
         $string   = 'dash separated words';
         $filter   = new SeparatorToDashFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash-separated-words', $filtered);
+        $this->assertSame('dash-separated-words', $filtered);
     }
 
-    public function testFilterSeparatesDashedWordsWithSomeString()
+    public function testFilterSeparatesDashedWordsWithSomeString(): void
     {
         $string   = 'dash=separated=words';
         $filter   = new SeparatorToDashFilter('=');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash-separated-words', $filtered);
+        $this->assertSame('dash-separated-words', $filtered);
     }
 }

--- a/test/Word/SeparatorToSeparatorTest.php
+++ b/test/Word/SeparatorToSeparatorTest.php
@@ -10,17 +10,17 @@ use stdClass;
 
 class SeparatorToSeparatorTest extends TestCase
 {
-    public function testFilterSeparatesWordsByDefault()
+    public function testFilterSeparatesWordsByDefault(): void
     {
         $string   = 'dash separated words';
         $filter   = new SeparatorToSeparatorFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash-separated-words', $filtered);
+        $this->assertSame('dash-separated-words', $filtered);
     }
 
-    public function testFilterSupportArray()
+    public function testFilterSupportArray(): void
     {
         $filter = new SeparatorToSeparatorFilter();
 
@@ -31,30 +31,30 @@ class SeparatorToSeparatorTest extends TestCase
         $filtered = $filter($input);
 
         $this->assertNotEquals($input, $filtered);
-        $this->assertEquals([
+        $this->assertSame([
             'dash-separated-words',
             '=test-something',
         ], $filtered);
     }
 
-    public function testFilterSeparatesWordsWithSearchSpecified()
+    public function testFilterSeparatesWordsWithSearchSpecified(): void
     {
         $string   = 'dash=separated=words';
         $filter   = new SeparatorToSeparatorFilter('=');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash-separated-words', $filtered);
+        $this->assertSame('dash-separated-words', $filtered);
     }
 
-    public function testFilterSeparatesWordsWithSearchAndReplacementSpecified()
+    public function testFilterSeparatesWordsWithSearchAndReplacementSpecified(): void
     {
         $string   = 'dash=separated=words';
         $filter   = new SeparatorToSeparatorFilter('=', '?');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('dash?separated?words', $filtered);
+        $this->assertSame('dash?separated?words', $filtered);
     }
 
     public function returnUnfilteredDataProvider()
@@ -67,12 +67,11 @@ class SeparatorToSeparatorTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @return void
      */
-    public function testReturnUnfiltered($input)
+    public function testReturnUnfiltered($input): void
     {
         $filter = new SeparatorToSeparatorFilter('=', '?');
 
-        $this->assertEquals($input, $filter($input));
+        $this->assertSame($input, $filter($input));
     }
 }

--- a/test/Word/SeparatorToSeparatorTest.php
+++ b/test/Word/SeparatorToSeparatorTest.php
@@ -74,4 +74,28 @@ class SeparatorToSeparatorTest extends TestCase
 
         $this->assertSame($input, $filter($input));
     }
+
+    /**
+     * @return array<int|float|bool>[]
+     */
+    public function returnNonStringScalarValues(): array
+    {
+        return [
+            [1],
+            [1.0],
+            [true],
+            [false],
+        ];
+    }
+
+    /**
+     * @dataProvider returnNonStringScalarValues
+     * @param int|float|bool $input
+     */
+    public function testShouldFilterNonStringScalarValues($input): void
+    {
+        $filter = new SeparatorToSeparatorFilter('=', '?');
+
+        $this->assertSame((string) $input, $filter($input));
+    }
 }

--- a/test/Word/UnderscoreToCamelCaseTest.php
+++ b/test/Word/UnderscoreToCamelCaseTest.php
@@ -9,51 +9,51 @@ use PHPUnit\Framework\TestCase;
 
 class UnderscoreToCamelCaseTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithDashes()
+    public function testFilterSeparatesCamelCasedWordsWithDashes(): void
     {
         $string   = 'camel_cased_words';
         $filter   = new UnderscoreToCamelCaseFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('CamelCasedWords', $filtered);
+        $this->assertSame('CamelCasedWords', $filtered);
     }
 
     /**
      * Laminas-4097
      */
-    public function testSomeFilterValues()
+    public function testSomeFilterValues(): void
     {
         $filter = new UnderscoreToCamelCaseFilter();
 
         $string   = 'laminas_project';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('LaminasProject', $filtered);
+        $this->assertSame('LaminasProject', $filtered);
 
         $string   = 'laminas_Project';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('LaminasProject', $filtered);
+        $this->assertSame('LaminasProject', $filtered);
 
         $string   = 'laminasProject';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('LaminasProject', $filtered);
+        $this->assertSame('LaminasProject', $filtered);
 
         $string   = 'laminasproject';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Laminasproject', $filtered);
+        $this->assertSame('Laminasproject', $filtered);
 
         $string   = '_laminasproject';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('Laminasproject', $filtered);
+        $this->assertSame('Laminasproject', $filtered);
 
         $string   = '_laminas_project';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('LaminasProject', $filtered);
+        $this->assertSame('LaminasProject', $filtered);
     }
 }

--- a/test/Word/UnderscoreToDashTest.php
+++ b/test/Word/UnderscoreToDashTest.php
@@ -9,13 +9,13 @@ use PHPUnit\Framework\TestCase;
 
 class UnderscoreToDashTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsWithDashes()
+    public function testFilterSeparatesCamelCasedWordsWithDashes(): void
     {
         $string   = 'underscore_separated_words';
         $filter   = new UnderscoreToDashFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('underscore-separated-words', $filtered);
+        $this->assertSame('underscore-separated-words', $filtered);
     }
 }

--- a/test/Word/UnderscoreToSeparatorTest.php
+++ b/test/Word/UnderscoreToSeparatorTest.php
@@ -9,23 +9,23 @@ use PHPUnit\Framework\TestCase;
 
 class UnderscoreToSeparatorTest extends TestCase
 {
-    public function testFilterSeparatesCamelCasedWordsDefaultSeparator()
+    public function testFilterSeparatesCamelCasedWordsDefaultSeparator(): void
     {
         $string   = 'underscore_separated_words';
         $filter   = new UnderscoreToSeparatorFilter();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('underscore separated words', $filtered);
+        $this->assertSame('underscore separated words', $filtered);
     }
 
-    public function testFilterSeparatesCamelCasedWordsProvidedSeparator()
+    public function testFilterSeparatesCamelCasedWordsProvidedSeparator(): void
     {
         $string   = 'underscore_separated_words';
         $filter   = new UnderscoreToSeparatorFilter(':=:');
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('underscore:=:separated:=:words', $filtered);
+        $this->assertSame('underscore:=:separated:=:words', $filtered);
     }
 }

--- a/test/Word/UnderscoreToStudlyCaseTest.php
+++ b/test/Word/UnderscoreToStudlyCaseTest.php
@@ -9,69 +9,69 @@ use PHPUnit\Framework\TestCase;
 
 class UnderscoreToStudlyCaseTest extends TestCase
 {
-    public function testFilterSeparatesStudlyCasedWordsWithDashes()
+    public function testFilterSeparatesStudlyCasedWordsWithDashes(): void
     {
         $string   = 'studly_cased_words';
         $filter   = new UnderscoreToStudlyCase();
         $filtered = $filter($string);
 
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('studlyCasedWords', $filtered);
+        $this->assertSame('studlyCasedWords', $filtered);
     }
 
-    public function testSomeFilterValues()
+    public function testSomeFilterValues(): void
     {
         $filter = new UnderscoreToStudlyCase();
 
         $string   = 'laminas_project';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('laminasProject', $filtered);
+        $this->assertSame('laminasProject', $filtered);
 
         $string   = 'laminas_Project';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('laminasProject', $filtered);
+        $this->assertSame('laminasProject', $filtered);
 
         $string   = 'laminasProject';
         $filtered = $filter($string);
-        $this->assertEquals('laminasProject', $filtered);
+        $this->assertSame('laminasProject', $filtered);
 
         $string   = 'laminas';
         $filtered = $filter($string);
-        $this->assertEquals('laminas', $filtered);
+        $this->assertSame('laminas', $filtered);
 
         $string   = '_laminas';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('laminas', $filtered);
+        $this->assertSame('laminas', $filtered);
 
         $string   = '_laminas_project';
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals('laminasProject', $filtered);
+        $this->assertSame('laminasProject', $filtered);
     }
 
-    public function testFiltersArray()
+    public function testFiltersArray(): void
     {
         $filter = new UnderscoreToStudlyCase();
 
         $string   = ['laminas_project', '_laminas_project'];
         $filtered = $filter($string);
         $this->assertNotEquals($string, $filtered);
-        $this->assertEquals(['laminasProject', 'laminasProject'], $filtered);
+        $this->assertSame(['laminasProject', 'laminasProject'], $filtered);
     }
 
-    public function testWithEmpties()
+    public function testWithEmpties(): void
     {
         $filter = new UnderscoreToStudlyCase();
 
         $string   = '';
         $filtered = $filter($string);
-        $this->assertEquals('', $filtered);
+        $this->assertSame('', $filtered);
 
         $string   = ['', 'Laminas_Project'];
         $filtered = $filter($string);
-        $this->assertEquals(['', 'laminasProject'], $filtered);
+        $this->assertSame(['', 'laminasProject'], $filtered);
     }
 }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->

As per issue https://github.com/laminas/laminas-filter/issues/41, this PR ensures that non-string scalar types (int|float|bool) still pass through the filters as before. The classes I identified with the problem are:
- `PregReplace::class`
- `StripNewlines::class`
- `Word/CamelCaseToSeparator::class`
- `Word/DashToSeparator::class`
- `Word/SeparatorToCamelCase::class`
- `Word/SeparatorToSeparator::class`
- `Word/UnderscoreToStudlyCase::class`

In this PR are 2 commits. The first ensures thats all tests are checking for valid types now that `strict_types` is used. The second adds the fixes described above.

A couple of extra things that should be pointed out. The BooleanFilter was previously expecting null to be filtered to null, with all types and no casting. This is incorrect as TYPES_ALL includes TYPE_NULL. Changing to use `assertSame` instead of `assertEquals` caught this error.

There is also a CS ignore for a deprecated OpenSSL method to allow the CS checks to pass as there is no alternative method, as the functionality it provided is now default.