### PR TITLE
Avoid `null` return value from `Uri#getPath()` leading to a crash in `UriNormalize`

### DIFF
--- a/src/UriNormalize.php
+++ b/src/UriNormalize.php
@@ -123,7 +123,8 @@ class UriNormalize extends AbstractFilter
      */
     protected function enforceScheme(Uri $uri)
     {
-        $path = $uri->getPath();
+        $path = $uri->getPath() ?? '';
+
         if (strpos($path, '/') !== false) {
             [$host, $path] = explode('/', $path, 2);
             $path          = '/' . $path;

--- a/test/UriNormalizeTest.php
+++ b/test/UriNormalizeTest.php
@@ -55,6 +55,7 @@ class UriNormalizeTest extends TestCase
             ['http', 'www.example.com/foo/bar?q=q', 'http://www.example.com/foo/bar?q=q'],
             ['ftp', 'www.example.com/path/to/file.ext', 'ftp://www.example.com/path/to/file.ext'],
             ['http', '/just/a/path', '/just/a/path'], // cannot be enforced, no host
+            ['http', '', ''],
         ];
     }
 


### PR DESCRIPTION
Signed-off-by: Dennis Plettner <d.plettner@adcell.de>

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Using the UriNormalizer with enforcedScheme and an empty string will cause strpos() to fail because it expects a string.
uri->getPath() however can return a string and null. Now if the filter() function is called with an empty string then an uri object will be created with path being null.

i also provided a testcase for this specific situation.