### PR TITLE
Revert addition of Plugin Manager methods that are incompatible with Service Manager 2.x

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1112,24 +1112,30 @@
       <code>gettype($callback)</code>
       <code>gettype($options)</code>
     </DocblockTypeContradiction>
-    <MixedArgument occurrences="6">
+    <MixedArgument occurrences="8">
       <code>$callback</code>
+      <code>$filter</code>
       <code>$item['data']</code>
+      <code>$item['priority']</code>
       <code>$key</code>
       <code>$name</code>
       <code>$priority</code>
       <code>$priority</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="5">
+    <MixedArrayAccess occurrences="7">
+      <code>$item['data']</code>
+      <code>$item['priority']</code>
       <code>$spec['callback']</code>
       <code>$spec['name']</code>
       <code>$spec['options']</code>
       <code>$spec['priority']</code>
       <code>$spec['priority']</code>
     </MixedArrayAccess>
-    <MixedAssignment occurrences="12">
+    <MixedAssignment occurrences="14">
       <code>$callback</code>
       <code>$filter</code>
+      <code>$filter</code>
+      <code>$item</code>
       <code>$key</code>
       <code>$name</code>
       <code>$options</code>
@@ -1144,6 +1150,12 @@
     <MixedFunctionCall occurrences="1">
       <code>call_user_func($filter, $valueFiltered)</code>
     </MixedFunctionCall>
+    <MixedInferredReturnType occurrences="1">
+      <code>FilterInterface|callable(mixed): mixed</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$plugins-&gt;get($name, $options)</code>
+    </MixedReturnStatement>
     <RedundantConditionGivenDocblockType occurrences="2">
       <code>is_object($callback)</code>
       <code>is_object($options)</code>
@@ -1164,12 +1176,10 @@
       <code>$e-&gt;getCode()</code>
     </InvalidScalarArgument>
     <MixedArrayOffset occurrences="2"/>
-    <MixedInferredReturnType occurrences="1"/>
     <NonInvariantDocblockPropertyType occurrences="1">
       <code>$factories</code>
     </NonInvariantDocblockPropertyType>
-    <ParamNameMismatch occurrences="2">
-      <code>$name</code>
+    <ParamNameMismatch occurrences="1">
       <code>$plugin</code>
     </ParamNameMismatch>
     <UndefinedClass occurrences="26">
@@ -1296,14 +1306,16 @@
     <MixedFunctionCall occurrences="1">
       <code>$ruleFilter($processedPart)</code>
     </MixedFunctionCall>
-    <MixedInferredReturnType occurrences="2">
+    <MixedInferredReturnType occurrences="3">
+      <code>FilterInterface|callable(mixed): mixed</code>
       <code>FilterInterface|false</code>
       <code>array|false</code>
     </MixedInferredReturnType>
     <MixedMethodCall occurrences="1">
       <code>new $options['pluginManager']()</code>
     </MixedMethodCall>
-    <MixedReturnStatement occurrences="2">
+    <MixedReturnStatement occurrences="3">
+      <code>$this-&gt;getPluginManager()-&gt;get($rule)</code>
       <code>$this-&gt;rules[$spec]</code>
       <code>$this-&gt;rules[$spec][$index]</code>
     </MixedReturnStatement>
@@ -1406,6 +1418,12 @@
     <InvalidThrow occurrences="1">
       <code>Exception\ExceptionInterface</code>
     </InvalidThrow>
+    <MixedAssignment occurrences="1">
+      <code>$filter</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>$filter($value)</code>
+    </MixedFunctionCall>
   </file>
   <file src="src/StringPrefix.php">
     <DocblockTypeContradiction occurrences="1">
@@ -2547,6 +2565,12 @@
       <code>$config</code>
     </UnusedVariable>
   </file>
+  <file src="test/FilterPluginManagerTest.php">
+    <MixedAssignment occurrences="2">
+      <code>$filterOne</code>
+      <code>$filterTwo</code>
+    </MixedAssignment>
+  </file>
   <file src="test/HtmlEntitiesTest.php">
     <MissingParamType occurrences="3">
       <code>$errno</code>
@@ -2687,7 +2711,27 @@
       <code>$input</code>
     </MixedArgument>
   </file>
+  <file src="test/StaticAnalysis/PluginRetrievalTest.php">
+    <MixedAssignment occurrences="1">
+      <code>$plugin</code>
+    </MixedAssignment>
+    <MixedFunctionCall occurrences="1">
+      <code>$plugin($value)</code>
+    </MixedFunctionCall>
+    <MixedInferredReturnType occurrences="1">
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement occurrences="1">
+      <code>$plugin-&gt;filter($value)</code>
+    </MixedReturnStatement>
+    <PossiblyInvalidMethodCall occurrences="1">
+      <code>filter</code>
+    </PossiblyInvalidMethodCall>
+  </file>
   <file src="test/StaticFilterTest.php">
+    <InvalidArgument occurrences="1">
+      <code>Exception\ExceptionInterface::class</code>
+    </InvalidArgument>
     <MissingClosureParamType occurrences="2">
       <code>$value</code>
       <code>$value</code>

--- a/src/FilterPluginManager.php
+++ b/src/FilterPluginManager.php
@@ -509,29 +509,4 @@ class FilterPluginManager extends AbstractPluginManager
             throw new RuntimeException($e->getMessage(), $e->getCode(), $e);
         }
     }
-
-    /**
-     * @inheritDoc
-     * @template InstanceType of FilterInterface
-     * @param class-string<InstanceType>|string $name Service name of plugin to retrieve.
-     * @param null|array<mixed> $options Options to use when creating the instance.
-     * @return InstanceType|callable(mixed): mixed
-     * @psalm-return ($name is class-string ? InstanceType : callable(mixed): mixed)
-     */
-    public function get($name, ?array $options = null)
-    {
-        /** @psalm-suppress MixedReturnStatement */
-        return parent::get($name, $options);
-    }
-
-    /**
-     * @param string $name
-     * @param FilterInterface|callable(mixed): mixed $service
-     * @return void
-     * @psalm-suppress MoreSpecificImplementedParamType
-     */
-    public function setService($name, $service)
-    {
-        parent::setService($name, $service);
-    }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes

### Description

`2.15.0` broke compatibility with service manager `2.x` series by adding incompatible method signatures to the Filter Plugin Manager.

This patch reverts the addition of those methods
