### PR TITLE
Add tests to cover `AbstractUnicode` fixing undefined offset error

### DIFF
--- a/src/AbstractUnicode.php
+++ b/src/AbstractUnicode.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Laminas\Filter;
 
 use function array_map;
+use function assert;
 use function function_exists;
 use function in_array;
+use function is_string;
 use function mb_internal_encoding;
 use function mb_list_encodings;
 use function sprintf;
@@ -53,7 +55,9 @@ abstract class AbstractUnicode extends AbstractFilter
      */
     public function getEncoding()
     {
-        if ($this->options['encoding'] === null && function_exists('mb_internal_encoding')) {
+        $encoding = $this->options['encoding'] ?? null;
+        assert($encoding === null || is_string($encoding));
+        if ($encoding === null && function_exists('mb_internal_encoding')) {
             $this->options['encoding'] = mb_internal_encoding();
         }
 

--- a/test/AbstractUnicodeTest.php
+++ b/test/AbstractUnicodeTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Filter;
+
+use Laminas\Filter\AbstractUnicode;
+use Laminas\Filter\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+
+use function assert;
+use function is_string;
+use function mb_internal_encoding;
+use function strtolower;
+
+class AbstractUnicodeTest extends TestCase
+{
+    /** @var AbstractUnicode */
+    private $filter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->filter = new class extends AbstractUnicode {
+            /** @param mixed $value */
+            public function filter($value): string
+            {
+                assert(is_string($value));
+                return strtolower($value);
+            }
+        };
+    }
+
+    /** @return list<array{0: string, 1: string}> */
+    public function encodingProvider(): array
+    {
+        return [
+            ['ISO-8859-16', 'iso-8859-16'],
+            ['UTF-8', 'utf-8'],
+            ['Windows-1251', 'windows-1251'],
+        ];
+    }
+
+    /** @dataProvider encodingProvider */
+    public function testThatEncodingOptionIsLowerCased(string $encoding, string $expectedEncoding): void
+    {
+        $this->filter->setEncoding($encoding);
+        self::assertNotSame($encoding, $this->filter->getEncoding());
+        self::assertSame($expectedEncoding, $this->filter->getEncoding());
+    }
+
+    public function testThatAnUnSupportedEncodingCausesAnException(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Encoding \'goats\' is not supported by mbstring extension');
+
+        $this->filter->setEncoding('Goats');
+    }
+
+    public function testThatMbStringInternalEncodingIsReturnedWhenEncodingHasNotBeenSpecified(): void
+    {
+        $expect = mb_internal_encoding();
+        self::assertSame($expect, $this->filter->getEncoding());
+    }
+
+    public function testThatExplicitlySettingEncodingToNullWillYieldDefaultEncoding(): void
+    {
+        $this->filter->setEncoding(null);
+        self::assertSame(mb_internal_encoding(), $this->filter->getEncoding());
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

This test case has been added to document that `AbstractUnicode` lower cases it's encoding option. Also discovered that an undefined index would be caused by accessing the encoding option when no default had been set.