### PR TITLE
Test Cleanup

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1618,9 +1618,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>$strict</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="1">
-      <code>$list</code>
-    </MissingParamType>
     <MixedArrayAccess occurrences="2">
       <code>$expected</code>
       <code>$value</code>
@@ -1629,21 +1626,6 @@
       <code>$data</code>
       <code>[$value, $expected]</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>array</code>
-      <code>array</code>
-    </MixedInferredReturnType>
-    <UnusedVariable occurrences="1">
-      <code>$filter</code>
-    </UnusedVariable>
-  </file>
-  <file src="test/BaseNameTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
   </file>
   <file src="test/BlacklistTest.php">
     <DeprecatedClass occurrences="1">
@@ -1654,16 +1636,6 @@
     <InvalidScalarArgument occurrences="1">
       <code>true</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="1">
-      <code>$expected</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="5">
-      <code>combinedTypeTestProvider</code>
-      <code>defaultTestProvider</code>
-      <code>duplicateProvider</code>
-      <code>noCastingTestProvider</code>
-      <code>typeTestProvider</code>
-    </MissingReturnType>
     <MixedArgument occurrences="4">
       <code>$value</code>
       <code>$value</code>
@@ -1683,56 +1655,27 @@
       <code>[$value, $expected]</code>
       <code>[$value, $expected]</code>
     </MixedAssignment>
+    <MixedInferredReturnType occurrences="1">
+      <code>array</code>
+    </MixedInferredReturnType>
+    <PossiblyInvalidArgument occurrences="1">
+      <code>testTypes</code>
+    </PossiblyInvalidArgument>
   </file>
   <file src="test/CallbackTest.php">
     <InvalidArgument occurrences="2">
       <code>'param'</code>
       <code>'param'</code>
     </InvalidArgument>
-    <MissingParamType occurrences="5">
-      <code>$param</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="3">
-      <code>objectCallback</code>
-      <code>objectCallbackWithParams</code>
-      <code>staticCallback</code>
-    </MissingReturnType>
-    <MixedOperand occurrences="5">
-      <code>$param</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MixedOperand>
   </file>
   <file src="test/Compress/Bz2Test.php">
     <DocblockTypeContradiction occurrences="2">
       <code>assertTrue</code>
       <code>assertTrue</code>
     </DocblockTypeContradiction>
-    <MissingPropertyType occurrences="1">
-      <code>$target</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="1">
       <code>testBz2DecompressNullValueIsAccepted</code>
     </MissingReturnType>
-    <MixedArgument occurrences="7">
-      <code>$archive</code>
-      <code>$archive</code>
-      <code>$archive</code>
-      <code>$archive</code>
-      <code>$archive</code>
-      <code>$this-&gt;target</code>
-      <code>$this-&gt;target</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="2">
-      <code>$archive</code>
-      <code>$archive</code>
-    </MixedAssignment>
     <NullArgument occurrences="2">
       <code>null</code>
       <code>null</code>
@@ -1742,19 +1685,6 @@
     <DocblockTypeContradiction occurrences="1">
       <code>assertTrue</code>
     </DocblockTypeContradiction>
-    <MissingPropertyType occurrences="1">
-      <code>$target</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="5">
-      <code>$archive</code>
-      <code>$archive</code>
-      <code>$archive</code>
-      <code>$this-&gt;target</code>
-      <code>$this-&gt;target</code>
-    </MixedArgument>
-    <MixedAssignment occurrences="1">
-      <code>$archive</code>
-    </MixedAssignment>
     <NullArgument occurrences="2">
       <code>null</code>
       <code>null</code>
@@ -1773,29 +1703,6 @@
     <InvalidReturnType occurrences="1">
       <code>unknown</code>
     </InvalidReturnType>
-    <MissingPropertyType occurrences="1">
-      <code>$tmp</code>
-    </MissingPropertyType>
-    <MixedOperand occurrences="18">
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-    </MixedOperand>
     <UndefinedDocblockClass occurrences="1">
       <code>unknown</code>
     </UndefinedDocblockClass>
@@ -1831,176 +1738,10 @@
       <code>$tar</code>
     </UnusedVariable>
   </file>
-  <file src="test/Compress/TarTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$tmp</code>
-    </MissingPropertyType>
-    <MixedArgumentTypeCoercion occurrences="1"/>
-    <MixedAssignment occurrences="1">
-      <code>$target</code>
-    </MixedAssignment>
-    <MixedOperand occurrences="33">
-      <code>$target</code>
-      <code>$target</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-    </MixedOperand>
-  </file>
-  <file src="test/Compress/ZipTest.php">
-    <MixedOperand occurrences="53">
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-    </MixedOperand>
-    <UndefinedThisPropertyAssignment occurrences="1">
-      <code>$this-&gt;tmp</code>
-    </UndefinedThisPropertyAssignment>
-    <UndefinedThisPropertyFetch occurrences="7">
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-      <code>$this-&gt;tmp</code>
-    </UndefinedThisPropertyFetch>
-  </file>
   <file src="test/CompressTest.php">
-    <MissingParamType occurrences="10">
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$input</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$tmpDir</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="13">
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-    </MixedArgument>
-    <MixedArrayAccess occurrences="5">
-      <code>$parameters[0]</code>
-      <code>$parameters[0]</code>
-      <code>$parameters[0]</code>
-      <code>$parameters[0]</code>
-      <code>$parameters[0]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="1">
       <code>$compressed</code>
-      <code>$parameters</code>
-      <code>$parameters</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>iterable</code>
-      <code>iterable</code>
-    </MixedInferredReturnType>
-    <MixedOperand occurrences="8">
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$parameters[0]</code>
-      <code>$parameters[0]</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-    </MixedOperand>
     <UndefinedInterfaceMethod occurrences="2">
       <code>getArchive</code>
       <code>getArchive</code>
@@ -2016,97 +1757,15 @@
       <code>1500</code>
       <code>1500</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="2">
-      <code>binaryBytesTestProvider</code>
-      <code>decimalBytesTestProvider</code>
-    </MissingReturnType>
-    <UnusedVariable occurrences="3">
-      <code>$filter</code>
-      <code>$filter</code>
-      <code>$filter</code>
-    </UnusedVariable>
-  </file>
-  <file src="test/DateSelectTest.php">
-    <MissingReturnType occurrences="1">
-      <code>provideFilter</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/DateTimeFormatterTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$defaultTimezone</code>
-    </MissingPropertyType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="1">
-      <code>$this-&gt;defaultTimezone</code>
-    </MixedArgument>
-    <UnusedVariable occurrences="1">
-      <code>$result</code>
-    </UnusedVariable>
-  </file>
-  <file src="test/DateTimeSelectTest.php">
-    <MissingReturnType occurrences="1">
-      <code>provideFilter</code>
-    </MissingReturnType>
   </file>
   <file src="test/DecompressTest.php">
-    <MissingParamType occurrences="6">
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$input</code>
-    </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$tmpDir</code>
-    </MissingPropertyType>
-    <MixedArgument occurrences="13">
+    <MixedArgument occurrences="2">
       <code>$compressed</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
       <code>$input</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
     </MixedArgument>
-    <MixedArrayAccess occurrences="4">
-      <code>$parameter[0]</code>
-      <code>$parameter[0]</code>
-      <code>$parameters[0]</code>
-      <code>$parameters[0]</code>
-    </MixedArrayAccess>
-    <MixedAssignment occurrences="3">
+    <MixedAssignment occurrences="1">
       <code>$compressed</code>
-      <code>$parameter</code>
-      <code>$parameters</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>iterable</code>
-      <code>iterable</code>
-    </MixedInferredReturnType>
-    <MixedOperand occurrences="10">
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$filterType</code>
-      <code>$parameters[0]</code>
-      <code>$parameters[0]</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-    </MixedOperand>
     <NullArgument occurrences="1">
       <code>null</code>
     </NullArgument>
@@ -2145,32 +1804,11 @@
       <code>$data</code>
       <code>[$value, $expected]</code>
     </MixedAssignment>
-    <MixedInferredReturnType occurrences="2">
-      <code>array</code>
-      <code>array</code>
-    </MixedInferredReturnType>
-    <UnusedVariable occurrences="1">
-      <code>$filter</code>
-    </UnusedVariable>
   </file>
   <file src="test/DigitsTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
     <MixedAssignment occurrences="1">
       <code>$result</code>
     </MixedAssignment>
-  </file>
-  <file src="test/DirTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
   </file>
   <file src="test/Encrypt/BlockCipherTest.php">
     <DeprecatedClass occurrences="12">
@@ -2258,21 +1896,14 @@
     <MissingParamType occurrences="1">
       <code>$input</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="2">
-      <code>$fileToEncrypt</code>
-      <code>$tmpDir</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="1">
       <code>returnUnfilteredDataProvider</code>
     </MissingReturnType>
-    <MixedArgument occurrences="4">
+    <PossiblyNullArgument occurrences="2">
       <code>$this-&gt;fileToEncrypt</code>
       <code>$this-&gt;fileToEncrypt</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-    </MixedArgument>
-    <MixedOperand occurrences="21">
-      <code>$this-&gt;tmpDir</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="17">
       <code>$this-&gt;tmpDir</code>
       <code>$this-&gt;tmpDir</code>
       <code>$this-&gt;tmpDir</code>
@@ -2290,10 +1921,7 @@
       <code>$this-&gt;tmpDir</code>
       <code>$this-&gt;tmpDir</code>
       <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-      <code>$this-&gt;tmpDir</code>
-    </MixedOperand>
+    </PossiblyNullOperand>
   </file>
   <file src="test/File/EncryptTest.php">
     <DeprecatedClass occurrences="6">
@@ -2307,70 +1935,66 @@
     <MissingParamType occurrences="1">
       <code>$input</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="3">
-      <code>$fileToEncrypt</code>
-      <code>$testDir</code>
-      <code>$testFile</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="1">
       <code>returnUnfilteredDataProvider</code>
     </MissingReturnType>
-    <MixedArgument occurrences="16">
-      <code>$this-&gt;fileToEncrypt</code>
-      <code>$this-&gt;fileToEncrypt</code>
-      <code>$this-&gt;fileToEncrypt</code>
-      <code>$this-&gt;fileToEncrypt</code>
-      <code>$this-&gt;testDir</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-      <code>$this-&gt;testFile</code>
-    </MixedArgument>
   </file>
   <file src="test/File/LowerCaseTest.php">
     <MissingParamType occurrences="1">
       <code>$input</code>
     </MissingParamType>
-    <MissingPropertyType occurrences="1">
-      <code>$testDir</code>
-    </MissingPropertyType>
     <MissingReturnType occurrences="1">
       <code>returnUnfilteredDataProvider</code>
     </MissingReturnType>
-    <MixedArgument occurrences="2">
+    <PossiblyNullArgument occurrences="7">
       <code>$this-&gt;testDir</code>
       <code>$this-&gt;testDir</code>
-    </MixedArgument>
+      <code>$this-&gt;testFile</code>
+      <code>$this-&gt;testFile</code>
+      <code>$this-&gt;testFile</code>
+      <code>$this-&gt;testFile</code>
+      <code>$this-&gt;testFile</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="1">
+      <code>$this-&gt;testFile</code>
+    </PossiblyNullOperand>
   </file>
   <file src="test/File/RenameTest.php">
     <InvalidScalarArgument occurrences="2">
       <code>1234</code>
       <code>1234</code>
     </InvalidScalarArgument>
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-    <UnusedVariable occurrences="1">
-      <code>$filter</code>
-    </UnusedVariable>
+    <PossiblyNullArgument occurrences="20">
+      <code>$this-&gt;newDir</code>
+      <code>$this-&gt;newDir</code>
+      <code>$this-&gt;newDirFile</code>
+      <code>$this-&gt;newFile</code>
+      <code>$this-&gt;newFile</code>
+      <code>$this-&gt;newFile</code>
+      <code>$this-&gt;newFile</code>
+      <code>$this-&gt;newFile</code>
+      <code>$this-&gt;newFile</code>
+      <code>$this-&gt;newFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;oldFile</code>
+      <code>$this-&gt;origFile</code>
+      <code>$this-&gt;tmpPath</code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand occurrences="2">
+      <code>$this-&gt;tmpPath</code>
+      <code>$this-&gt;tmpPath</code>
+    </PossiblyNullOperand>
   </file>
   <file src="test/File/RenameUploadTest.php">
     <InvalidScalarArgument occurrences="1">
       <code>1234</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="1">
-      <code>removeDir</code>
-    </MissingReturnType>
     <MixedArgument occurrences="5">
       <code>$filter($this-&gt;sourceFile)</code>
       <code>$filter($this-&gt;sourceFile)</code>
@@ -2430,36 +2054,15 @@
     </UnusedClosureParam>
   </file>
   <file src="test/HtmlEntitiesTest.php">
-    <MissingParamType occurrences="3">
-      <code>$errno</code>
-      <code>$errstr</code>
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="2">
-      <code>errorHandler</code>
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
     <MixedArgument occurrences="3">
       <code>$input</code>
       <code>$result</code>
       <code>$result</code>
     </MixedArgument>
-    <MixedArgumentTypeCoercion occurrences="3">
-      <code>[$this, 'errorHandler']</code>
-      <code>[$this, 'errorHandler']</code>
-      <code>[$this, 'errorHandler']</code>
-    </MixedArgumentTypeCoercion>
-    <MixedAssignment occurrences="3">
-      <code>$result</code>
+    <MixedAssignment occurrences="2">
       <code>$result</code>
       <code>$result</code>
     </MixedAssignment>
-    <PossiblyInvalidArgument occurrences="1">
-      <code>$result</code>
-    </PossiblyInvalidArgument>
-    <UnusedVariable occurrences="1">
-      <code>$result</code>
-    </UnusedVariable>
   </file>
   <file src="test/InflectorTest.php">
     <MissingParamType occurrences="1">
@@ -2526,50 +2129,41 @@
       <code>$this-&gt;_context</code>
       <code>$this-&gt;_context</code>
     </UndefinedThisPropertyAssignment>
-    <UnusedVariable occurrences="3">
+    <UnusedVariable occurrences="2">
       <code>$filtered</code>
-      <code>$inflector</code>
       <code>$rule</code>
     </UnusedVariable>
-  </file>
-  <file src="test/MonthSelectTest.php">
-    <MissingReturnType occurrences="1">
-      <code>provideFilter</code>
-    </MissingReturnType>
   </file>
   <file src="test/PregReplaceTest.php">
     <DeprecatedMethod occurrences="1">
       <code>PregReplaceFilter::hasPcreUnicodeSupport()</code>
     </DeprecatedMethod>
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-    <MixedAssignment occurrences="1">
-      <code>$filtered</code>
-    </MixedAssignment>
-    <UnusedVariable occurrences="1">
-      <code>$filtered</code>
-    </UnusedVariable>
   </file>
   <file src="test/RealPathTest.php">
     <InvalidArgument occurrences="1">
       <code>['unknown']</code>
     </InvalidArgument>
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$filter($this-&gt;_filesPath . DIRECTORY_SEPARATOR . $filename)</code>
+    <MixedArgument occurrences="1">
       <code>$input</code>
     </MixedArgument>
   </file>
   <file src="test/StaticFilterTest.php">
+    <DeprecatedClass occurrences="16">
+      <code>StaticFilter::execute('"O\'Reilly"', HtmlEntities::class, ['quotestyle' =&gt; ENT_COMPAT])</code>
+      <code>StaticFilter::execute('"O\'Reilly"', HtmlEntities::class, ['quotestyle' =&gt; ENT_QUOTES])</code>
+      <code>StaticFilter::execute('1234', 'UnknownFilter')</code>
+      <code>StaticFilter::execute('1a2b3c4d', Digits::class)</code>
+      <code>StaticFilter::execute('foo', 'doStuff')</code>
+      <code>StaticFilter::getPluginManager()</code>
+      <code>StaticFilter::getPluginManager()</code>
+      <code>StaticFilter::getPluginManager()</code>
+      <code>StaticFilter::getPluginManager()</code>
+      <code>StaticFilter::setPluginManager($plugins)</code>
+      <code>StaticFilter::setPluginManager($plugins)</code>
+      <code>StaticFilter::setPluginManager($plugins)</code>
+      <code>StaticFilter::setPluginManager(null)</code>
+      <code>StaticFilter::setPluginManager(null)</code>
+    </DeprecatedClass>
     <MissingClosureParamType occurrences="2">
       <code>$value</code>
       <code>$value</code>
@@ -2587,82 +2181,34 @@
       <code>$filter('sample')</code>
       <code>$prefix</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
   </file>
   <file src="test/StringSuffixTest.php">
     <MixedArgument occurrences="2">
       <code>$filter('sample')</code>
       <code>$suffix</code>
     </MixedArgument>
-    <MixedInferredReturnType occurrences="1">
-      <code>array</code>
-    </MixedInferredReturnType>
   </file>
   <file src="test/StringToLowerTest.php">
     <DeprecatedMethod occurrences="1">
       <code>setMethods</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="3">
+    <InvalidArgument occurrences="1">
       <code>$e-&gt;getMessage()</code>
       <code>$e-&gt;getMessage()</code>
       <code>$e-&gt;getMessage()</code>
     </InvalidArgument>
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
   </file>
   <file src="test/StringToUpperTest.php">
     <DeprecatedMethod occurrences="1">
       <code>setMethods</code>
     </DeprecatedMethod>
-    <InvalidArgument occurrences="3">
-      <code>$e-&gt;getMessage()</code>
-      <code>$e-&gt;getMessage()</code>
-      <code>$e-&gt;getMessage()</code>
-    </InvalidArgument>
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
   </file>
   <file src="test/StringTrimTest.php">
-    <MissingParamType occurrences="1">
-      <code>$value</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="5">
-      <code>getNonStringValues</code>
-      <code>testLaminas10891</code>
-      <code>testLaminas170</code>
-      <code>testLaminas7183</code>
-      <code>testLaminas7902</code>
-    </MissingReturnType>
     <MixedArgument occurrences="1">
       <code>$value</code>
     </MixedArgument>
   </file>
-  <file src="test/StripNewlinesTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-  </file>
   <file src="test/StripTagsTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="2">
-      <code>badCommentProvider</code>
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
     <MixedArgument occurrences="2">
       <code>$filtered</code>
       <code>$input</code>
@@ -2686,30 +2232,10 @@
       <code>$value</code>
     </MixedArgument>
   </file>
-  <file src="test/ToFloatTest.php">
-    <MissingReturnType occurrences="2">
-      <code>filterableValuesProvider</code>
-      <code>unfilterableValuesProvider</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/ToIntTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-  </file>
   <file src="test/ToNullTest.php">
     <InvalidScalarArgument occurrences="1">
       <code>true</code>
     </InvalidScalarArgument>
-    <MissingReturnType occurrences="4">
-      <code>combinedTypeTestProvider</code>
-      <code>defaultTestProvider</code>
-      <code>duplicateTypeProvider</code>
-      <code>typeTestProvider</code>
-    </MissingReturnType>
     <MixedArgument occurrences="3">
       <code>$value</code>
       <code>$value</code>
@@ -2729,88 +2255,11 @@
       <code>[$value, $expected]</code>
     </MixedAssignment>
   </file>
-  <file src="test/UpperCaseWordsTest.php">
-    <InvalidArgument occurrences="3">
-      <code>$e-&gt;getMessage()</code>
-      <code>$e-&gt;getMessage()</code>
-      <code>$e-&gt;getMessage()</code>
-    </InvalidArgument>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/UriNormalizeTest.php">
-    <MissingParamType occurrences="6">
-      <code>$expected</code>
-      <code>$expected</code>
-      <code>$input</code>
-      <code>$input</code>
-      <code>$scheme</code>
-      <code>$url</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="3">
-      <code>abnormalUriProvider</code>
-      <code>enforcedSchemeTestcaseProvider</code>
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-    <MixedArgument occurrences="2">
-      <code>$input</code>
-      <code>$url</code>
-    </MixedArgument>
-  </file>
-  <file src="test/WhitelistTest.php">
-    <DeprecatedClass occurrences="1">
-      <code>new WhitelistFilter()</code>
-    </DeprecatedClass>
-  </file>
-  <file src="test/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php">
-    <MissingPropertyType occurrences="1">
-      <code>$reflection</code>
-    </MissingPropertyType>
-    <MixedMethodCall occurrences="1">
-      <code>setValue</code>
-    </MixedMethodCall>
-    <UnevaluatedCode occurrences="1">
-      <code>return;</code>
-    </UnevaluatedCode>
-  </file>
-  <file src="test/Word/CamelCaseToSeparatorTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-  </file>
   <file src="test/Word/CamelCaseToUnderscoreTest.php">
     <MixedAssignment occurrences="2">
       <code>$filtered</code>
       <code>$filtered</code>
     </MixedAssignment>
-  </file>
-  <file src="test/Word/DashToSeparatorTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/Word/SeparatorToCamelCaseTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
-  </file>
-  <file src="test/Word/SeparatorToSeparatorTest.php">
-    <MissingParamType occurrences="1">
-      <code>$input</code>
-    </MissingParamType>
-    <MissingReturnType occurrences="1">
-      <code>returnUnfilteredDataProvider</code>
-    </MissingReturnType>
   </file>
   <file src="test/Word/UnderscoreToCamelCaseTest.php">
     <MixedAssignment occurrences="5">

--- a/test/AbstractUnicodeTest.php
+++ b/test/AbstractUnicodeTest.php
@@ -15,8 +15,7 @@ use function strtolower;
 
 class AbstractUnicodeTest extends TestCase
 {
-    /** @var AbstractUnicode */
-    private $filter;
+    private AbstractUnicode $filter;
 
     protected function setUp(): void
     {

--- a/test/AllowListTest.php
+++ b/test/AllowListTest.php
@@ -24,16 +24,16 @@ class AllowListTest extends TestCase
             'strict' => true,
         ]);
 
-        $this->assertSame(true, $filter->getStrict());
-        $this->assertSame(['test', 1], $filter->getList());
+        self::assertSame(true, $filter->getStrict());
+        self::assertSame(['test', 1], $filter->getList());
     }
 
     public function testConstructorDefaults(): void
     {
         $filter = new AllowListFilter();
 
-        $this->assertSame(false, $filter->getStrict());
-        $this->assertSame([], $filter->getList());
+        self::assertSame(false, $filter->getStrict());
+        self::assertSame([], $filter->getList());
     }
 
     public function testWithPluginManager(): void
@@ -41,13 +41,13 @@ class AllowListTest extends TestCase
         $pluginManager = new FilterPluginManager(new ServiceManager());
         $filter        = $pluginManager->get('AllowList');
 
-        $this->assertInstanceOf(AllowListFilter::class, $filter);
+        self::assertInstanceOf(AllowListFilter::class, $filter);
     }
 
     public function testNullListShouldThrowException(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $filter = new AllowListFilter([
+        new AllowListFilter([
             'list' => null,
         ]);
     }
@@ -59,7 +59,7 @@ class AllowListTest extends TestCase
         $filter = new AllowListFilter([
             'list' => $obj,
         ]);
-        $this->assertSame($array, $filter->getList());
+        self::assertSame($array, $filter->getList());
     }
 
     public function testSetStrictShouldCastToBoolean(): void
@@ -67,26 +67,22 @@ class AllowListTest extends TestCase
         $filter = new AllowListFilter([
             'strict' => 1,
         ]);
-        $this->assertSame(true, $filter->getStrict());
+        self::assertSame(true, $filter->getStrict());
     }
 
     /**
-     * @param mixed $value
-     * @param bool  $expected
      * @dataProvider defaultTestProvider
      */
-    public function testDefault($value, $expected): void
+    public function testDefault(mixed $value): void
     {
         $filter = new AllowListFilter();
-        $this->assertSame($expected, $filter->filter($value));
+        self::assertNull($filter->filter($value));
     }
 
     /**
-     * @param bool $strict
-     * @param array $testData
      * @dataProvider listTestProvider
      */
-    public function testList($strict, $list, $testData): void
+    public function testList(bool $strict, array $list, array $testData): void
     {
         $filter = new AllowListFilter([
             'strict' => $strict,
@@ -101,10 +97,11 @@ class AllowListTest extends TestCase
                 var_export($expected, true),
                 $strict
             );
-            $this->assertSame($expected, $filter->filter($value), $message);
+            self::assertSame($expected, $filter->filter($value), $message);
         }
     }
 
+    /** @return list<array{0: mixed, 1: null}> */
     public static function defaultTestProvider(): array
     {
         return [
@@ -116,6 +113,7 @@ class AllowListTest extends TestCase
         ];
     }
 
+    /** @return list<array{0: bool, 1: array, 2: array}> */
     public static function listTestProvider(): array
     {
         return [

--- a/test/BaseNameTest.php
+++ b/test/BaseNameTest.php
@@ -21,11 +21,12 @@ class BaseNameTest extends TestCase
             '/path/to/filename.ext' => 'filename.ext',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -42,10 +43,10 @@ class BaseNameTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new BaseNameFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/BlacklistTest.php
+++ b/test/BlacklistTest.php
@@ -15,7 +15,7 @@ class BlacklistTest extends TestCase
     public function testConstructor(): void
     {
         $filter = new BlacklistFilter();
-        $this->assertInstanceOf(DenyList::class, $filter);
+        self::assertInstanceOf(DenyList::class, $filter);
     }
 
     public function testWithPluginManager(): void
@@ -23,6 +23,6 @@ class BlacklistTest extends TestCase
         $pluginManager = new FilterPluginManager(new ServiceManager());
         $filter        = $pluginManager->get('blacklist');
 
-        $this->assertInstanceOf(DenyList::class, $filter);
+        self::assertInstanceOf(DenyList::class, $filter);
     }
 }

--- a/test/BooleanTest.php
+++ b/test/BooleanTest.php
@@ -21,46 +21,41 @@ class BooleanTest extends TestCase
             'casting' => false,
         ]);
 
-        $this->assertSame(BooleanFilter::TYPE_INTEGER, $filter->getType());
-        $this->assertFalse($filter->getCasting());
+        self::assertSame(BooleanFilter::TYPE_INTEGER, $filter->getType());
+        self::assertFalse($filter->getCasting());
     }
 
     public function testConstructorParams(): void
     {
         $filter = new BooleanFilter(BooleanFilter::TYPE_INTEGER, false);
 
-        $this->assertSame(BooleanFilter::TYPE_INTEGER, $filter->getType());
-        $this->assertFalse($filter->getCasting());
+        self::assertSame(BooleanFilter::TYPE_INTEGER, $filter->getType());
+        self::assertFalse($filter->getCasting());
     }
 
     /**
-     * @param mixed $value
-     * @param bool  $expected
      * @dataProvider defaultTestProvider
      */
-    public function testDefault($value, $expected): void
+    public function testDefault(mixed $value, bool $expected): void
     {
         $filter = new BooleanFilter();
-        $this->assertSame($expected, $filter->filter($value));
+        self::assertSame($expected, $filter->filter($value));
     }
 
     /**
-     * @param mixed $value
-     * @param bool  $expected
      * @dataProvider noCastingTestProvider
      */
-    public function testNoCasting($value, $expected): void
+    public function testNoCasting(mixed $value, mixed $expected): void
     {
         $filter = new BooleanFilter('all', false);
-        $this->assertSame($expected, $filter->filter($value));
+        self::assertSame($expected, $filter->filter($value));
     }
 
     /**
-     * @param int $type
-     * @param array $testData
+     * @param array{0: mixed, 1: mixed} $testData
      * @dataProvider typeTestProvider
      */
-    public function testTypes($type, $testData): void
+    public function testTypes(int $type, array $testData): void
     {
         $filter = new BooleanFilter($type);
         foreach ($testData as $data) {
@@ -72,7 +67,7 @@ class BooleanTest extends TestCase
                 var_export($expected, true),
                 $type
             );
-            $this->assertSame($expected, $filter->filter($value), $message);
+            self::assertSame($expected, $filter->filter($value), $message);
         }
     }
 
@@ -94,7 +89,7 @@ class BooleanTest extends TestCase
                     var_export($expected, true),
                     var_export($type, true)
                 );
-                $this->assertSame($expected, $filter->filter($value), $message);
+                self::assertSame($expected, $filter->filter($value), $message);
             }
         }
     }
@@ -113,10 +108,10 @@ class BooleanTest extends TestCase
             ],
         ]);
 
-        $this->assertTrue($filter->filter('yes'));
-        $this->assertTrue($filter->filter('yay'));
-        $this->assertFalse($filter->filter('n'));
-        $this->assertFalse($filter->filter('nay'));
+        self::assertTrue($filter->filter('yes'));
+        self::assertTrue($filter->filter('yay'));
+        self::assertFalse($filter->filter('n'));
+        self::assertFalse($filter->filter('nay'));
     }
 
     public function testSettingFalseType(): void
@@ -130,7 +125,7 @@ class BooleanTest extends TestCase
     public function testGettingDefaultType(): void
     {
         $filter = new BooleanFilter();
-        $this->assertSame(127, $filter->getType());
+        self::assertSame(127, $filter->getType());
     }
 
     /**
@@ -140,13 +135,14 @@ class BooleanTest extends TestCase
      * @param mixed $type Type to double initialize
      * @dataProvider duplicateProvider
      */
-    public function testDuplicateTypesWorkProperly($type, $expected): void
+    public function testDuplicateTypesWorkProperly(int|string $type, int $expected): void
     {
         $filter = new BooleanFilter([$type, $type]);
-        $this->assertSame($expected, $filter->getType());
+        self::assertSame($expected, $filter->getType());
     }
 
-    public static function defaultTestProvider()
+    /** @return list<array{0: mixed, 1: bool}> */
+    public static function defaultTestProvider(): array
     {
         return [
             [false, false],
@@ -169,7 +165,8 @@ class BooleanTest extends TestCase
         ];
     }
 
-    public static function noCastingTestProvider()
+    /** @return list<array{0: mixed, 1: mixed}> */
+    public static function noCastingTestProvider(): array
     {
         return [
             [false, false],
@@ -193,7 +190,8 @@ class BooleanTest extends TestCase
         ];
     }
 
-    public static function typeTestProvider()
+    /** @return list<array{0: int, 1: mixed[]}> */
+    public static function typeTestProvider(): array
     {
         return [
             [
@@ -443,7 +441,7 @@ class BooleanTest extends TestCase
         ];
     }
 
-    public static function combinedTypeTestProvider()
+    public static function combinedTypeTestProvider(): array
     {
         return [
             [
@@ -484,7 +482,8 @@ class BooleanTest extends TestCase
         ];
     }
 
-    public static function duplicateProvider()
+    /** @return list<array{0: int|string, 1: int}> */
+    public static function duplicateProvider(): array
     {
         return [
             [BooleanFilter::TYPE_BOOLEAN, BooleanFilter::TYPE_BOOLEAN],

--- a/test/CallbackTest.php
+++ b/test/CallbackTest.php
@@ -12,7 +12,7 @@ class CallbackTest extends TestCase
     public function testObjectCallback(): void
     {
         $filter = new CallbackFilter([$this, 'objectCallback']);
-        $this->assertSame('objectCallback-test', $filter('test'));
+        self::assertSame('objectCallback-test', $filter('test'));
     }
 
     public function testConstructorWithOptions(): void
@@ -22,7 +22,7 @@ class CallbackTest extends TestCase
             'callback_params' => 0,
         ]);
 
-        $this->assertSame('objectCallbackWithParams-test-0', $filter('test'));
+        self::assertSame('objectCallbackWithParams-test-0', $filter('test'));
     }
 
     public function testStaticCallback(): void
@@ -30,59 +30,59 @@ class CallbackTest extends TestCase
         $filter = new CallbackFilter(
             [self::class, 'staticCallback']
         );
-        $this->assertSame('staticCallback-test', $filter('test'));
+        self::assertSame('staticCallback-test', $filter('test'));
     }
 
     public function testStringClassCallback(): void
     {
         $filter = new CallbackFilter(self::class);
-        $this->assertSame('stringClassCallback-test', $filter('test'));
+        self::assertSame('stringClassCallback-test', $filter('test'));
     }
 
     public function testSettingDefaultOptions(): void
     {
         $filter = new CallbackFilter([$this, 'objectCallback'], 'param');
-        $this->assertSame(['param'], $filter->getCallbackParams());
-        $this->assertSame('objectCallback-test', $filter('test'));
+        self::assertSame(['param'], $filter->getCallbackParams());
+        self::assertSame('objectCallback-test', $filter('test'));
     }
 
     public function testSettingDefaultOptionsAfterwards(): void
     {
         $filter = new CallbackFilter([$this, 'objectCallback']);
         $filter->setCallbackParams('param');
-        $this->assertSame(['param'], $filter->getCallbackParams());
-        $this->assertSame('objectCallback-test', $filter('test'));
+        self::assertSame(['param'], $filter->getCallbackParams());
+        self::assertSame('objectCallback-test', $filter('test'));
     }
 
     public function testCallbackWithStringParameter(): void
     {
         $filter = new CallbackFilter('strrev');
-        $this->assertSame('!olleH', $filter('Hello!'));
+        self::assertSame('!olleH', $filter('Hello!'));
     }
 
     public function testCallbackWithArrayParameters(): void
     {
         $filter = new CallbackFilter('strrev');
-        $this->assertSame('!olleH', $filter('Hello!'));
+        self::assertSame('!olleH', $filter('Hello!'));
     }
 
-    public function objectCallback($value)
+    public function objectCallback(string $value): string
     {
         return 'objectCallback-' . $value;
     }
 
-    public static function staticCallback($value)
+    public static function staticCallback(string $value): string
     {
         return 'staticCallback-' . $value;
     }
 
-    public function __invoke($value)
+    public function __invoke(string $value): string
     {
         return 'stringClassCallback-' . $value;
     }
 
-    public function objectCallbackWithParams($value, $param = null)
+    public function objectCallbackWithParams(string $value, int|string|null $param = null): string
     {
-        return 'objectCallbackWithParams-' . $value . '-' . $param;
+        return 'objectCallbackWithParams-' . $value . '-' . (string) $param;
     }
 }

--- a/test/Compress/Bz2Test.php
+++ b/test/Compress/Bz2Test.php
@@ -17,12 +17,12 @@ use function unlink;
 
 class Bz2Test extends TestCase
 {
-    public $target;
+    public string $target;
 
     public function setUp(): void
     {
         if (! extension_loaded('bz2')) {
-            $this->markTestSkipped('This adapter needs the bz2 extension');
+            self::markTestSkipped('This adapter needs the bz2 extension');
         }
 
         $this->target = sprintf('%s/%s.bz2', sys_get_temp_dir(), uniqid('laminasilter'));
@@ -43,10 +43,10 @@ class Bz2Test extends TestCase
         $filter = new Bz2Compression();
 
         $content = $filter->compress('compress me');
-        $this->assertNotEquals('compress me', $content);
+        self::assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -57,20 +57,20 @@ class Bz2Test extends TestCase
     public function testBz2GetSetOptions()
     {
         $filter = new Bz2Compression();
-        $this->assertSame(['blocksize' => 4, 'archive' => null], $filter->getOptions());
+        self::assertSame(['blocksize' => 4, 'archive' => null], $filter->getOptions());
 
-        $this->assertSame(4, $filter->getOptions('blocksize'));
+        self::assertSame(4, $filter->getOptions('blocksize'));
 
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['blocksize' => 6]);
-        $this->assertSame(6, $filter->getOptions('blocksize'));
+        self::assertSame(6, $filter->getOptions('blocksize'));
 
         $filter->setOptions(['archive' => 'test.txt']);
-        $this->assertSame('test.txt', $filter->getOptions('archive'));
+        self::assertSame('test.txt', $filter->getOptions('archive'));
 
         $filter->setOptions(['nooption' => 0]);
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
     }
 
     /**
@@ -81,7 +81,7 @@ class Bz2Test extends TestCase
     public function testBz2GetSetOptionsInConstructor()
     {
         $filter2 = new Bz2Compression(['blocksize' => 8]);
-        $this->assertSame(['blocksize' => 8, 'archive' => null], $filter2->getOptions());
+        self::assertSame(['blocksize' => 8, 'archive' => null], $filter2->getOptions());
     }
 
     /**
@@ -92,9 +92,9 @@ class Bz2Test extends TestCase
     public function testBz2GetSetBlocksize()
     {
         $filter = new Bz2Compression();
-        $this->assertSame(4, $filter->getBlocksize());
+        self::assertSame(4, $filter->getBlocksize());
         $filter->setBlocksize(6);
-        $this->assertSame(6, $filter->getOptions('blocksize'));
+        self::assertSame(6, $filter->getOptions('blocksize'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('must be between');
@@ -109,10 +109,10 @@ class Bz2Test extends TestCase
     public function testBz2GetSetArchive()
     {
         $filter = new Bz2Compression();
-        $this->assertSame(null, $filter->getArchive());
+        self::assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getArchive());
-        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
+        self::assertSame('Testfile.txt', $filter->getArchive());
+        self::assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -127,16 +127,16 @@ class Bz2Test extends TestCase
         $filter->setArchive($archive);
 
         $content = $filter->compress('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new Bz2Compression();
         $content2 = $filter2->decompress($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
 
         $filter3 = new Bz2Compression();
         $filter3->setArchive($archive);
         $content3 = $filter3->decompress(null);
-        $this->assertSame('compress me', $content3);
+        self::assertSame('compress me', $content3);
     }
 
     /**
@@ -147,7 +147,7 @@ class Bz2Test extends TestCase
     public function testBz2ToString()
     {
         $filter = new Bz2Compression();
-        $this->assertSame('Bz2', $filter->toString());
+        self::assertSame('Bz2', $filter->toString());
     }
 
     /**
@@ -162,11 +162,11 @@ class Bz2Test extends TestCase
         $filter->setArchive($archive);
 
         $content = $filter->compress('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new Bz2Compression();
         $content2 = $filter2->decompress($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
     }
 
     public function testBz2DecompressNullValueIsAccepted()
@@ -174,6 +174,6 @@ class Bz2Test extends TestCase
         $filter = new Bz2Compression();
         $result = $filter->decompress(null);
 
-        $this->assertEmpty($result);
+        self::assertEmpty($result);
     }
 }

--- a/test/Compress/GzTest.php
+++ b/test/Compress/GzTest.php
@@ -17,12 +17,12 @@ use function unlink;
 
 class GzTest extends TestCase
 {
-    public $target;
+    public string $target;
 
     public function setUp(): void
     {
         if (! extension_loaded('zlib')) {
-            $this->markTestSkipped('This adapter needs the zlib extension');
+            self::markTestSkipped('This adapter needs the zlib extension');
         }
 
         $this->target = sprintf('%s/%s.gz', sys_get_temp_dir(), uniqid('laminasilter'));
@@ -43,10 +43,10 @@ class GzTest extends TestCase
         $filter = new GzCompression();
 
         $content = $filter->compress('compress me');
-        $this->assertNotEquals('compress me', $content);
+        self::assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -55,22 +55,22 @@ class GzTest extends TestCase
     public function testGzGetSetOptions(): void
     {
         $filter = new GzCompression();
-        $this->assertSame(['level' => 9, 'mode' => 'compress', 'archive' => null], $filter->getOptions());
+        self::assertSame(['level' => 9, 'mode' => 'compress', 'archive' => null], $filter->getOptions());
 
-        $this->assertSame(9, $filter->getOptions('level'));
+        self::assertSame(9, $filter->getOptions('level'));
 
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooption' => 'foo']);
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['level' => 6]);
-        $this->assertSame(6, $filter->getOptions('level'));
+        self::assertSame(6, $filter->getOptions('level'));
 
         $filter->setOptions(['mode' => 'deflate']);
-        $this->assertSame('deflate', $filter->getOptions('mode'));
+        self::assertSame('deflate', $filter->getOptions('mode'));
 
         $filter->setOptions(['archive' => 'test.txt']);
-        $this->assertSame('test.txt', $filter->getOptions('archive'));
+        self::assertSame('test.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -79,7 +79,7 @@ class GzTest extends TestCase
     public function testGzGetSetOptionsInConstructor(): void
     {
         $filter2 = new GzCompression(['level' => 8]);
-        $this->assertSame(['level' => 8, 'mode' => 'compress', 'archive' => null], $filter2->getOptions());
+        self::assertSame(['level' => 8, 'mode' => 'compress', 'archive' => null], $filter2->getOptions());
     }
 
     /**
@@ -88,9 +88,9 @@ class GzTest extends TestCase
     public function testGzGetSetLevel(): void
     {
         $filter = new GzCompression();
-        $this->assertSame(9, $filter->getLevel());
+        self::assertSame(9, $filter->getLevel());
         $filter->setLevel(6);
-        $this->assertSame(6, $filter->getOptions('level'));
+        self::assertSame(6, $filter->getOptions('level'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('must be between');
@@ -103,9 +103,9 @@ class GzTest extends TestCase
     public function testGzGetSetMode(): void
     {
         $filter = new GzCompression();
-        $this->assertSame('compress', $filter->getMode());
+        self::assertSame('compress', $filter->getMode());
         $filter->setMode('deflate');
-        $this->assertSame('deflate', $filter->getOptions('mode'));
+        self::assertSame('deflate', $filter->getOptions('mode'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('mode not supported');
@@ -118,10 +118,10 @@ class GzTest extends TestCase
     public function testGzGetSetArchive(): void
     {
         $filter = new GzCompression();
-        $this->assertSame(null, $filter->getArchive());
+        self::assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getArchive());
-        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
+        self::assertSame('Testfile.txt', $filter->getArchive());
+        self::assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -134,16 +134,16 @@ class GzTest extends TestCase
         $filter->setArchive($archive);
 
         $content = $filter->compress('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new GzCompression();
         $content2 = $filter2->decompress($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
 
         $filter3 = new GzCompression();
         $filter3->setArchive($archive);
         $content3 = $filter3->decompress(null);
-        $this->assertSame('compress me', $content3);
+        self::assertSame('compress me', $content3);
     }
 
     /**
@@ -154,10 +154,10 @@ class GzTest extends TestCase
         $filter = new GzCompression(['mode' => 'deflate']);
 
         $content = $filter->compress('compress me');
-        $this->assertNotEquals('compress me', $content);
+        self::assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -166,7 +166,7 @@ class GzTest extends TestCase
     public function testGzToString(): void
     {
         $filter = new GzCompression();
-        $this->assertSame('Gz', $filter->toString());
+        self::assertSame('Gz', $filter->toString());
     }
 
     public function testGzDecompressNullThrowsRuntimeException(): void

--- a/test/Compress/RarTest.php
+++ b/test/Compress/RarTest.php
@@ -24,12 +24,12 @@ use const DIRECTORY_SEPARATOR;
 
 class RarTest extends TestCase
 {
-    public $tmp;
+    public string $tmp;
 
     public function setUp(): void
     {
         if (! extension_loaded('rar')) {
-            $this->markTestSkipped('This adapter needs the rar extension');
+            self::markTestSkipped('This adapter needs the rar extension');
         }
 
         $this->tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('laminasilter');
@@ -97,15 +97,15 @@ class RarTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertSame(
+        self::assertSame(
             dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'compressed.rar',
             $content
         );
 
         $content = $filter->decompress($content);
-        $this->assertTrue($content);
+        self::assertTrue($content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -114,7 +114,7 @@ class RarTest extends TestCase
     public function testRarGetSetOptions(): void
     {
         $filter = new RarCompression();
-        $this->assertSame(
+        self::assertSame(
             [
                 'archive'  => null,
                 'callback' => null,
@@ -124,14 +124,14 @@ class RarTest extends TestCase
             $filter->getOptions()
         );
 
-        $this->assertSame(null, $filter->getOptions('archive'));
+        self::assertSame(null, $filter->getOptions('archive'));
 
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooption' => 'foo']);
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['archive' => 'temp.txt']);
-        $this->assertSame('temp.txt', $filter->getOptions('archive'));
+        self::assertSame('temp.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -140,10 +140,10 @@ class RarTest extends TestCase
     public function testRarGetSetArchive(): void
     {
         $filter = new RarCompression();
-        $this->assertSame(null, $filter->getArchive());
+        self::assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getArchive());
-        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
+        self::assertSame('Testfile.txt', $filter->getArchive());
+        self::assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -152,13 +152,13 @@ class RarTest extends TestCase
     public function testRarGetSetPassword(): void
     {
         $filter = new RarCompression();
-        $this->assertSame(null, $filter->getPassword());
+        self::assertSame(null, $filter->getPassword());
         $filter->setPassword('test');
-        $this->assertSame('test', $filter->getPassword());
-        $this->assertSame('test', $filter->getOptions('password'));
+        self::assertSame('test', $filter->getPassword());
+        self::assertSame('test', $filter->getOptions('password'));
         $filter->setOptions(['password' => 'test2']);
-        $this->assertSame('test2', $filter->getPassword());
-        $this->assertSame('test2', $filter->getOptions('password'));
+        self::assertSame('test2', $filter->getPassword());
+        self::assertSame('test2', $filter->getOptions('password'));
     }
 
     /**
@@ -167,10 +167,10 @@ class RarTest extends TestCase
     public function testRarGetSetTarget(): void
     {
         $filter = new RarCompression();
-        $this->assertSame('.', $filter->getTarget());
+        self::assertSame('.', $filter->getTarget());
         $filter->setTarget('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getTarget());
-        $this->assertSame('Testfile.txt', $filter->getOptions('target'));
+        self::assertSame('Testfile.txt', $filter->getTarget());
+        self::assertSame('Testfile.txt', $filter->getOptions('target'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not exist');
@@ -186,7 +186,7 @@ class RarTest extends TestCase
 
         $callback = [self::class, 'rarCompress'];
         $filter->setCallback($callback);
-        $this->assertSame($callback, $filter->getCallback());
+        self::assertSame($callback, $filter->getCallback());
     }
 
     public function testSettingCallbackThrowsExceptionOnMissingCallback(): void
@@ -222,15 +222,15 @@ class RarTest extends TestCase
         file_put_contents($this->tmp . '/zipextracted.txt', 'compress me');
 
         $content = $filter->compress($this->tmp . '/zipextracted.txt');
-        $this->assertSame(
+        self::assertSame(
             dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'compressed.rar',
             $content
         );
 
         $content = $filter->decompress($content);
-        $this->assertTrue($content);
+        self::assertTrue($content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -246,14 +246,14 @@ class RarTest extends TestCase
             ]
         );
         $content = $filter->compress(dirname(__DIR__) . '/_files/Compress');
-        $this->assertSame(
+        self::assertSame(
             dirname(__DIR__) . DIRECTORY_SEPARATOR . '_files' . DIRECTORY_SEPARATOR . 'compressed.rar',
             $content
         );
 
         mkdir($this->tmp . '/_compress');
         $content = $filter->decompress($content);
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $base = $this->tmp
             . DIRECTORY_SEPARATOR
@@ -261,10 +261,10 @@ class RarTest extends TestCase
             . DIRECTORY_SEPARATOR
             . 'Compress'
             . DIRECTORY_SEPARATOR;
-        $this->assertFileExists($base);
-        $this->assertFileExists($base . 'zipextracted.txt');
-        $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
-        $this->assertFileExists(
+        self::assertFileExists($base);
+        self::assertFileExists($base . 'zipextracted.txt');
+        self::assertFileExists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
+        self::assertFileExists(
             $base . 'First' . DIRECTORY_SEPARATOR . 'Second' . DIRECTORY_SEPARATOR . 'zipextracted.txt'
         );
     }
@@ -275,7 +275,7 @@ class RarTest extends TestCase
     public function testRarToString(): void
     {
         $filter = new RarCompression();
-        $this->assertSame('Rar', $filter->toString());
+        self::assertSame('Rar', $filter->toString());
     }
 
     /**

--- a/test/Compress/SnappyTest.php
+++ b/test/Compress/SnappyTest.php
@@ -19,7 +19,7 @@ class SnappyTest extends TestCase
     public function setUp(): void
     {
         if (! extension_loaded('snappy')) {
-            $this->markTestSkipped('This adapter needs the snappy extension');
+            self::markTestSkipped('This adapter needs the snappy extension');
         }
     }
 
@@ -31,10 +31,10 @@ class SnappyTest extends TestCase
         $filter = new SnappyCompression();
 
         $content = $filter->compress('compress me');
-        $this->assertNotEquals('compress me', $content);
+        self::assertNotEquals('compress me', $content);
 
         $content = $filter->decompress($content);
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -50,7 +50,7 @@ class SnappyTest extends TestCase
         $content = $filter->compress([]);
         restore_error_handler();
 
-        $this->assertNull($content);
+        self::assertNull($content);
     }
 
     /**
@@ -62,7 +62,7 @@ class SnappyTest extends TestCase
 
         $content = $filter->compress(false);
         $content = $filter->decompress($content);
-        $this->assertSame('', $content, 'Snappy failed to decompress empty string.');
+        self::assertSame('', $content, 'Snappy failed to decompress empty string.');
     }
 
     /**
@@ -88,7 +88,7 @@ class SnappyTest extends TestCase
     public function testSnappyToString(): void
     {
         $filter = new SnappyCompression();
-        $this->assertSame('Snappy', $filter->toString());
+        self::assertSame('Snappy', $filter->toString());
     }
 
     /**

--- a/test/Compress/TarLoadArchiveTarTest.php
+++ b/test/Compress/TarLoadArchiveTarTest.php
@@ -27,7 +27,7 @@ class TarLoadArchiveTarTest extends TestCase
 
         if (class_exists('Archive_Tar')) {
             restore_error_handler();
-            $this->markTestSkipped('PEAR Archive_Tar is present; skipping test that expects its absence');
+            self::markTestSkipped('PEAR Archive_Tar is present; skipping test that expects its absence');
         }
         restore_error_handler();
 

--- a/test/Compress/TarTest.php
+++ b/test/Compress/TarTest.php
@@ -27,7 +27,7 @@ use const DIRECTORY_SEPARATOR;
 
 class TarTest extends TestCase
 {
-    public $tmp;
+    public string $tmp;
 
     public function setUp(): void
     {
@@ -76,15 +76,15 @@ class TarTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertSame(
+        self::assertSame(
             $this->tmp . DIRECTORY_SEPARATOR . 'compressed.tar',
             $content
         );
 
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -93,7 +93,7 @@ class TarTest extends TestCase
     public function testTarGetSetOptions(): void
     {
         $filter = new TarCompression();
-        $this->assertSame(
+        self::assertSame(
             [
                 'archive' => null,
                 'target'  => '.',
@@ -102,14 +102,14 @@ class TarTest extends TestCase
             $filter->getOptions()
         );
 
-        $this->assertSame(null, $filter->getOptions('archive'));
+        self::assertSame(null, $filter->getOptions('archive'));
 
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooptions' => 'foo']);
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['archive' => 'temp.txt']);
-        $this->assertSame('temp.txt', $filter->getOptions('archive'));
+        self::assertSame('temp.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -118,10 +118,10 @@ class TarTest extends TestCase
     public function testTarGetSetArchive(): void
     {
         $filter = new TarCompression();
-        $this->assertSame(null, $filter->getArchive());
+        self::assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getArchive());
-        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
+        self::assertSame('Testfile.txt', $filter->getArchive());
+        self::assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -130,10 +130,10 @@ class TarTest extends TestCase
     public function testTarGetSetTarget(): void
     {
         $filter = new TarCompression();
-        $this->assertSame('.', $filter->getTarget());
+        self::assertSame('.', $filter->getTarget());
         $filter->setTarget('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getTarget());
-        $this->assertSame('Testfile.txt', $filter->getOptions('target'));
+        self::assertSame('Testfile.txt', $filter->getTarget());
+        self::assertSame('Testfile.txt', $filter->getOptions('target'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not exist');
@@ -154,15 +154,15 @@ class TarTest extends TestCase
         file_put_contents($this->tmp . '/zipextracted.txt', 'compress me');
 
         $content = $filter->compress($this->tmp . '/zipextracted.txt');
-        $this->assertSame(
+        self::assertSame(
             $this->tmp . DIRECTORY_SEPARATOR . 'compressed.tar',
             $content
         );
 
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -177,7 +177,7 @@ class TarTest extends TestCase
             ]
         );
         $content = $filter->compress(dirname(__DIR__) . '/_files/Compress');
-        $this->assertSame(
+        self::assertSame(
             $this->tmp . DIRECTORY_SEPARATOR . 'compressed.tar',
             $content
         );
@@ -196,7 +196,7 @@ class TarTest extends TestCase
             $filter->setArchive($archive);
             $filter->setMode($mode);
             $content = $filter->compress('compress me');
-            $this->assertSame($archive, $content);
+            self::assertSame($archive, $content);
         }
     }
 
@@ -206,7 +206,7 @@ class TarTest extends TestCase
     public function testTarToString(): void
     {
         $filter = new TarCompression();
-        $this->assertSame('Tar', $filter->toString());
+        self::assertSame('Tar', $filter->toString());
     }
 
     /**

--- a/test/Compress/ZipTest.php
+++ b/test/Compress/ZipTest.php
@@ -24,10 +24,12 @@ use const DIRECTORY_SEPARATOR;
 
 class ZipTest extends TestCase
 {
+    private string $tmp;
+
     public function setUp(): void
     {
         if (! extension_loaded('zip')) {
-            $this->markTestSkipped('This adapter needs the zip extension');
+            self::markTestSkipped('This adapter needs the zip extension');
         }
 
         $this->tmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . str_replace('\\', '_', self::class);
@@ -104,7 +106,7 @@ class ZipTest extends TestCase
     public function testBasicUsage(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
-            $this->markTestSkipped('ZIP compression tests are currently disabled');
+            self::markTestSkipped('ZIP compression tests are currently disabled');
         }
 
         $filter = new ZipCompression(
@@ -115,12 +117,12 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -129,16 +131,16 @@ class ZipTest extends TestCase
     public function testZipGetSetOptions(): void
     {
         $filter = new ZipCompression();
-        $this->assertSame(['archive' => null, 'target' => null], $filter->getOptions());
+        self::assertSame(['archive' => null, 'target' => null], $filter->getOptions());
 
-        $this->assertSame(null, $filter->getOptions('archive'));
+        self::assertSame(null, $filter->getOptions('archive'));
 
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
         $filter->setOptions(['nooption' => 'foo']);
-        $this->assertNull($filter->getOptions('nooption'));
+        self::assertNull($filter->getOptions('nooption'));
 
         $filter->setOptions(['archive' => 'temp.txt']);
-        $this->assertSame('temp.txt', $filter->getOptions('archive'));
+        self::assertSame('temp.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -147,10 +149,10 @@ class ZipTest extends TestCase
     public function testZipGetSetArchive(): void
     {
         $filter = new ZipCompression();
-        $this->assertSame(null, $filter->getArchive());
+        self::assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getArchive());
-        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
+        self::assertSame('Testfile.txt', $filter->getArchive());
+        self::assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -159,10 +161,10 @@ class ZipTest extends TestCase
     public function testZipGetSetTarget(): void
     {
         $filter = new ZipCompression();
-        $this->assertNull($filter->getTarget());
+        self::assertNull($filter->getTarget());
         $filter->setTarget('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getTarget());
-        $this->assertSame('Testfile.txt', $filter->getOptions('target'));
+        self::assertSame('Testfile.txt', $filter->getTarget());
+        self::assertSame('Testfile.txt', $filter->getOptions('target'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not exist');
@@ -175,7 +177,7 @@ class ZipTest extends TestCase
     public function testZipCompressFile(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
-            $this->markTestSkipped('ZIP compression tests are currently disabled');
+            self::markTestSkipped('ZIP compression tests are currently disabled');
         }
 
         $filter = new ZipCompression(
@@ -187,12 +189,12 @@ class ZipTest extends TestCase
         file_put_contents($this->tmp . '/zipextracted.txt', 'compress me');
 
         $content = $filter->compress($this->tmp . '/zipextracted.txt');
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zipextracted.txt');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -201,7 +203,7 @@ class ZipTest extends TestCase
     public function testCompressNonExistingTargetFile(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
-            $this->markTestSkipped('ZIP compression tests are currently disabled');
+            self::markTestSkipped('ZIP compression tests are currently disabled');
         }
 
         $filter = new ZipCompression(
@@ -212,12 +214,12 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/zip.tmp');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -226,7 +228,7 @@ class ZipTest extends TestCase
     public function testZipCompressDirectory(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
-            $this->markTestSkipped('ZIP compression tests are currently disabled');
+            self::markTestSkipped('ZIP compression tests are currently disabled');
         }
 
         $filter  = new ZipCompression(
@@ -236,21 +238,21 @@ class ZipTest extends TestCase
             ]
         );
         $content = $filter->compress($this->tmp . '/Compress');
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         mkdir($this->tmp . DIRECTORY_SEPARATOR . '_compress');
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . '_compress'
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . '_compress'
                             . DIRECTORY_SEPARATOR, $content);
 
         $base = $this->tmp . DIRECTORY_SEPARATOR . '_compress' . DIRECTORY_SEPARATOR . 'Compress' . DIRECTORY_SEPARATOR;
-        $this->assertFileExists($base);
-        $this->assertFileExists($base . 'zipextracted.txt');
-        $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
-        $this->assertFileExists($base . 'First' . DIRECTORY_SEPARATOR
+        self::assertFileExists($base);
+        self::assertFileExists($base . 'zipextracted.txt');
+        self::assertFileExists($base . 'First' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
+        self::assertFileExists($base . 'First' . DIRECTORY_SEPARATOR
                           . 'Second' . DIRECTORY_SEPARATOR . 'zipextracted.txt');
         $content = file_get_contents($this->tmp . '/Compress/zipextracted.txt');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -259,13 +261,13 @@ class ZipTest extends TestCase
     public function testZipToString(): void
     {
         $filter = new ZipCompression();
-        $this->assertSame('Zip', $filter->toString());
+        self::assertSame('Zip', $filter->toString());
     }
 
     public function testDecompressWillThrowExceptionWhenDecompressingWithNoTarget(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
-            $this->markTestSkipped('ZIP compression tests are currently disabled');
+            self::markTestSkipped('ZIP compression tests are currently disabled');
         }
 
         $filter = new ZipCompression(
@@ -276,7 +278,7 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $filter  = new ZipCompression(
             [
@@ -285,9 +287,9 @@ class ZipTest extends TestCase
             ]
         );
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/_compress');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 
     /**
@@ -297,7 +299,7 @@ class ZipTest extends TestCase
     public function testDecompressWhenNoArchieveInClass(): void
     {
         if (! getenv('TESTS_LAMINAS_FILTER_COMPRESS_ZIP_ENABLED')) {
-            $this->markTestSkipped('ZIP compression tests are currently disabled');
+            self::markTestSkipped('ZIP compression tests are currently disabled');
         }
 
         $filter = new ZipCompression(
@@ -308,7 +310,7 @@ class ZipTest extends TestCase
         );
 
         $content = $filter->compress('compress me');
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR . 'compressed.zip', $content);
 
         $filter  = new ZipCompression(
             [
@@ -316,8 +318,8 @@ class ZipTest extends TestCase
             ]
         );
         $content = $filter->decompress($content);
-        $this->assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
+        self::assertSame($this->tmp . DIRECTORY_SEPARATOR, $content);
         $content = file_get_contents($this->tmp . '/_compress');
-        $this->assertSame('compress me', $content);
+        self::assertSame('compress me', $content);
     }
 }

--- a/test/CompressTest.php
+++ b/test/CompressTest.php
@@ -23,12 +23,12 @@ use function unlink;
 
 class CompressTest extends TestCase
 {
-    public $tmpDir;
+    private string $tmpDir;
 
     public function setUp(): void
     {
         if (! extension_loaded('bz2') && ! extension_loaded('zlib')) {
-            $this->markTestSkipped('This filter requires bz2 of zlib extension');
+            self::markTestSkipped('This filter requires bz2 of zlib extension');
         }
 
         $this->tmpDir = sprintf('%s/%s', sys_get_temp_dir(), uniqid('laminasfilter'));
@@ -47,6 +47,7 @@ class CompressTest extends TestCase
         }
     }
 
+    /** @return iterable<array-key, array{0: string}> */
     public function returnFilterType(): iterable
     {
         if (extension_loaded('bz2')) {
@@ -62,16 +63,16 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testBasicUsage($filterType): void
+    public function testBasicUsage(string $filterType): void
     {
         $filter = new CompressFilter($filterType);
 
         $text       = 'compress me';
         $compressed = $filter($text);
-        $this->assertNotEquals($text, $compressed);
+        self::assertNotEquals($text, $compressed);
 
         $decompressed = $filter->decompress($compressed);
-        $this->assertSame($text, $decompressed);
+        self::assertSame($text, $decompressed);
     }
 
     /**
@@ -79,7 +80,7 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testGetSetAdapterOptionsInConstructor($filterType): void
+    public function testGetSetAdapterOptionsInConstructor(string $filterType): void
     {
         $filter = new CompressFilter([
             'adapter' => $filterType,
@@ -88,13 +89,13 @@ class CompressTest extends TestCase
             ],
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             ['archive' => 'test.txt'],
             $filter->getAdapterOptions()
         );
 
         $adapter = $filter->getAdapter();
-        $this->assertSame('test.txt', $adapter->getArchive());
+        self::assertSame('test.txt', $adapter->getArchive());
     }
 
     /**
@@ -102,18 +103,18 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testGetSetAdapterOptions($filterType): void
+    public function testGetSetAdapterOptions(string $filterType): void
     {
         $filter = new CompressFilter($filterType);
         $filter->setAdapterOptions([
             'archive' => 'test.txt',
         ]);
-        $this->assertSame(
+        self::assertSame(
             ['archive' => 'test.txt'],
             $filter->getAdapterOptions()
         );
         $adapter = $filter->getAdapter();
-        $this->assertSame('test.txt', $adapter->getArchive());
+        self::assertSame('test.txt', $adapter->getArchive());
     }
 
     /**
@@ -122,13 +123,13 @@ class CompressTest extends TestCase
     public function testGetSetBlocksize(): void
     {
         if (! extension_loaded('bz2')) {
-            $this->markTestSkipped('Extension bz2 is required for this test');
+            self::markTestSkipped('Extension bz2 is required for this test');
         }
 
         $filter = new CompressFilter('bz2');
-        $this->assertSame(4, $filter->getBlocksize());
+        self::assertSame(4, $filter->getBlocksize());
         $filter->setBlocksize(6);
-        $this->assertSame(6, $filter->getOptions('blocksize'));
+        self::assertSame(6, $filter->getOptions('blocksize'));
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('must be between');
@@ -140,13 +141,13 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testGetSetArchive($filterType): void
+    public function testGetSetArchive(string $filterType): void
     {
         $filter = new CompressFilter($filterType);
-        $this->assertSame(null, $filter->getArchive());
+        self::assertSame(null, $filter->getArchive());
         $filter->setArchive('Testfile.txt');
-        $this->assertSame('Testfile.txt', $filter->getArchive());
-        $this->assertSame('Testfile.txt', $filter->getOptions('archive'));
+        self::assertSame('Testfile.txt', $filter->getArchive());
+        self::assertSame('Testfile.txt', $filter->getOptions('archive'));
     }
 
     /**
@@ -154,23 +155,23 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testCompressToFile($filterType): void
+    public function testCompressToFile(string $filterType): void
     {
         $filter  = new CompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
         $filter->setArchive($archive);
 
         $content = $filter('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new CompressFilter($filterType);
         $content2 = $filter2->decompress($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
 
         $filter3 = new CompressFilter($filterType);
         $filter3->setArchive($archive);
         $content3 = $filter3->decompress(null);
-        $this->assertSame('compress me', $content3);
+        self::assertSame('compress me', $content3);
     }
 
     /**
@@ -178,10 +179,10 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testToString($filterType): void
+    public function testToString(string $filterType): void
     {
         $filter = new CompressFilter($filterType);
-        $this->assertEqualsIgnoringCase($filterType, $filter->toString());
+        self::assertEqualsIgnoringCase($filterType, $filter->toString());
     }
 
     /**
@@ -189,12 +190,12 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testGetAdapter($filterType): void
+    public function testGetAdapter(string $filterType): void
     {
         $filter  = new CompressFilter($filterType);
         $adapter = $filter->getAdapter();
-        $this->assertInstanceOf(CompressionAlgorithmInterface::class, $adapter);
-        $this->assertEqualsIgnoringCase($filterType, $filter->getAdapterName());
+        self::assertInstanceOf(CompressionAlgorithmInterface::class, $adapter);
+        self::assertEqualsIgnoringCase($filterType, $filter->getAdapterName());
     }
 
     /**
@@ -203,11 +204,11 @@ class CompressTest extends TestCase
     public function testSetAdapter(): void
     {
         if (! extension_loaded('zlib')) {
-            $this->markTestSkipped('This filter is tested with the zlib extension');
+            self::markTestSkipped('This filter is tested with the zlib extension');
         }
 
         $filter = new CompressFilter();
-        $this->assertSame('Gz', $filter->getAdapterName());
+        self::assertSame('Gz', $filter->getAdapterName());
 
         $filter->setAdapter(Boolean::class);
 
@@ -221,18 +222,18 @@ class CompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testDecompressArchive($filterType): void
+    public function testDecompressArchive(string $filterType): void
     {
         $filter  = new CompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
         $filter->setArchive($archive);
 
         $content = $filter('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new CompressFilter($filterType);
         $content2 = $filter2->decompress($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
     }
 
     /**
@@ -247,6 +248,7 @@ class CompressTest extends TestCase
         $filter->invalidMethod();
     }
 
+    /** @return iterable<array-key, array{0: string, 1: mixed}> */
     public function returnUnfilteredDataProvider(): iterable
     {
         foreach ($this->returnFilterType() as $parameters) {
@@ -265,10 +267,10 @@ class CompressTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($filterType, $input): void
+    public function testReturnUnfiltered(string $filterType, mixed $input): void
     {
         $filter = new CompressFilter($filterType);
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/DataUnitFormatterTest.php
+++ b/test/DataUnitFormatterTest.php
@@ -11,31 +11,27 @@ use PHPUnit\Framework\TestCase;
 class DataUnitFormatterTest extends TestCase
 {
     /**
-     * @param float $value
-     * @param string $expected
      * @dataProvider decimalBytesTestProvider
      */
-    public function testDecimalBytes($value, $expected): void
+    public function testDecimalBytes(float $value, string $expected): void
     {
         $filter = new DataUnitFormatterFilter([
             'mode' => DataUnitFormatterFilter::MODE_DECIMAL,
             'unit' => 'B',
         ]);
-        $this->assertSame($expected, $filter->filter($value));
+        self::assertSame($expected, $filter->filter($value));
     }
 
     /**
-     * @param float $value
-     * @param string $expected
      * @dataProvider binaryBytesTestProvider
      */
-    public function testBinaryBytes($value, $expected): void
+    public function testBinaryBytes(float $value, string $expected): void
     {
         $filter = new DataUnitFormatterFilter([
             'mode' => DataUnitFormatterFilter::MODE_BINARY,
             'unit' => 'B',
         ]);
-        $this->assertSame($expected, $filter->filter($value));
+        self::assertSame($expected, $filter->filter($value));
     }
 
     public function testPrecision(): void
@@ -45,7 +41,7 @@ class DataUnitFormatterTest extends TestCase
             'precision' => 3,
         ]);
 
-        $this->assertSame('1.500 kB', $filter->filter(1500));
+        self::assertSame('1.500 kB', $filter->filter(1500));
     }
 
     public function testCustomPrefixes(): void
@@ -55,31 +51,32 @@ class DataUnitFormatterTest extends TestCase
             'prefixes' => ['', 'kilos'],
         ]);
 
-        $this->assertSame('1.50 kilosB', $filter->filter(1500));
+        self::assertSame('1.50 kilosB', $filter->filter(1500));
     }
 
     public function testSettingNoOptions(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $filter = new DataUnitFormatterFilter();
+        new DataUnitFormatterFilter();
     }
 
     public function testSettingNoUnit(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $filter = new DataUnitFormatterFilter([]);
+        new DataUnitFormatterFilter([]);
     }
 
     public function testSettingFalseMode(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $filter = new DataUnitFormatterFilter([
+        new DataUnitFormatterFilter([
             'unit' => 'B',
             'mode' => 'invalid',
         ]);
     }
 
-    public static function decimalBytesTestProvider()
+    /** @return list<array{0: float, 1: string}> */
+    public static function decimalBytesTestProvider(): array
     {
         return [
             [0, '0 B'],
@@ -97,7 +94,8 @@ class DataUnitFormatterTest extends TestCase
         ];
     }
 
-    public static function binaryBytesTestProvider()
+    /** @return list<array{0: float, 1: string}> */
+    public static function binaryBytesTestProvider(): array
     {
         return [
             [0, '0 B'],

--- a/test/DateSelectTest.php
+++ b/test/DateSelectTest.php
@@ -12,18 +12,16 @@ class DateSelectTest extends TestCase
 {
     /**
      * @dataProvider provideFilter
-     * @param array $options filter options
-     * @param array|mixed|null|string $input input provided to the filter
-     * @param array|mixed|null|string $expected expected output
      */
-    public function testFilter($options, $input, $expected): void
+    public function testFilter(array $options, array $input, ?string $expected): void
     {
         $sut = new DateSelectFilter();
         $sut->setOptions($options);
-        $this->assertSame($expected, $sut->filter($input));
+        self::assertSame($expected, $sut->filter($input));
     }
 
-    public function provideFilter()
+    /** @return list<array{0: array, 1: array, 2: string|null}> */
+    public function provideFilter(): array
     {
         return [
             [[], ['year' => '2014', 'month' => '10', 'day' => '26'], '2014-10-26'],

--- a/test/DateTimeFormatterTest.php
+++ b/test/DateTimeFormatterTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace LaminasTest\Filter;
 
 use DateTime;
+use DateTimeInterface;
 use Laminas\Filter\DateTimeFormatter;
 use Laminas\Filter\Exception;
 use PHPUnit\Framework\TestCase;
@@ -15,7 +16,7 @@ use function date_default_timezone_set;
 
 class DateTimeFormatterTest extends TestCase
 {
-    protected $defaultTimezone;
+    private string $defaultTimezone;
 
     public function setUp(): void
     {
@@ -27,7 +28,8 @@ class DateTimeFormatterTest extends TestCase
         date_default_timezone_set($this->defaultTimezone);
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -46,13 +48,13 @@ class DateTimeFormatterTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 
     public function testFormatterFormatsZero(): void
@@ -61,7 +63,7 @@ class DateTimeFormatterTest extends TestCase
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter(0);
-        $this->assertSame('1970-01-01T00:00:00+0000', $result);
+        self::assertSame('1970-01-01T00:00:00+0000', $result);
     }
 
     public function testDateTimeFormatted(): void
@@ -70,7 +72,7 @@ class DateTimeFormatterTest extends TestCase
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter('2012-01-01');
-        $this->assertSame('2012-01-01T00:00:00+0000', $result);
+        self::assertSame('2012-01-01T00:00:00+0000', $result);
     }
 
     public function testDateTimeFormattedWithAlternateTimezones(): void
@@ -80,12 +82,12 @@ class DateTimeFormatterTest extends TestCase
         date_default_timezone_set('Europe/Paris');
 
         $resultParis = $filter->filter('2012-01-01');
-        $this->assertSame('2012-01-01T00:00:00+0100', $resultParis);
+        self::assertSame('2012-01-01T00:00:00+0100', $resultParis);
 
         date_default_timezone_set('America/New_York');
 
         $resultNewYork = $filter->filter('2012-01-01');
-        $this->assertSame('2012-01-01T00:00:00-0500', $resultNewYork);
+        self::assertSame('2012-01-01T00:00:00-0500', $resultNewYork);
     }
 
     public function testSetFormat(): void
@@ -93,9 +95,9 @@ class DateTimeFormatterTest extends TestCase
         date_default_timezone_set('UTC');
 
         $filter = new DateTimeFormatter();
-        $filter->setFormat(DateTime::RFC1036);
+        $filter->setFormat(DateTimeInterface::RFC1036);
         $result = $filter->filter('2012-01-01');
-        $this->assertSame('Sun, 01 Jan 12 00:00:00 +0000', $result);
+        self::assertSame('Sun, 01 Jan 12 00:00:00 +0000', $result);
     }
 
     public function testFormatDateTimeFromTimestamp(): void
@@ -104,7 +106,7 @@ class DateTimeFormatterTest extends TestCase
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter(1_359_739_801);
-        $this->assertSame('2013-02-01T17:30:01+0000', $result);
+        self::assertSame('2013-02-01T17:30:01+0000', $result);
     }
 
     public function testAcceptDateTimeValue(): void
@@ -113,14 +115,13 @@ class DateTimeFormatterTest extends TestCase
 
         $filter = new DateTimeFormatter();
         $result = $filter->filter(new DateTime('2012-01-01'));
-        $this->assertSame('2012-01-01T00:00:00+0000', $result);
+        self::assertSame('2012-01-01T00:00:00+0000', $result);
     }
 
     public function testInvalidArgumentExceptionThrownOnInvalidInput(): void
     {
-        $this->expectException(Exception\InvalidArgumentException::class);
-
         $filter = new DateTimeFormatter();
-        $result = $filter->filter('2013-31-31');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $filter->filter('2013-31-31');
     }
 }

--- a/test/DateTimeSelectTest.php
+++ b/test/DateTimeSelectTest.php
@@ -12,18 +12,16 @@ class DateTimeSelectTest extends TestCase
 {
     /**
      * @dataProvider provideFilter
-     * @param array $options filter options
-     * @param array|mixed|null|string $input input provided to the filter
-     * @param array|mixed|null|string $expected expected output
      */
-    public function testFilter($options, $input, $expected): void
+    public function testFilter(array $options, array $input, ?string $expected): void
     {
         $sut = new DateTimeSelectFilter();
         $sut->setOptions($options);
-        $this->assertSame($expected, $sut->filter($input));
+        self::assertSame($expected, $sut->filter($input));
     }
 
-    public function provideFilter()
+    /** @return list<array{0: array, 1: array, 2: null|string}> */
+    public function provideFilter(): array
     {
         return [
             [

--- a/test/DecompressTest.php
+++ b/test/DecompressTest.php
@@ -20,12 +20,12 @@ use function unlink;
 
 class DecompressTest extends TestCase
 {
-    public $tmpDir;
+    private string $tmpDir;
 
     public function setUp(): void
     {
         if (! extension_loaded('bz2')) {
-            $this->markTestSkipped('This filter is tested with the bz2 extension');
+            self::markTestSkipped('This filter is tested with the bz2 extension');
         }
 
         $this->tmpDir = sprintf('%s/%s', sys_get_temp_dir(), uniqid('laminasilter'));
@@ -44,6 +44,7 @@ class DecompressTest extends TestCase
         }
     }
 
+    /** @return iterable<array-key, array{0: string}> */
     public function returnFilterType(): iterable
     {
         if (extension_loaded('bz2')) {
@@ -59,16 +60,16 @@ class DecompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testBasicUsage($filterType): void
+    public function testBasicUsage(string $filterType): void
     {
         $filter = new DecompressFilter($filterType);
 
         $text       = 'compress me';
         $compressed = $filter->compress($text);
-        $this->assertNotEquals($text, $compressed);
+        self::assertNotEquals($text, $compressed);
 
         $decompressed = $filter($compressed);
-        $this->assertSame($text, $decompressed);
+        self::assertSame($text, $decompressed);
     }
 
     /**
@@ -76,23 +77,23 @@ class DecompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testCompressToFile($filterType): void
+    public function testCompressToFile(string $filterType): void
     {
         $filter  = new DecompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
         $filter->setArchive($archive);
 
         $content = $filter->compress('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new DecompressFilter($filterType);
         $content2 = $filter2($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
 
         $filter3 = new DecompressFilter($filterType);
         $filter3->setArchive($archive);
         $content3 = $filter3(null);
-        $this->assertSame('compress me', $content3);
+        self::assertSame('compress me', $content3);
     }
 
     /**
@@ -100,37 +101,38 @@ class DecompressTest extends TestCase
      *
      * @dataProvider returnFilterType
      */
-    public function testDecompressArchive($filterType): void
+    public function testDecompressArchive(string $filterType): void
     {
         $filter  = new DecompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
         $filter->setArchive($archive);
 
         $content = $filter->compress('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new DecompressFilter($filterType);
         $content2 = $filter2($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
     }
 
     /**
      * @dataProvider returnFilterType
      */
-    public function testFilterMethodProxiesToDecompress($filterType): void
+    public function testFilterMethodProxiesToDecompress(string $filterType): void
     {
         $filter  = new DecompressFilter($filterType);
         $archive = $this->tmpDir . '/compressed.' . $filterType;
         $filter->setArchive($archive);
 
         $content = $filter->compress('compress me');
-        $this->assertTrue($content);
+        self::assertTrue($content);
 
         $filter2  = new DecompressFilter($filterType);
         $content2 = $filter2->filter($archive);
-        $this->assertSame('compress me', $content2);
+        self::assertSame('compress me', $content2);
     }
 
+    /** @return iterable<array-key, array{0: string, 1: mixed}> */
     public function returnUnfilteredDataProvider(): iterable
     {
         foreach ($this->returnFilterType() as $parameter) {
@@ -148,10 +150,10 @@ class DecompressTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($filterType, $input): void
+    public function testReturnUnfiltered(string $filterType, mixed $input): void
     {
         $filter = new DecompressFilter($filterType);
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/DecryptTest.php
+++ b/test/DecryptTest.php
@@ -17,7 +17,7 @@ class DecryptTest extends TestCase
     public function setUp(): void
     {
         if (! extension_loaded('mcrypt') && ! extension_loaded('openssl')) {
-            $this->markTestSkipped('This filter needs the mcrypt or openssl extension');
+            self::markTestSkipped('This filter needs the mcrypt or openssl extension');
         }
     }
 
@@ -36,7 +36,7 @@ class DecryptTest extends TestCase
         $enc = $filter->getEncryption();
         $filter->setKey('1234567890123456');
         foreach ($valuesExpected as $input => $output) {
-            $this->assertNotEquals($output, $filter($input));
+            self::assertNotEquals($output, $filter($input));
         }
     }
 
@@ -50,7 +50,7 @@ class DecryptTest extends TestCase
         // @codingStandardsIgnoreStart
         $decrypted = $decrypt->filter('ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
         // @codingStandardsIgnoreEnd
-        $this->assertSame($decrypted, 'test');
+        self::assertSame($decrypted, 'test');
     }
 
     /**
@@ -59,7 +59,7 @@ class DecryptTest extends TestCase
     public function testBasicOpenssl(): void
     {
         if (! extension_loaded('openssl')) {
-            $this->markTestSkipped('Openssl extension not installed');
+            self::markTestSkipped('Openssl extension not installed');
         }
 
         $filter = new DecryptFilter(['adapter' => 'Openssl']);
@@ -72,7 +72,7 @@ bK22CwD/l7SMBOz4M9XH0Jb0OhNxLza4XMDu0ANMIpnkn1KOcmQ4gB8fmAbBt');
         $filter->setPrivateKey(__DIR__ . '/_files/privatekey.pem');
 
         $key = $filter->getPrivateKey();
-        $this->assertSame(
+        self::assertSame(
             [
                 __DIR__ . '/_files/privatekey.pem'
                   => '-----BEGIN RSA PRIVATE KEY-----
@@ -99,17 +99,17 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
     public function testSettingAdapterManually(): void
     {
         if (! extension_loaded('openssl')) {
-            $this->markTestSkipped('Openssl extension not installed');
+            self::markTestSkipped('Openssl extension not installed');
         }
 
         $filter = new DecryptFilter();
         $filter->setAdapter('Openssl');
-        $this->assertSame('Openssl', $filter->getAdapter());
-        $this->assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
+        self::assertSame('Openssl', $filter->getAdapter());
+        self::assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
 
         $filter->setAdapter('BlockCipher');
-        $this->assertSame('BlockCipher', $filter->getAdapter());
-        $this->assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
+        self::assertSame('BlockCipher', $filter->getAdapter());
+        self::assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not implement');
@@ -147,6 +147,6 @@ d/fxzPfuO/bLpADozTAnYT9Hu3wPrQVLeAfCp0ojqH7DYg==
         $decrypt->setVector('1234567890123456890');
 
         $decrypted = $decrypt->filter($input);
-        $this->assertSame($input, $decrypted);
+        self::assertSame($input, $decrypted);
     }
 }

--- a/test/DenyListTest.php
+++ b/test/DenyListTest.php
@@ -24,16 +24,16 @@ class DenyListTest extends TestCase
             'strict' => true,
         ]);
 
-        $this->assertSame(true, $filter->getStrict());
-        $this->assertSame(['test', 1], $filter->getList());
+        self::assertSame(true, $filter->getStrict());
+        self::assertSame(['test', 1], $filter->getList());
     }
 
     public function testConstructorDefaults(): void
     {
         $filter = new DenyListFilter();
 
-        $this->assertSame(false, $filter->getStrict());
-        $this->assertSame([], $filter->getList());
+        self::assertSame(false, $filter->getStrict());
+        self::assertSame([], $filter->getList());
     }
 
     public function testWithPluginManager(): void
@@ -41,13 +41,13 @@ class DenyListTest extends TestCase
         $pluginManager = new FilterPluginManager(new ServiceManager());
         $filter        = $pluginManager->get('DenyList');
 
-        $this->assertInstanceOf(DenyListFilter::class, $filter);
+        self::assertInstanceOf(DenyListFilter::class, $filter);
     }
 
     public function testNullListShouldThrowException(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
-        $filter = new DenyListFilter([
+        new DenyListFilter([
             'list' => null,
         ]);
     }
@@ -59,7 +59,7 @@ class DenyListTest extends TestCase
         $filter = new DenyListFilter([
             'list' => $obj,
         ]);
-        $this->assertSame($array, $filter->getList());
+        self::assertSame($array, $filter->getList());
     }
 
     public function testSetStrictShouldCastToBoolean(): void
@@ -67,18 +67,16 @@ class DenyListTest extends TestCase
         $filter = new DenyListFilter([
             'strict' => 1,
         ]);
-        $this->assertSame(true, $filter->getStrict());
+        self::assertSame(true, $filter->getStrict());
     }
 
     /**
-     * @param mixed $value
-     * @param mixed  $expected
      * @dataProvider defaultTestProvider
      */
-    public function testDefault($value, $expected): void
+    public function testDefault(mixed $value, mixed $expected): void
     {
         $filter = new DenyListFilter();
-        $this->assertSame($expected, $filter->filter($value));
+        self::assertSame($expected, $filter->filter($value));
     }
 
     /**
@@ -100,10 +98,11 @@ class DenyListTest extends TestCase
                 gettype($value),
                 (int) $strict
             );
-            $this->assertSame($expected, $filter->filter($value), $message);
+            self::assertSame($expected, $filter->filter($value), $message);
         }
     }
 
+    /** @return list<array{0: mixed, 1: mixed}> */
     public static function defaultTestProvider(): array
     {
         return [
@@ -115,6 +114,7 @@ class DenyListTest extends TestCase
         ];
     }
 
+    /** @return list<array{0: bool, 1: array, 2: array}> */
     public static function listTestProvider(): array
     {
         return [

--- a/test/DigitsTest.php
+++ b/test/DigitsTest.php
@@ -8,28 +8,21 @@ use Laminas\Filter\Digits as DigitsFilter;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use function extension_loaded;
 use function preg_match;
 
 class DigitsTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
     /**
      * Is PCRE is compiled with UTF-8 and Unicode support
-     *
-     * @var mixed
      **/
-    protected static $_unicodeEnabled;
-    // @codingStandardsIgnoreEnd
+    private bool $unicodeEnabled;
 
     /**
      * Creates a new Laminas_Filter_Digits object for each test method
      */
     public function setUp(): void
     {
-        if (null === static::$_unicodeEnabled) {
-            static::$_unicodeEnabled = (bool) @preg_match('/\pL/u', 'a');
-        }
+        $this->unicodeEnabled = (bool) @preg_match('/\pL/u', 'a');
     }
 
     /**
@@ -39,7 +32,7 @@ class DigitsTest extends TestCase
     {
         $filter = new DigitsFilter();
 
-        if (static::$_unicodeEnabled && extension_loaded('mbstring')) {
+        if ($this->unicodeEnabled) {
             // Filter for the value with mbstring
             /**
              * The first element of $valuesExpected contains multibyte digit characters.
@@ -69,7 +62,7 @@ class DigitsTest extends TestCase
         }
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame(
+            self::assertSame(
                 $output,
                 $result = $filter($input),
                 "Expected '$input' to filter to '$output', but received '$result' instead"
@@ -77,7 +70,8 @@ class DigitsTest extends TestCase
         }
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -96,10 +90,10 @@ class DigitsTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new DigitsFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/DirTest.php
+++ b/test/DirTest.php
@@ -22,11 +22,12 @@ class DirTest extends TestCase
             '/path/to/filename.ext' => '/path/to',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -43,10 +44,10 @@ class DirTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new DirFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/Encrypt/BlockCipherTest.php
+++ b/test/Encrypt/BlockCipherTest.php
@@ -17,7 +17,7 @@ class BlockCipherTest extends TestCase
     public function setUp(): void
     {
         if (! extension_loaded('mcrypt') && ! extension_loaded('openssl')) {
-            $this->markTestSkipped('This filter needs the mcrypt or openssl extension');
+            self::markTestSkipped('This filter needs the mcrypt or openssl extension');
         }
     }
 
@@ -36,9 +36,9 @@ class BlockCipherTest extends TestCase
         // @codingStandardsIgnoreEnd
         $filter->setVector('Laminas__Project');
         $enc = $filter->getEncryption();
-        $this->assertSame('testkey', $enc['key']);
+        self::assertSame('testkey', $enc['key']);
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter->encrypt($input));
+            self::assertSame($output, $filter->encrypt($input));
         }
     }
 
@@ -49,7 +49,7 @@ class BlockCipherTest extends TestCase
     {
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
         $filter->setVector('1234567890123456');
-        $this->assertSame('1234567890123456', $filter->getVector());
+        self::assertSame('1234567890123456', $filter->getVector());
     }
 
     public function testWrongSizeVector(): void
@@ -66,7 +66,7 @@ class BlockCipherTest extends TestCase
     {
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
         $filter->setVector('1234567890123456');
-        $this->assertSame(
+        self::assertSame(
             [
                 'key'           => 'testkey',
                 'key_iteration' => 5000,
@@ -88,7 +88,7 @@ class BlockCipherTest extends TestCase
         $filter->setEncryption(
             ['algorithm' => 'aes']
         );
-        $this->assertSame(
+        self::assertSame(
             [
                 'algorithm'     => 'aes',
                 'key'           => 'testkey',
@@ -109,17 +109,17 @@ class BlockCipherTest extends TestCase
         $filter->setVector('1234567890123456');
         $output = $filter->encrypt('teststring');
 
-        $this->assertNotEquals('teststring', $output);
+        self::assertNotEquals('teststring', $output);
 
         $input = $filter->decrypt($output);
-        $this->assertSame('teststring', trim($input));
+        self::assertSame('teststring', trim($input));
     }
 
     public function testConstructionWithStringKey(): void
     {
         $filter = new BlockCipherEncryption('testkey');
         $data   = $filter->getEncryption();
-        $this->assertSame('testkey', $data['key']);
+        self::assertSame('testkey', $data['key']);
     }
 
     public function testConstructionWithInteger(): void
@@ -132,7 +132,7 @@ class BlockCipherTest extends TestCase
     public function testToString(): void
     {
         $filter = new BlockCipherEncryption('testkey');
-        $this->assertSame('BlockCipher', $filter->toString());
+        self::assertSame('BlockCipher', $filter->toString());
     }
 
     public function testSettingEncryptionOptions(): void
@@ -140,26 +140,26 @@ class BlockCipherTest extends TestCase
         $filter = new BlockCipherEncryption('testkey');
         $filter->setEncryption('newkey');
         $test = $filter->getEncryption();
-        $this->assertSame('newkey', $test['key']);
+        self::assertSame('newkey', $test['key']);
 
         try {
             $filter->setEncryption(1234);
             $filter->fail();
         } catch (InvalidArgumentException $e) {
-            $this->assertStringContainsString('Invalid options argument', $e->getMessage());
+            self::assertStringContainsString('Invalid options argument', $e->getMessage());
         }
 
         try {
             $filter->setEncryption(['algorithm' => 'unknown']);
             $filter->fail();
         } catch (InvalidArgumentException $e) {
-            $this->assertStringContainsString('The algorithm', $e->getMessage());
+            self::assertStringContainsString('The algorithm', $e->getMessage());
         }
 
         try {
             $filter->setEncryption(['mode' => 'unknown']);
         } catch (InvalidArgumentException $e) {
-            $this->assertStringContainsString('The mode', $e->getMessage());
+            self::assertStringContainsString('The mode', $e->getMessage());
         }
     }
 
@@ -177,7 +177,7 @@ class BlockCipherTest extends TestCase
     public function testEncryptionWithDecryptionAndCompression(): void
     {
         if (! extension_loaded('bz2')) {
-            $this->markTestSkipped('This adapter needs the bz2 extension');
+            self::markTestSkipped('This adapter needs the bz2 extension');
         }
 
         $filter = new BlockCipherEncryption(['key' => 'testkey']);
@@ -185,9 +185,9 @@ class BlockCipherTest extends TestCase
         $filter->setCompression('bz2');
         $output = $filter->encrypt('teststring');
 
-        $this->assertNotEquals('teststring', $output);
+        self::assertNotEquals('teststring', $output);
 
         $input = $filter->decrypt($output);
-        $this->assertSame('teststring', trim($input));
+        self::assertSame('teststring', trim($input));
     }
 }

--- a/test/EncryptTest.php
+++ b/test/EncryptTest.php
@@ -17,7 +17,7 @@ class EncryptTest extends TestCase
     public function setUp(): void
     {
         if (! extension_loaded('mcrypt') && ! extension_loaded('openssl')) {
-            $this->markTestSkipped('This filter needs the mcrypt or openssl extension');
+            self::markTestSkipped('This filter needs the mcrypt or openssl extension');
         }
     }
 
@@ -39,9 +39,9 @@ class EncryptTest extends TestCase
 
         $enc = $filter->getEncryption();
         $filter->setVector('1234567890123456');
-        $this->assertSame('testkey', $enc['key']);
+        self::assertSame('testkey', $enc['key']);
         foreach ($valuesExpected as $input => $output) {
-            $this->assertNotEquals($output, $filter($input));
+            self::assertNotEquals($output, $filter($input));
         }
     }
 
@@ -54,7 +54,7 @@ class EncryptTest extends TestCase
         $encrypt->setVector('1234567890123456890');
         $encrypted = $encrypt->filter('test');
         // @codingStandardsIgnoreStart
-        $this->assertSame($encrypted, 'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
+        self::assertSame($encrypted, 'ec133eb7460682b0020b736ad6d2ef14c35de0f1e5976330ae1dd096ef3b4cb7MTIzNDU2Nzg5MDEyMzQ1NoZvxY1JkeL6TnQP3ug5F0k=');
         // @codingStandardsIgnoreEnd
     }
 
@@ -66,7 +66,7 @@ class EncryptTest extends TestCase
         self::markTestSkipped('The OpenSSL Adapter is deprecated and tests will not pass on OpenSSL 3.x');
 
         if (! extension_loaded('openssl')) {
-            $this->markTestSkipped('Openssl extension not installed');
+            self::markTestSkipped('Openssl extension not installed');
         }
 
         $filter         = new EncryptFilter(['adapter' => 'Openssl']);
@@ -78,7 +78,7 @@ class EncryptTest extends TestCase
 
         $filter->setPublicKey(__DIR__ . '/_files/publickey.pem');
         $key = $filter->getPublicKey();
-        $this->assertSame(
+        self::assertSame(
             [
                 __DIR__ . '/_files/publickey.pem'
                   => '-----BEGIN CERTIFICATE-----
@@ -104,7 +104,7 @@ PIDs9E7uuizAKDhRRRvho8BS
             $key
         );
         foreach ($valuesExpected as $input => $output) {
-            $this->assertNotEquals($output, $filter($input));
+            self::assertNotEquals($output, $filter($input));
         }
     }
 
@@ -113,8 +113,8 @@ PIDs9E7uuizAKDhRRRvho8BS
         $filter = new EncryptFilter();
 
         $filter->setAdapter('BlockCipher');
-        $this->assertSame('BlockCipher', $filter->getAdapter());
-        $this->assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
+        self::assertSame('BlockCipher', $filter->getAdapter());
+        self::assertInstanceOf(EncryptionAlgorithmInterface::class, $filter->getAdapterInstance());
 
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('does not implement');
@@ -152,6 +152,6 @@ PIDs9E7uuizAKDhRRRvho8BS
         $encrypt->setVector('1234567890123456890');
 
         $encrypted = $encrypt->filter($input);
-        $this->assertSame($input, $encrypted);
+        self::assertSame($input, $encrypted);
     }
 }

--- a/test/File/DecryptTest.php
+++ b/test/File/DecryptTest.php
@@ -25,14 +25,13 @@ use function unlink;
 
 class DecryptTest extends TestCase
 {
-    public $fileToEncrypt;
+    private ?string $fileToEncrypt;
+    private ?string $tmpDir = null;
 
-    public $tmpDir;
-
-    public function setUp(): void
+    protected function setUp(): void
     {
         if (! extension_loaded('mcrypt') && ! extension_loaded('openssl')) {
-            $this->markTestSkipped('This filter needs the mcrypt or openssl extension');
+            self::markTestSkipped('This filter needs the mcrypt or openssl extension');
         }
 
         $this->tmpDir = sprintf('%s/%s', sys_get_temp_dir(), uniqid('laminasilter'));
@@ -41,9 +40,9 @@ class DecryptTest extends TestCase
         $this->fileToEncrypt = dirname(__DIR__) . '/_files/encryption.txt';
     }
 
-    public function tearDown(): void
+    protected function tearDown(): void
     {
-        if (is_dir($this->tmpDir)) {
+        if ($this->tmpDir !== null && is_dir($this->tmpDir)) {
             if (file_exists($this->tmpDir . '/newencryption.txt')) {
                 unlink($this->tmpDir . '/newencryption.txt');
             }
@@ -64,7 +63,7 @@ class DecryptTest extends TestCase
         $filter = new FileEncrypt();
         $filter->setFilename($this->tmpDir . '/newencryption.txt');
 
-        $this->assertSame(
+        self::assertSame(
             $this->tmpDir . '/newencryption.txt',
             $filter->getFilename()
         );
@@ -74,18 +73,18 @@ class DecryptTest extends TestCase
 
         $filter = new FileDecrypt();
 
-        $this->assertNotEquals(
+        self::assertNotEquals(
             'Encryption',
             file_get_contents($this->tmpDir . '/newencryption.txt')
         );
 
         $filter->setKey('1234567890123456');
-        $this->assertSame(
+        self::assertSame(
             $this->tmpDir . '/newencryption.txt',
             $filter->filter($this->tmpDir . '/newencryption.txt')
         );
 
-        $this->assertSame(
+        self::assertSame(
             'Encryption',
             trim(file_get_contents($this->tmpDir . '/newencryption.txt'))
         );
@@ -96,12 +95,12 @@ class DecryptTest extends TestCase
         $filter = new FileEncrypt();
         $filter->setFilename($this->tmpDir . '/newencryption.txt');
         $filter->setKey('1234567890123456');
-        $this->assertSame(
+        self::assertSame(
             $this->tmpDir . '/newencryption.txt',
             $filter->filter($this->fileToEncrypt)
         );
 
-        $this->assertNotEquals(
+        self::assertNotEquals(
             'Encryption',
             file_get_contents($this->tmpDir . '/newencryption.txt')
         );
@@ -109,16 +108,16 @@ class DecryptTest extends TestCase
         $filter = new FileDecrypt();
         $filter->setFilename($this->tmpDir . '/newencryption2.txt');
 
-        $this->assertSame(
+        self::assertSame(
             $this->tmpDir . '/newencryption2.txt',
             $filter->getFilename()
         );
 
         $filter->setKey('1234567890123456');
         $input = $filter->filter($this->tmpDir . '/newencryption.txt');
-        $this->assertSame($this->tmpDir . '/newencryption2.txt', $input);
+        self::assertSame($this->tmpDir . '/newencryption2.txt', $input);
 
-        $this->assertSame(
+        self::assertSame(
             'Encryption',
             trim(file_get_contents($this->tmpDir . '/newencryption2.txt'))
         );
@@ -156,6 +155,6 @@ class DecryptTest extends TestCase
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/File/EncryptTest.php
+++ b/test/File/EncryptTest.php
@@ -23,14 +23,14 @@ use function unlink;
 
 class EncryptTest extends TestCase
 {
-    public $fileToEncrypt;
-    public $testDir;
-    public $testFile;
+    public string $fileToEncrypt;
+    public string $testDir;
+    public string $testFile;
 
     public function setUp(): void
     {
         if (! extension_loaded('mcrypt') && ! extension_loaded('openssl')) {
-            $this->markTestSkipped('This filter needs the mcrypt or openssl extension');
+            self::markTestSkipped('This filter needs the mcrypt or openssl extension');
         }
 
         $this->fileToEncrypt = dirname(__DIR__) . '/_files/encryption.txt';
@@ -53,14 +53,14 @@ class EncryptTest extends TestCase
         $filter = new FileEncrypt();
         $filter->setFilename($this->testFile);
 
-        $this->assertSame($this->testFile, $filter->getFilename());
+        self::assertSame($this->testFile, $filter->getFilename());
 
         $filter->setKey('1234567890123456');
-        $this->assertSame($this->testFile, $filter->filter($this->fileToEncrypt));
+        self::assertSame($this->testFile, $filter->filter($this->fileToEncrypt));
 
-        $this->assertSame('Encryption', file_get_contents($this->fileToEncrypt));
+        self::assertSame('Encryption', file_get_contents($this->fileToEncrypt));
 
-        $this->assertNotEquals('Encryption', file_get_contents($this->testFile));
+        self::assertNotEquals('Encryption', file_get_contents($this->testFile));
     }
 
     public function testEncryptionWithDecryption(): void
@@ -68,16 +68,16 @@ class EncryptTest extends TestCase
         $filter = new FileEncrypt();
         $filter->setFilename($this->testFile);
         $filter->setKey('1234567890123456');
-        $this->assertSame($this->testFile, $filter->filter($this->fileToEncrypt));
+        self::assertSame($this->testFile, $filter->filter($this->fileToEncrypt));
 
-        $this->assertNotEquals('Encryption', file_get_contents($this->testFile));
+        self::assertNotEquals('Encryption', file_get_contents($this->testFile));
 
         $filter = new FileDecrypt();
         $filter->setKey('1234567890123456');
         $input = $filter->filter($this->testFile);
-        $this->assertSame($this->testFile, $input);
+        self::assertSame($this->testFile, $input);
 
-        $this->assertSame('Encryption', trim(file_get_contents($this->testFile)));
+        self::assertSame('Encryption', trim(file_get_contents($this->testFile)));
     }
 
     public function testNonExistingFile(): void
@@ -98,7 +98,7 @@ class EncryptTest extends TestCase
         copy($this->fileToEncrypt, $this->testFile);
         $filter->filter($this->testFile);
 
-        $this->assertNotEquals('Encryption', trim(file_get_contents($this->testFile)));
+        self::assertNotEquals('Encryption', trim(file_get_contents($this->testFile)));
     }
 
     public function returnUnfilteredDataProvider()
@@ -123,6 +123,6 @@ class EncryptTest extends TestCase
         $filter = new FileEncrypt();
         $filter->setKey('1234567890123456');
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/File/LowerCaseTest.php
+++ b/test/File/LowerCaseTest.php
@@ -21,14 +21,8 @@ use function unlink;
 
 class LowerCaseTest extends TestCase
 {
-    protected $testDir;
-
-    /**
-     * Testfile
-     *
-     * @var string
-     */
-    protected $testFile;
+    private ?string $testDir  = null;
+    private ?string $testFile = null;
 
     /**
      * Sets the path to test files
@@ -53,18 +47,18 @@ class LowerCaseTest extends TestCase
 
     public function testInstanceCreationAndNormalWorkflow(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileLowerCase();
         $filter($this->testFile);
-        $this->assertStringContainsString('this is a file', file_get_contents($this->testFile));
+        self::assertStringContainsString('this is a file', file_get_contents($this->testFile));
     }
 
     public function testNormalWorkflowWithFilesArray(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileLowerCase();
         $filter(['tmp_name' => $this->testFile]);
-        $this->assertStringContainsString('this is a file', file_get_contents($this->testFile));
+        self::assertStringContainsString('this is a file', file_get_contents($this->testFile));
     }
 
     public function testFileNotFoundException(): void
@@ -77,26 +71,26 @@ class LowerCaseTest extends TestCase
 
     public function testCheckSettingOfEncodingInIstance(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
             $filter = new FileLowerCase('ISO-8859-1');
             $filter($this->testFile);
-            $this->assertStringContainsString('this is a file', file_get_contents($this->testFile));
+            self::assertStringContainsString('this is a file', file_get_contents($this->testFile));
         } catch (ExtensionNotLoadedException $e) {
-            $this->assertStringContainsString('mbstring is required', $e->getMessage());
+            self::assertStringContainsString('mbstring is required', $e->getMessage());
         }
     }
 
     public function testCheckSettingOfEncodingWithMethod(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
             $filter = new FileLowerCase();
             $filter->setEncoding('ISO-8859-1');
             $filter($this->testFile);
-            $this->assertStringContainsString('this is a file', file_get_contents($this->testFile));
+            self::assertStringContainsString('this is a file', file_get_contents($this->testFile));
         } catch (ExtensionNotLoadedException $e) {
-            $this->assertStringContainsString('mbstring is required', $e->getMessage());
+            self::assertStringContainsString('mbstring is required', $e->getMessage());
         }
     }
 
@@ -121,6 +115,6 @@ class LowerCaseTest extends TestCase
     {
         $filter = new FileLowerCase();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/File/RenameTest.php
+++ b/test/File/RenameTest.php
@@ -25,47 +25,12 @@ use const DIRECTORY_SEPARATOR;
 
 class RenameTest extends TestCase
 {
-    /**
-     * Path to test files
-     *
-     * @var string
-     */
-    protected $tmpPath;
-
-    /**
-     * Original testfile
-     *
-     * @var string
-     */
-    protected $origFile;
-
-    /**
-     * Testfile
-     *
-     * @var string
-     */
-    protected $oldFile;
-
-    /**
-     * Testfile
-     *
-     * @var string
-     */
-    protected $newFile;
-
-    /**
-     * Testdirectory
-     *
-     * @var string
-     */
-    protected $newDir;
-
-    /**
-     * Testfile in Testdirectory
-     *
-     * @var string
-     */
-    protected $newDirFile;
+    private ?string $tmpPath    = null;
+    private ?string $origFile   = null;
+    private ?string $oldFile    = null;
+    private ?string $newFile    = null;
+    private ?string $newDir     = null;
+    private ?string $newDirFile = null;
 
     /**
      * Sets the path to test files
@@ -119,7 +84,7 @@ class RenameTest extends TestCase
     {
         $filter = new FileRename($this->newFile);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'target'    => $this->newFile,
@@ -130,8 +95,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -141,7 +106,7 @@ class RenameTest extends TestCase
     {
         $filter = new FileRename($this->newFile);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'target'    => $this->newFile,
@@ -152,11 +117,11 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame(
+        self::assertSame(
             ['tmp_name' => $this->newFile],
             $filter(['tmp_name' => $this->oldFile])
         );
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -169,7 +134,7 @@ class RenameTest extends TestCase
             'target' => $this->newFile,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -180,8 +145,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -197,7 +162,7 @@ class RenameTest extends TestCase
             'unknown'   => false,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -208,8 +173,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -224,7 +189,7 @@ class RenameTest extends TestCase
             ],
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -235,8 +200,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -248,7 +213,7 @@ class RenameTest extends TestCase
             'source' => $this->oldFile,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -259,8 +224,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->oldFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->oldFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -272,7 +237,7 @@ class RenameTest extends TestCase
             'target' => $this->newFile,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'target'    => $this->newFile,
@@ -283,8 +248,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -294,7 +259,7 @@ class RenameTest extends TestCase
     {
         $filter = new FileRename($this->newDir);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'target'    => $this->newDir,
@@ -305,8 +270,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newDirFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newDirFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -319,7 +284,7 @@ class RenameTest extends TestCase
             'target' => $this->newDir,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -330,8 +295,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newDirFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newDirFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -346,7 +311,7 @@ class RenameTest extends TestCase
             ],
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -357,8 +322,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newDirFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newDirFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     /**
@@ -370,7 +335,7 @@ class RenameTest extends TestCase
             'target' => $this->newDir,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'target'    => $this->newDir,
@@ -381,8 +346,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newDirFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newDirFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     public function testAddSameFileAgainAndOverwriteExistingTarget(): void
@@ -397,7 +362,7 @@ class RenameTest extends TestCase
             'target' => $this->newFile,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -408,8 +373,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     public function testGetNewName(): void
@@ -419,7 +384,7 @@ class RenameTest extends TestCase
             'target' => $this->newDir,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -430,7 +395,7 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newDirFile, $filter->getNewName($this->oldFile));
+        self::assertSame($this->newDirFile, $filter->getNewName($this->oldFile));
     }
 
     public function testGetNewNameExceptionWithExistingFile(): void
@@ -442,7 +407,7 @@ class RenameTest extends TestCase
 
         copy($this->oldFile, $this->newFile);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -455,7 +420,7 @@ class RenameTest extends TestCase
         );
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('could not be renamed');
-        $this->assertSame($this->newFile, $filter->getNewName($this->oldFile));
+        self::assertSame($this->newFile, $filter->getNewName($this->oldFile));
     }
 
     public function testGetNewNameOverwriteWithExistingFile(): void
@@ -468,7 +433,7 @@ class RenameTest extends TestCase
 
         copy($this->oldFile, $this->newFile);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -479,7 +444,7 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter->getNewName($this->oldFile));
+        self::assertSame($this->newFile, $filter->getNewName($this->oldFile));
     }
 
     public function testGetRandomizedFile(): void
@@ -490,7 +455,7 @@ class RenameTest extends TestCase
             'randomize' => true,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -502,7 +467,7 @@ class RenameTest extends TestCase
             $filter->getFile()
         );
         $fileNoExt = $this->tmpPath . DIRECTORY_SEPARATOR . 'newfile';
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '#' . preg_quote($fileNoExt) . '_.{13}\.xml#',
             $filter->getNewName($this->oldFile)
         );
@@ -517,7 +482,7 @@ class RenameTest extends TestCase
             'randomize' => true,
         ]);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'source'    => $this->oldFile,
@@ -528,7 +493,7 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertMatchesRegularExpression(
+        self::assertMatchesRegularExpression(
             '#' . preg_quote($fileNoExt) . '_.{13}#',
             $filter->getNewName($this->oldFile)
         );
@@ -539,7 +504,7 @@ class RenameTest extends TestCase
         $filter = new FileRename($this->oldFile);
         $filter->addFile($this->newFile);
 
-        $this->assertSame(
+        self::assertSame(
             [
                 0 => [
                     'target'    => $this->newFile,
@@ -550,8 +515,8 @@ class RenameTest extends TestCase
             ],
             $filter->getFile()
         );
-        $this->assertSame($this->newFile, $filter($this->oldFile));
-        $this->assertSame('falsefile', $filter('falsefile'));
+        self::assertSame($this->newFile, $filter($this->oldFile));
+        self::assertSame('falsefile', $filter('falsefile'));
     }
 
     public function testAddFileWithInvalidOption(): void
@@ -566,10 +531,11 @@ class RenameTest extends TestCase
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid options');
-        $filter = new FileRename(1234);
+        new FileRename(1234);
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -586,10 +552,10 @@ class RenameTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new FileRename($this->newFile);
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/File/RenameUploadMock.php
+++ b/test/File/RenameUploadMock.php
@@ -13,9 +13,8 @@ class RenameUploadMock extends RenameUpload
     /**
      * @param  string $sourceFile Source file path
      * @param  string $targetFile Target file path
-     * @return bool
      */
-    protected function moveUploadedFile($sourceFile, $targetFile)
+    protected function moveUploadedFile($sourceFile, $targetFile): bool
     {
         return rename($sourceFile, $targetFile);
     }

--- a/test/File/RenameUploadTest.php
+++ b/test/File/RenameUploadTest.php
@@ -83,7 +83,7 @@ class RenameUploadTest extends TestCase
         $this->removeDir($this->filesPath);
     }
 
-    private function removeDir(string $dir)
+    private function removeDir(string $dir): void
     {
         if (! is_dir($dir)) {
             return;

--- a/test/File/UpperCaseTest.php
+++ b/test/File/UpperCaseTest.php
@@ -54,18 +54,18 @@ class UpperCaseTest extends TestCase
 
     public function testInstanceCreationAndNormalWorkflow(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileUpperCase();
         $filter($this->testFile);
-        $this->assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
+        self::assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
     }
 
     public function testNormalWorkflowWithFilesArray(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         $filter = new FileUpperCase();
         $filter(['tmp_name' => $this->testFile]);
-        $this->assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
+        self::assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
     }
 
     public function testFileNotFoundException(): void
@@ -78,26 +78,26 @@ class UpperCaseTest extends TestCase
 
     public function testCheckSettingOfEncodingInIstance(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
             $filter = new FileUpperCase('ISO-8859-1');
             $filter($this->testFile);
-            $this->assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
+            self::assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
         } catch (ExtensionNotLoadedException $e) {
-            $this->assertStringContainsString('mbstring is required', $e->getMessage());
+            self::assertStringContainsString('mbstring is required', $e->getMessage());
         }
     }
 
     public function testCheckSettingOfEncodingWithMethod(): void
     {
-        $this->assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
         try {
             $filter = new FileUpperCase();
             $filter->setEncoding('ISO-8859-1');
             $filter($this->testFile);
-            $this->assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
+            self::assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
         } catch (ExtensionNotLoadedException $e) {
-            $this->assertStringContainsString('mbstring is required', $e->getMessage());
+            self::assertStringContainsString('mbstring is required', $e->getMessage());
         }
     }
 
@@ -123,6 +123,6 @@ class UpperCaseTest extends TestCase
         $filter = new FileUpperCase();
         $filter->setEncoding('ISO-8859-1');
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/FilterPluginManagerTest.php
+++ b/test/FilterPluginManagerTest.php
@@ -27,7 +27,7 @@ class FilterPluginManagerTest extends TestCase
     public function testFilterSuccessfullyRetrieved(): void
     {
         $filter = $this->filters->get('int');
-        $this->assertInstanceOf(ToInt::class, $filter);
+        self::assertInstanceOf(ToInt::class, $filter);
     }
 
     public function testRegisteringInvalidFilterRaisesException(): void
@@ -59,9 +59,9 @@ class FilterPluginManagerTest extends TestCase
 
         $filter = $this->filters->get('wordseparatortoseparator', $options);
 
-        $this->assertInstanceOf(SeparatorToSeparator::class, $filter);
-        $this->assertSame($searchSeparator, $filter->getSearchSeparator());
-        $this->assertSame($replacementSeparator, $filter->getReplacementSeparator());
+        self::assertInstanceOf(SeparatorToSeparator::class, $filter);
+        self::assertSame($searchSeparator, $filter->getSearchSeparator());
+        self::assertSame($replacementSeparator, $filter->getReplacementSeparator());
     }
 
     /**
@@ -85,7 +85,7 @@ class FilterPluginManagerTest extends TestCase
             ]
         );
 
-        $this->assertNotEquals($filterOne, $filterTwo);
+        self::assertNotEquals($filterOne, $filterTwo);
     }
 
     /** @return class-string<Throwable> */

--- a/test/HtmlEntitiesTest.php
+++ b/test/HtmlEntitiesTest.php
@@ -5,42 +5,28 @@ declare(strict_types=1);
 namespace LaminasTest\Filter;
 
 use ArrayObject;
-use Exception;
 use Laminas\Filter\Exception\DomainException;
 use Laminas\Filter\HtmlEntities as HtmlEntitiesFilter;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 use function file_get_contents;
-use function phpversion;
-use function restore_error_handler;
-use function set_error_handler;
 use function strlen;
-use function version_compare;
 
-use const E_NOTICE;
-use const E_WARNING;
 use const ENT_COMPAT;
 use const ENT_NOQUOTES;
 use const ENT_QUOTES;
 
 class HtmlEntitiesTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
-    /**
-     * Laminas\Filter\HtmlEntities object
-     *
-     * @var \Laminas\Filter\HtmlEntities
-     */
-    protected $_filter;
-    // @codingStandardsIgnoreEnd
+    private HtmlEntitiesFilter $filter;
 
     /**
      * Creates a new Laminas\Filter\HtmlEntities object for each test method
      */
     public function setUp(): void
     {
-        $this->_filter = new HtmlEntitiesFilter();
+        $this->filter = new HtmlEntitiesFilter();
     }
 
     /**
@@ -56,9 +42,9 @@ class HtmlEntitiesTest extends TestCase
             '"'      => '&quot;',
             '&'      => '&amp;',
         ];
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -67,7 +53,7 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testGetQuoteStyle(): void
     {
-        $this->assertSame(ENT_QUOTES, $this->_filter->getQuoteStyle());
+        self::assertSame(ENT_QUOTES, $this->filter->getQuoteStyle());
     }
 
     /**
@@ -75,8 +61,8 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testSetQuoteStyle(): void
     {
-        $this->_filter->setQuoteStyle(ENT_QUOTES);
-        $this->assertSame(ENT_QUOTES, $this->_filter->getQuoteStyle());
+        $this->filter->setQuoteStyle(ENT_QUOTES);
+        self::assertSame(ENT_QUOTES, $this->filter->getQuoteStyle());
     }
 
     /**
@@ -86,7 +72,7 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testGetCharSet(): void
     {
-        $this->assertSame('UTF-8', $this->_filter->getCharSet());
+        self::assertSame('UTF-8', $this->filter->getCharSet());
     }
 
     /**
@@ -94,8 +80,8 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testSetCharSet(): void
     {
-        $this->_filter->setCharSet('UTF-8');
-        $this->assertSame('UTF-8', $this->_filter->getCharSet());
+        $this->filter->setCharSet('UTF-8');
+        self::assertSame('UTF-8', $this->filter->getCharSet());
     }
 
     /**
@@ -103,7 +89,7 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testGetDoubleQuote(): void
     {
-        $this->assertSame(true, $this->_filter->getDoubleQuote());
+        self::assertSame(true, $this->filter->getDoubleQuote());
     }
 
     /**
@@ -111,8 +97,8 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testSetDoubleQuote(): void
     {
-        $this->_filter->setDoubleQuote(false);
-        $this->assertSame(false, $this->_filter->getDoubleQuote());
+        $this->filter->setDoubleQuote(false);
+        self::assertSame(false, $this->filter->getDoubleQuote());
     }
 
     /**
@@ -122,8 +108,8 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testFluentInterface(): void
     {
-        $instance = $this->_filter->setCharSet('UTF-8')->setQuoteStyle(ENT_QUOTES)->setDoubleQuote(false);
-        $this->assertInstanceOf(HtmlEntitiesFilter::class, $instance);
+        $instance = $this->filter->setCharSet('UTF-8')->setQuoteStyle(ENT_QUOTES)->setDoubleQuote(false);
+        self::assertInstanceOf(HtmlEntitiesFilter::class, $instance);
     }
 
     /**
@@ -142,8 +128,8 @@ class HtmlEntitiesTest extends TestCase
             $config
         );
 
-        $this->assertSame('ISO-8859-1', $filter->getEncoding());
-        $this->assertSame(5, $filter->getQuoteStyle());
+        self::assertSame('ISO-8859-1', $filter->getEncoding());
+        self::assertSame(5, $filter->getQuoteStyle());
     }
 
     /**
@@ -156,8 +142,8 @@ class HtmlEntitiesTest extends TestCase
         $input  = "A 'single' and " . '"double"';
         $result = 'A &#039;single&#039; and &quot;double&quot;';
 
-        $this->_filter->setQuoteStyle(ENT_QUOTES);
-        $this->assertSame($result, $this->_filter->filter($input));
+        $this->filter->setQuoteStyle(ENT_QUOTES);
+        self::assertSame($result, $this->filter->filter($input));
     }
 
     /**
@@ -170,8 +156,8 @@ class HtmlEntitiesTest extends TestCase
         $input  = "A 'single' and " . '"double"';
         $result = "A 'single' and &quot;double&quot;";
 
-        $this->_filter->setQuoteStyle(ENT_COMPAT);
-        $this->assertSame($result, $this->_filter->filter($input));
+        $this->filter->setQuoteStyle(ENT_COMPAT);
+        self::assertSame($result, $this->filter->filter($input));
     }
 
     /**
@@ -184,8 +170,8 @@ class HtmlEntitiesTest extends TestCase
         $input  = "A 'single' and " . '"double"';
         $result = "A 'single' and " . '"double"';
 
-        $this->_filter->setQuoteStyle(ENT_NOQUOTES);
-        $this->assertSame($result, $this->_filter->filter($input));
+        $this->filter->setQuoteStyle(ENT_NOQUOTES);
+        self::assertSame($result, $this->filter->filter($input));
     }
 
     /**
@@ -193,19 +179,9 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testCorrectsForEncodingMismatch(): void
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $string = file_get_contents(__DIR__ . '/_files/latin-1-text.txt');
-
-        // restore_error_handler can emit an E_WARNING; let's ignore that, as
-        // we want to test the returned value
-        set_error_handler([$this, 'errorHandler'], E_NOTICE | E_WARNING);
-        $result = $this->_filter->filter($string);
-        restore_error_handler();
-
-        $this->assertGreaterThan(0, strlen($result));
+        $result = $this->filter->filter($string);
+        self::assertGreaterThan(0, strlen($result));
     }
 
     /**
@@ -213,19 +189,9 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testStripsUnknownCharactersWhenEncodingMismatchDetected(): void
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $string = file_get_contents(__DIR__ . '/_files/latin-1-text.txt');
-
-        // restore_error_handler can emit an E_WARNING; let's ignore that, as
-        // we want to test the returned value
-        set_error_handler([$this, 'errorHandler'], E_NOTICE | E_WARNING);
-        $result = $this->_filter->filter($string);
-        restore_error_handler();
-
-        $this->assertContains('&quot;&quot;', $result);
+        $result = $this->filter->filter($string);
+        self::assertStringContainsString('&quot;&quot;', $result);
     }
 
     /**
@@ -233,25 +199,13 @@ class HtmlEntitiesTest extends TestCase
      */
     public function testRaisesExceptionIfEncodingMismatchDetectedAndFinalStringIsEmpty(): void
     {
-        if (version_compare(phpversion(), '5.4', '>=')) {
-            $this->markTestIncomplete('Code to test is not compatible with PHP 5.4 ');
-        }
-
         $string = file_get_contents(__DIR__ . '/_files/latin-1-dash-only.txt');
-
-        // restore_error_handler can emit an E_WARNING; let's ignore that, as
-        // we want to test the returned value
-        // Also, explicit try, so that we don't mess up PHPUnit error handlers
-        set_error_handler([$this, 'errorHandler'], E_NOTICE | E_WARNING);
-        try {
-            $result = $this->_filter->filter($string);
-            $this->fail('Expected exception from single non-utf-8 character');
-        } catch (Exception $e) {
-            $this->assertInstanceOf(DomainException::class, $e);
-        }
+        $this->expectException(DomainException::class);
+        $this->filter->filter($string);
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -268,15 +222,8 @@ class HtmlEntitiesTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
-        $this->assertSame($input, $this->_filter->filter($input));
-    }
-
-    /**
-     * Null error handler; used when wanting to ignore specific error types
-     */
-    public function errorHandler($errno, $errstr)
-    {
+        self::assertSame($input, $this->filter->filter($input));
     }
 }

--- a/test/InflectorTest.php
+++ b/test/InflectorTest.php
@@ -16,7 +16,6 @@ use Laminas\Filter\Word\CamelCaseToDash;
 use Laminas\Filter\Word\CamelCaseToUnderscore;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
-use Traversable;
 
 use function array_values;
 use function count;
@@ -26,16 +25,9 @@ use const DIRECTORY_SEPARATOR;
 
 class InflectorTest extends TestCase
 {
-    /** @var InflectorFilter */
-    protected $inflector;
+    private InflectorFilter $inflector;
+    protected FilterPluginManager $broker;
 
-    /** @var FilterPluginManager */
-    protected $broker;
-
-    /**
-     * Sets up the fixture, for example, open a network connection.
-     * This method is called before a test is executed.
-     */
     public function setUp(): void
     {
         $this->inflector = new InflectorFilter();
@@ -45,7 +37,7 @@ class InflectorTest extends TestCase
     public function testGetPluginManagerReturnsFilterManagerByDefault(): void
     {
         $broker = $this->inflector->getPluginManager();
-        $this->assertInstanceOf(FilterPluginManager::class, $broker);
+        self::assertInstanceOf(FilterPluginManager::class, $broker);
     }
 
     public function testSetPluginManagerAllowsSettingAlternatePluginManager(): void
@@ -54,145 +46,145 @@ class InflectorTest extends TestCase
         $manager        = new FilterPluginManager(new ServiceManager());
         $this->inflector->setPluginManager($manager);
         $receivedManager = $this->inflector->getPluginManager();
-        $this->assertNotSame($defaultManager, $receivedManager);
-        $this->assertSame($manager, $receivedManager);
+        self::assertNotSame($defaultManager, $receivedManager);
+        self::assertSame($manager, $receivedManager);
     }
 
     public function testTargetAccessorsWork(): void
     {
         $this->inflector->setTarget('foo/:bar/:baz');
-        $this->assertSame('foo/:bar/:baz', $this->inflector->getTarget());
+        self::assertSame('foo/:bar/:baz', $this->inflector->getTarget());
     }
 
     public function testTargetInitiallyNull(): void
     {
-        $this->assertNull($this->inflector->getTarget());
+        self::assertNull($this->inflector->getTarget());
     }
 
     public function testPassingTargetToConstructorSetsTarget(): void
     {
         $inflector = new InflectorFilter('foo/:bar/:baz');
-        $this->assertSame('foo/:bar/:baz', $inflector->getTarget());
+        self::assertSame('foo/:bar/:baz', $inflector->getTarget());
     }
 
     public function testSetTargetByReferenceWorks(): void
     {
         $target = 'foo/:bar/:baz';
         $this->inflector->setTargetReference($target);
-        $this->assertSame('foo/:bar/:baz', $this->inflector->getTarget());
+        self::assertSame('foo/:bar/:baz', $this->inflector->getTarget());
         $target .= '/:bat';
-        $this->assertSame('foo/:bar/:baz/:bat', $this->inflector->getTarget());
+        self::assertSame('foo/:bar/:baz/:bat', $this->inflector->getTarget());
     }
 
     public function testSetFilterRuleWithStringRuleCreatesRuleEntryAndFilterObject(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $this->inflector->setFilterRule('controller', PregReplace::class);
         $rules = $this->inflector->getRules('controller');
-        $this->assertSame(1, count($rules));
+        self::assertSame(1, count($rules));
         $filter = $rules[0];
-        $this->assertInstanceOf(FilterInterface::class, $filter);
+        self::assertInstanceOf(FilterInterface::class, $filter);
     }
 
     public function testSetFilterRuleWithFilterObjectCreatesRuleEntryWithFilterObject(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $filter = new PregReplace();
         $this->inflector->setFilterRule('controller', $filter);
         $rules = $this->inflector->getRules('controller');
-        $this->assertSame(1, count($rules));
+        self::assertSame(1, count($rules));
         $received = $rules[0];
-        $this->assertInstanceOf(FilterInterface::class, $received);
-        $this->assertSame($filter, $received);
+        self::assertInstanceOf(FilterInterface::class, $received);
+        self::assertSame($filter, $received);
     }
 
     public function testAddFilterRuleAppendsRuleEntries(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $this->inflector->setFilterRule('controller', [PregReplace::class, TestAsset\Alpha::class]);
         $rules = $this->inflector->getRules('controller');
-        $this->assertSame(2, count($rules));
-        $this->assertInstanceOf(FilterInterface::class, $rules[0]);
-        $this->assertInstanceOf(FilterInterface::class, $rules[1]);
+        self::assertSame(2, count($rules));
+        self::assertInstanceOf(FilterInterface::class, $rules[0]);
+        self::assertInstanceOf(FilterInterface::class, $rules[1]);
     }
 
     public function testSetStaticRuleCreatesScalarRuleEntry(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $this->inflector->setStaticRule('controller', 'foobar');
         $rules = $this->inflector->getRules('controller');
         /** @psalm-suppress DocblockTypeContradiction */
-        $this->assertSame('foobar', $rules);
+        self::assertSame('foobar', $rules);
     }
 
     public function testSetStaticRuleMultipleTimesOverwritesEntry(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $this->inflector->setStaticRule('controller', 'foobar');
         $rules = $this->inflector->getRules('controller');
         /** @psalm-suppress DocblockTypeContradiction */
-        $this->assertSame('foobar', $rules);
+        self::assertSame('foobar', $rules);
         $this->inflector->setStaticRule('controller', 'bazbat');
         $rules = $this->inflector->getRules('controller');
         /** @psalm-suppress DocblockTypeContradiction */
-        $this->assertSame('bazbat', $rules);
+        self::assertSame('bazbat', $rules);
     }
 
     public function testSetStaticRuleReferenceAllowsUpdatingRuleByReference(): void
     {
         $rule  = 'foobar';
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $this->inflector->setStaticRuleReference('controller', $rule);
         $rules = $this->inflector->getRules('controller');
         /** @psalm-suppress DocblockTypeContradiction */
-        $this->assertSame('foobar', $rules);
+        self::assertSame('foobar', $rules);
         $rule .= '/baz';
         $rules = $this->inflector->getRules('controller');
         /** @psalm-suppress DocblockTypeContradiction */
-        $this->assertSame('foobar/baz', $rules);
+        self::assertSame('foobar/baz', $rules);
     }
 
     public function testAddRulesCreatesAppropriateRuleEntries(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $this->inflector->addRules([
             ':controller' => [PregReplace::class, TestAsset\Alpha::class],
             'suffix'      => 'phtml',
         ]);
         $rules = $this->inflector->getRules();
-        $this->assertSame(2, count($rules));
-        $this->assertSame(2, count($rules['controller']));
-        $this->assertSame('phtml', $rules['suffix']);
+        self::assertSame(2, count($rules));
+        self::assertSame(2, count($rules['controller']));
+        self::assertSame('phtml', $rules['suffix']);
     }
 
     public function testSetRulesCreatesAppropriateRuleEntries(): void
     {
         $this->inflector->setStaticRule('some-rules', 'some-value');
         $rules = $this->inflector->getRules();
-        $this->assertSame(1, count($rules));
+        self::assertSame(1, count($rules));
         $this->inflector->setRules([
             ':controller' => [PregReplace::class, TestAsset\Alpha::class],
             'suffix'      => 'phtml',
         ]);
         $rules = $this->inflector->getRules();
-        $this->assertSame(2, count($rules));
-        $this->assertSame(2, count($rules['controller']));
+        self::assertSame(2, count($rules));
+        self::assertSame(2, count($rules['controller']));
         /** @psalm-suppress PossiblyInvalidArrayAccess */
-        $this->assertSame('phtml', $rules['suffix']);
+        self::assertSame('phtml', $rules['suffix']);
     }
 
     public function testGetRule(): void
     {
         $this->inflector->setFilterRule(':controller', [TestAsset\Alpha::class, StringToLower::class]);
-        $this->assertInstanceOf(StringToLower::class, $this->inflector->getRule('controller', 1));
-        $this->assertFalse($this->inflector->getRule('controller', 2));
+        self::assertInstanceOf(StringToLower::class, $this->inflector->getRule('controller', 1));
+        self::assertFalse($this->inflector->getRule('controller', 2));
     }
 
     public function testFilterTransformsStringAccordingToRules(): void
@@ -210,14 +202,14 @@ class InflectorTest extends TestCase
             'controller' => 'FooBar',
             'action'     => 'bazBat',
         ]);
-        $this->assertSame('Foo-Bar/baz-Bat.phtml', $filtered);
+        self::assertSame('Foo-Bar/baz-Bat.phtml', $filtered);
     }
 
     public function testTargetReplacementIdentiferAccessorsWork(): void
     {
-        $this->assertSame(':', $this->inflector->getTargetReplacementIdentifier());
+        self::assertSame(':', $this->inflector->getTargetReplacementIdentifier());
         $this->inflector->setTargetReplacementIdentifier('?=');
-        $this->assertSame('?=', $this->inflector->getTargetReplacementIdentifier());
+        self::assertSame('?=', $this->inflector->getTargetReplacementIdentifier());
     }
 
     public function testTargetReplacementIdentiferWorksWhenInflected(): void
@@ -238,21 +230,21 @@ class InflectorTest extends TestCase
             'action'     => 'bazBat',
         ]);
 
-        $this->assertSame('Foo-Bar/baz-Bat.phtml', $filtered);
+        self::assertSame('Foo-Bar/baz-Bat.phtml', $filtered);
     }
 
     public function testThrowTargetExceptionsAccessorsWork(): void
     {
-        $this->assertSame(':', $this->inflector->getTargetReplacementIdentifier());
+        self::assertSame(':', $this->inflector->getTargetReplacementIdentifier());
         $this->inflector->setTargetReplacementIdentifier('?=');
-        $this->assertSame('?=', $this->inflector->getTargetReplacementIdentifier());
+        self::assertSame('?=', $this->inflector->getTargetReplacementIdentifier());
     }
 
     public function testThrowTargetExceptionsOnAccessorsWork(): void
     {
-        $this->assertTrue($this->inflector->isThrowTargetExceptionsOn());
+        self::assertTrue($this->inflector->isThrowTargetExceptionsOn());
         $this->inflector->setThrowTargetExceptionsOn(false);
-        $this->assertFalse($this->inflector->isThrowTargetExceptionsOn());
+        self::assertFalse($this->inflector->isThrowTargetExceptionsOn());
     }
 
     public function testTargetExceptionThrownWhenTargetSourceNotSatisfied(): void
@@ -287,7 +279,7 @@ class InflectorTest extends TestCase
         );
 
         $filtered = $inflector(['controller' => 'FooBar', 'action' => 'MooToo']);
-        $this->assertSame($filtered, 'e:\path\to\foo-bar\Moo-Too.phtml');
+        self::assertSame($filtered, 'e:\path\to\foo-bar\Moo-Too.phtml');
     }
 
     /**
@@ -317,10 +309,8 @@ class InflectorTest extends TestCase
      * This method returns an ArrayObject instance in place of a
      * Laminas\Config\Config instance; the two are interchangeable, as inflectors
      * consume the more general array or Traversable types.
-     *
-     * @return Traversable
      */
-    public function getConfig()
+    public function getConfig(): ArrayObject
     {
         $options = $this->getOptions();
 
@@ -333,25 +323,25 @@ class InflectorTest extends TestCase
         // @codingStandardsIgnoreEnd
         $options = $this->getOptions();
         $broker  = $inflector->getPluginManager();
-        $this->assertSame($options['target'], $inflector->getTarget());
+        self::assertSame($options['target'], $inflector->getTarget());
 
-        $this->assertInstanceOf(FilterPluginManager::class, $broker);
-        $this->assertTrue($inflector->isThrowTargetExceptionsOn());
-        $this->assertSame($options['targetReplacementIdentifier'], $inflector->getTargetReplacementIdentifier());
+        self::assertInstanceOf(FilterPluginManager::class, $broker);
+        self::assertTrue($inflector->isThrowTargetExceptionsOn());
+        self::assertSame($options['targetReplacementIdentifier'], $inflector->getTargetReplacementIdentifier());
 
         $rules = $inflector->getRules();
         /** @psalm-suppress MixedArrayAccess */
         foreach (array_values($options['rules'][':controller']) as $key => $rule) {
             $class = get_class($rules['controller'][$key]);
-            $this->assertStringContainsString($rule, $class);
+            self::assertStringContainsString($rule, $class);
         }
         /** @psalm-suppress MixedArrayAccess */
         foreach (array_values($options['rules'][':action']) as $key => $rule) {
             $class = get_class($rules['action'][$key]);
-            $this->assertStringContainsString($rule, $class);
+            self::assertStringContainsString($rule, $class);
         }
         /** @psalm-suppress MixedArrayAccess */
-        $this->assertSame($options['rules']['suffix'], $rules['suffix']);
+        self::assertSame($options['rules']['suffix'], $rules['suffix']);
     }
 
     public function testSetConfigSetsStateAndRules(): void
@@ -386,7 +376,7 @@ class InflectorTest extends TestCase
             'controller' => 'FooBar',
             'action'     => 'MooToo',
         ]);
-        $this->assertSame(
+        self::assertSame(
             $filtered,
             'C:\htdocs\public\cache\00\01\42\app\modules'
             . DIRECTORY_SEPARATOR
@@ -402,10 +392,10 @@ class InflectorTest extends TestCase
     public function testTestForFalseInConstructorParams(): void
     {
         $inflector = new InflectorFilter('something', [], false, false);
-        $this->assertFalse($inflector->isThrowTargetExceptionsOn());
-        $this->assertSame($inflector->getTargetReplacementIdentifier(), ':');
+        self::assertFalse($inflector->isThrowTargetExceptionsOn());
+        self::assertSame($inflector->getTargetReplacementIdentifier(), ':');
 
-        $inflector = new InflectorFilter('something', [], false, '#');
+        new InflectorFilter('something', [], false, '#');
     }
 
     /**
@@ -415,7 +405,7 @@ class InflectorTest extends TestCase
     {
         $inflector = new InflectorFilter('abc');
         $inflector->addRules([':foo' => []]);
-        $this->assertSame($inflector(['fo' => 'bar']), 'abc');
+        self::assertSame($inflector(['fo' => 'bar']), 'abc');
     }
 
     /**
@@ -424,20 +414,20 @@ class InflectorTest extends TestCase
     public function testAddFilterRuleMultipleTimes(): void
     {
         $rules = $this->inflector->getRules();
-        $this->assertSame(0, count($rules));
+        self::assertSame(0, count($rules));
         $this->inflector->setFilterRule('controller', PregReplace::class);
         $rules = $this->inflector->getRules('controller');
-        $this->assertSame(1, count($rules));
+        self::assertSame(1, count($rules));
         $this->inflector->addFilterRule('controller', [TestAsset\Alpha::class, StringToLower::class]);
         $rules = $this->inflector->getRules('controller');
         /** @psalm-suppress PossiblyFalseArgument */
-        $this->assertSame(3, count($rules));
+        self::assertSame(3, count($rules));
         $this->_context = StringToLower::class;
         $this->inflector->setStaticRuleReference('context', $this->_context);
         $this->inflector->addFilterRule('controller', [TestAsset\Alpha::class, StringToLower::class]);
         $rules = $this->inflector->getRules('controller');
         /** @psalm-suppress PossiblyFalseArgument */
-        $this->assertSame(5, count($rules));
+        self::assertSame(5, count($rules));
     }
 
     /**

--- a/test/MonthSelectTest.php
+++ b/test/MonthSelectTest.php
@@ -12,18 +12,16 @@ class MonthSelectTest extends TestCase
 {
     /**
      * @dataProvider provideFilter
-     * @param array $options filter options
-     * @param array|mixed|null|string $input input provided to the filter
-     * @param array|mixed|null|string $expected expected output
      */
-    public function testFilter($options, $input, $expected): void
+    public function testFilter(array $options, array $input, ?string $expected): void
     {
         $sut = new MonthSelectFilter();
         $sut->setOptions($options);
-        $this->assertSame($expected, $sut->filter($input));
+        self::assertSame($expected, $sut->filter($input));
     }
 
-    public function provideFilter()
+    /** @return list<array{0: array, 1: array, 2: string|null}> */
+    public function provideFilter(): array
     {
         return [
             [[], ['year' => '2014', 'month' => '10'], '2014-10'],

--- a/test/PregReplaceTest.php
+++ b/test/PregReplaceTest.php
@@ -13,8 +13,7 @@ use function preg_match;
 
 class PregReplaceTest extends TestCase
 {
-    /** @var PregReplaceFilter */
-    protected $filter;
+    private PregReplaceFilter $filter;
 
     public function setUp(): void
     {
@@ -24,46 +23,46 @@ class PregReplaceTest extends TestCase
     public function testDetectsPcreUnicodeSupport(): void
     {
         $enabled = (bool) @preg_match('/\pL/u', 'a');
-        $this->assertSame($enabled, PregReplaceFilter::hasPcreUnicodeSupport());
+        self::assertSame($enabled, PregReplaceFilter::hasPcreUnicodeSupport());
     }
 
     public function testPassingPatternToConstructorSetsPattern(): void
     {
         $pattern = '#^controller/(?P<action>[a-z_-]+)#';
         $filter  = new PregReplaceFilter($pattern);
-        $this->assertSame($pattern, $filter->getPattern());
+        self::assertSame($pattern, $filter->getPattern());
     }
 
     public function testPassingReplacementToConstructorSetsReplacement(): void
     {
         $replace = 'foo/bar';
         $filter  = new PregReplaceFilter(null, $replace);
-        $this->assertSame($replace, $filter->getReplacement());
+        self::assertSame($replace, $filter->getReplacement());
     }
 
     public function testPatternIsNullByDefault(): void
     {
-        $this->assertNull($this->filter->getPattern());
+        self::assertNull($this->filter->getPattern());
     }
 
     public function testPatternAccessorsWork(): void
     {
         $pattern = '#^controller/(?P<action>[a-z_-]+)#';
         $this->filter->setPattern($pattern);
-        $this->assertSame($pattern, $this->filter->getPattern());
+        self::assertSame($pattern, $this->filter->getPattern());
     }
 
     public function testReplacementIsEmptyByDefault(): void
     {
         $replacement = $this->filter->getReplacement();
-        $this->assertEmpty($replacement);
+        self::assertEmpty($replacement);
     }
 
     public function testReplacementAccessorsWork(): void
     {
         $replacement = 'foo/bar';
         $this->filter->setReplacement($replacement);
-        $this->assertSame($replacement, $this->filter->getReplacement());
+        self::assertSame($replacement, $this->filter->getReplacement());
     }
 
     public function testFilterPerformsRegexReplacement(): void
@@ -73,8 +72,8 @@ class PregReplaceTest extends TestCase
 
         $string   = 'controller/action';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('foo/bar', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('foo/bar', $filtered);
     }
 
     public function testFilterPerformsRegexReplacementWithArray(): void
@@ -88,8 +87,8 @@ class PregReplaceTest extends TestCase
         ];
 
         $filtered = $filter($input);
-        $this->assertNotEquals($input, $filtered);
-        $this->assertSame([
+        self::assertNotEquals($input, $filtered);
+        self::assertSame([
             'foo/bar',
             'This should stay the same',
         ], $filtered);
@@ -102,7 +101,7 @@ class PregReplaceTest extends TestCase
         $filter->setReplacement('foo/bar');
         $this->expectException(Exception\RuntimeException::class);
         $this->expectExceptionMessage('does not have a valid pattern set');
-        $filtered = $filter($string);
+        $filter($string);
     }
 
     public function testPassingPatternWithExecModifierRaisesException(): void
@@ -113,7 +112,8 @@ class PregReplaceTest extends TestCase
         $filter->setPattern('/foo/e');
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -124,12 +124,12 @@ class PregReplaceTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
 
-        $this->assertSame($input, $filter->filter($input));
+        self::assertSame($input, $filter->filter($input));
     }
 
     /**
@@ -147,13 +147,12 @@ class PregReplaceTest extends TestCase
 
     /**
      * @dataProvider returnNonStringScalarValues
-     * @param int|float|bool $input
      */
-    public function testShouldFilterNonStringScalarValues($input): void
+    public function testShouldFilterNonStringScalarValues(float|bool|int $input): void
     {
         $filter = $this->filter;
         $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
 
-        $this->assertSame((string) $input, $filter($input));
+        self::assertSame((string) $input, $filter($input));
     }
 }

--- a/test/RealPathTest.php
+++ b/test/RealPathTest.php
@@ -15,29 +15,11 @@ use const PHP_OS;
 
 class RealPathTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
-    /**
-     * Path to test files
-     *
-     * @var string
-     */
-    protected $_filesPath;
+    private RealPathFilter $filter;
 
-    /**
-     * Laminas_Filter_Basename object
-     *
-     * @var RealPathFilter
-     */
-    protected $_filter;
-    // @codingStandardsIgnoreEnd
-
-    /**
-     * Creates a new Laminas_Filter_Basename object for each test method
-     */
     public function setUp(): void
     {
-        $this->_filesPath = __DIR__ . DIRECTORY_SEPARATOR . '_files';
-        $this->_filter    = new RealPathFilter();
+        $this->filter = new RealPathFilter();
     }
 
     /**
@@ -45,9 +27,10 @@ class RealPathTest extends TestCase
      */
     public function testFileExists(): void
     {
-        $filter   = $this->_filter;
-        $filename = 'file.1';
-        $this->assertStringContainsString($filename, $filter($this->_filesPath . DIRECTORY_SEPARATOR . $filename));
+        $filename = __DIR__ . '/_files/file.1';
+        $result   = $this->filter->filter($filename);
+        self::assertIsString($result);
+        self::assertStringContainsString($filename, $result);
     }
 
     /**
@@ -55,52 +38,52 @@ class RealPathTest extends TestCase
      */
     public function testFileNonexistent(): void
     {
-        $filter = $this->_filter;
-        $path   = '/path/to/nonexistent';
+        $path = '/path/to/nonexistent';
         if (false !== strpos(PHP_OS, 'BSD')) {
-            $this->assertSame($path, $filter($path));
+            self::assertSame($path, $this->filter->filter($path));
         } else {
-            $this->assertSame(false, $filter($path));
+            self::assertSame(false, $this->filter->filter($path));
         }
     }
 
     public function testGetAndSetExistsParameter(): void
     {
-        $this->assertTrue($this->_filter->getExists());
-        $this->_filter->setExists(false);
-        $this->assertFalse($this->_filter->getExists());
+        self::assertTrue($this->filter->getExists());
+        $this->filter->setExists(false);
+        self::assertFalse($this->filter->getExists());
 
-        $this->_filter->setExists(['unknown']);
-        $this->assertTrue($this->_filter->getExists());
+        $this->filter->setExists(['unknown']);
+        self::assertTrue($this->filter->getExists());
     }
 
-    public function testNonExistantPath(): void
+    public function testNonExistentPath(): void
     {
-        $filter = $this->_filter;
+        $filter = $this->filter;
         $filter->setExists(false);
 
         $path = __DIR__ . DIRECTORY_SEPARATOR . '_files';
-        $this->assertSame($path, $filter($path));
+        self::assertSame($path, $filter($path));
 
         $path2 = __DIR__ . DIRECTORY_SEPARATOR . '_files'
                . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '_files';
-        $this->assertSame($path, $filter($path2));
+        self::assertSame($path, $filter($path2));
 
         $path3 = __DIR__ . DIRECTORY_SEPARATOR . '_files'
                . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '.'
                . DIRECTORY_SEPARATOR . '_files';
-        $this->assertSame($path, $filter($path3));
+        self::assertSame($path, $filter($path3));
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
             [new stdClass()],
             [
                 [
-                    $this->_filesPath . DIRECTORY_SEPARATOR . 'file.1',
-                    $this->_filesPath . DIRECTORY_SEPARATOR . 'file.2',
+                    __DIR__ . '/_files/file.1',
+                    __DIR__ . '/_files/file.2',
                 ],
             ],
         ];
@@ -109,8 +92,8 @@ class RealPathTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
-        $this->assertSame($input, $this->_filter->filter($input));
+        self::assertSame($input, (new RealPathFilter())->filter($input));
     }
 }

--- a/test/StaticAnalysis/PluginRetrievalTest.php
+++ b/test/StaticAnalysis/PluginRetrievalTest.php
@@ -23,8 +23,7 @@ final class PluginRetrievalTest
         return $plugin->filter($value);
     }
 
-    /** @return mixed */
-    public function filterSomethingWithAnAlias(string $value)
+    public function filterSomethingWithAnAlias(string $value): mixed
     {
         $plugin = $this->pluginManager->get('stringToUpper');
 

--- a/test/StaticFilterTest.php
+++ b/test/StaticFilterTest.php
@@ -18,7 +18,6 @@ use function strtoupper;
 use const ENT_COMPAT;
 use const ENT_QUOTES;
 
-/** @psalm-suppress DeprecatedClass */
 class StaticFilterTest extends TestCase
 {
     /**
@@ -32,25 +31,25 @@ class StaticFilterTest extends TestCase
     public function testUsesFilterPluginManagerByDefault(): void
     {
         $plugins = StaticFilter::getPluginManager();
-        $this->assertInstanceOf(FilterPluginManager::class, $plugins);
+        self::assertInstanceOf(FilterPluginManager::class, $plugins);
     }
 
     public function testCanSpecifyCustomPluginManager(): void
     {
         $plugins = new FilterPluginManager(new ServiceManager());
         StaticFilter::setPluginManager($plugins);
-        $this->assertSame($plugins, StaticFilter::getPluginManager());
+        self::assertSame($plugins, StaticFilter::getPluginManager());
     }
 
     public function testCanResetPluginManagerByPassingNull(): void
     {
         $plugins = new FilterPluginManager(new ServiceManager());
         StaticFilter::setPluginManager($plugins);
-        $this->assertSame($plugins, StaticFilter::getPluginManager());
+        self::assertSame($plugins, StaticFilter::getPluginManager());
         StaticFilter::setPluginManager(null);
         $registered = StaticFilter::getPluginManager();
-        $this->assertNotSame($plugins, $registered);
-        $this->assertInstanceOf(FilterPluginManager::class, $registered);
+        self::assertNotSame($plugins, $registered);
+        self::assertInstanceOf(FilterPluginManager::class, $registered);
     }
 
     /**
@@ -61,7 +60,7 @@ class StaticFilterTest extends TestCase
     public function testStaticFactory(): void
     {
         $filteredValue = StaticFilter::execute('1a2b3c4d', Digits::class);
-        $this->assertSame('1234', $filteredValue);
+        self::assertSame('1234', $filteredValue);
     }
 
     /**
@@ -72,13 +71,13 @@ class StaticFilterTest extends TestCase
     {
         // Test HtmlEntities with one ctor argument.
         $filteredValue = StaticFilter::execute('"O\'Reilly"', HtmlEntities::class, ['quotestyle' => ENT_COMPAT]);
-        $this->assertSame('&quot;O\'Reilly&quot;', $filteredValue);
+        self::assertSame('&quot;O\'Reilly&quot;', $filteredValue);
 
         // Test HtmlEntities with a different ctor argument,
         // and make sure it gives the correct response
         // so we know it passed the arg to the ctor.
         $filteredValue = StaticFilter::execute('"O\'Reilly"', HtmlEntities::class, ['quotestyle' => ENT_QUOTES]);
-        $this->assertSame('&quot;O&#039;Reilly&quot;', $filteredValue);
+        self::assertSame('&quot;O&#039;Reilly&quot;', $filteredValue);
     }
 
     /**
@@ -103,9 +102,9 @@ class StaticFilterTest extends TestCase
         $second = StaticFilter::execute('foo', Callback::class, [
             'callback' => static fn($value) => 'BAR',
         ]);
-        $this->assertNotSame($first, $second);
-        $this->assertSame('FOO', $first);
-        $this->assertSame('BAR', $second);
+        self::assertNotSame($first, $second);
+        self::assertSame('FOO', $first);
+        self::assertSame('BAR', $second);
     }
 
     public function testThatCallablesRegisteredWithThePluginManagerCanBeExecuted(): void

--- a/test/StringPrefixTest.php
+++ b/test/StringPrefixTest.php
@@ -13,8 +13,7 @@ use function fopen;
 
 class StringPrefixTest extends TestCase
 {
-    /** @var StringPrefixFilter */
-    protected $filter;
+    private StringPrefixFilter $filter;
 
     public function setUp(): void
     {
@@ -31,7 +30,7 @@ class StringPrefixTest extends TestCase
         $prefix = 'ABC123';
         $filter->setPrefix($prefix);
 
-        $this->assertStringStartsWith($prefix, $filter('sample'));
+        self::assertStringStartsWith($prefix, $filter('sample'));
     }
 
     public function testWithoutPrefix(): void
@@ -44,9 +43,9 @@ class StringPrefixTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<string, array{0: mixed}>
      */
-    public function invalidPrefixesDataProvider()
+    public function invalidPrefixesDataProvider(): array
     {
         return [
             'int'                 => [1],
@@ -65,9 +64,8 @@ class StringPrefixTest extends TestCase
 
     /**
      * @dataProvider invalidPrefixesDataProvider
-     * @param mixed $prefix
      */
-    public function testInvalidPrefixes($prefix): void
+    public function testInvalidPrefixes(mixed $prefix): void
     {
         $filter = $this->filter;
 
@@ -85,6 +83,6 @@ class StringPrefixTest extends TestCase
         $prefix = 'ABC123';
         $filter->setPrefix($prefix);
 
-        $this->assertInstanceOf(stdClass::class, $filter(new stdClass()));
+        self::assertInstanceOf(stdClass::class, $filter(new stdClass()));
     }
 }

--- a/test/StringSuffixTest.php
+++ b/test/StringSuffixTest.php
@@ -13,8 +13,7 @@ use function fopen;
 
 class StringSuffixTest extends TestCase
 {
-    /** @var StringSuffixFilter */
-    protected $filter;
+    private StringSuffixFilter $filter;
 
     public function setUp(): void
     {
@@ -31,7 +30,7 @@ class StringSuffixTest extends TestCase
         $suffix = 'ABC123';
         $filter->setSuffix($suffix);
 
-        $this->assertStringEndsWith($suffix, $filter('sample'));
+        self::assertStringEndsWith($suffix, $filter('sample'));
     }
 
     public function testWithoutSuffix(): void
@@ -44,9 +43,9 @@ class StringSuffixTest extends TestCase
     }
 
     /**
-     * @return array
+     * @return array<string, array{0: mixed}>
      */
-    public function invalidSuffixesDataProvider()
+    public function invalidSuffixesDataProvider(): array
     {
         return [
             'int'                 => [1],
@@ -65,9 +64,8 @@ class StringSuffixTest extends TestCase
 
     /**
      * @dataProvider invalidSuffixesDataProvider
-     * @param mixed $suffix
      */
-    public function testInvalidSuffixes($suffix): void
+    public function testInvalidSuffixes(mixed $suffix): void
     {
         $filter = $this->filter;
 
@@ -85,6 +83,6 @@ class StringSuffixTest extends TestCase
         $suffix = 'ABC123';
         $filter->setSuffix($suffix);
 
-        $this->assertInstanceOf(stdClass::class, $filter(new stdClass()));
+        self::assertInstanceOf(stdClass::class, $filter(new stdClass()));
     }
 }

--- a/test/StringToLowerTest.php
+++ b/test/StringToLowerTest.php
@@ -13,21 +13,11 @@ use function mb_internal_encoding;
 
 class StringToLowerTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
-    /**
-     * Laminas_Filter_StringToLower object
-     *
-     * @var StringToLowerFilter
-     */
-    protected $_filter;
-    // @codingStandardsIgnoreEnd
+    private StringToLowerFilter $filter;
 
-    /**
-     * Creates a new Laminas_Filter_StringToLower object for each test method
-     */
     public function setUp(): void
     {
-        $this->_filter = new StringToLowerFilter();
+        $this->filter = new StringToLowerFilter();
     }
 
     /**
@@ -35,7 +25,7 @@ class StringToLowerTest extends TestCase
      */
     public function testBasic(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             'string' => 'string',
             'aBc1@3' => 'abc1@3',
@@ -43,7 +33,7 @@ class StringToLowerTest extends TestCase
         ];
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -53,20 +43,16 @@ class StringToLowerTest extends TestCase
      */
     public function testWithEncoding(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             'Ü'     => 'ü',
             'Ñ'     => 'ñ',
             'ÜÑ123' => 'üñ123',
         ];
 
-        try {
-            $filter->setEncoding('UTF-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $filter->setEncoding('UTF-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -74,7 +60,7 @@ class StringToLowerTest extends TestCase
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('is not supported');
-        $this->_filter->setEncoding('aaaaa');
+        $this->filter->setEncoding('aaaaa');
     }
 
     /**
@@ -88,13 +74,9 @@ class StringToLowerTest extends TestCase
             'ÜÑ123' => 'üñ123',
         ];
 
-        try {
-            $filter = new StringToLowerFilter(['encoding' => 'UTF-8']);
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $filter = new StringToLowerFilter(['encoding' => 'UTF-8']);
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -103,7 +85,7 @@ class StringToLowerTest extends TestCase
      */
     public function testCaseInsensitiveEncoding(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             'Ü'     => 'ü',
             'Ñ'     => 'ñ',
@@ -113,20 +95,20 @@ class StringToLowerTest extends TestCase
         try {
             $filter->setEncoding('UTF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
+                self::assertSame($output, $filter($input));
             }
 
-            $this->_filter->setEncoding('utf-8');
+            $this->filter->setEncoding('utf-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
+                self::assertSame($output, $filter($input));
             }
 
-            $this->_filter->setEncoding('UtF-8');
+            $this->filter->setEncoding('UtF-8');
             foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
+                self::assertSame($output, $filter($input));
             }
         } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+            self::assertContains('mbstring is required', $e->getMessage());
         }
     }
 
@@ -135,10 +117,11 @@ class StringToLowerTest extends TestCase
      */
     public function testDetectMbInternalEncoding(): void
     {
-        $this->assertSame(mb_internal_encoding(), $this->_filter->getEncoding());
+        self::assertSame(mb_internal_encoding(), $this->filter->getEncoding());
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -155,9 +138,9 @@ class StringToLowerTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
-        $this->assertSame($input, $this->_filter->filter($input));
+        self::assertSame($input, $this->filter->filter($input));
     }
 
     /**

--- a/test/StringToUpperTest.php
+++ b/test/StringToUpperTest.php
@@ -13,21 +13,11 @@ use function mb_internal_encoding;
 
 class StringToUpperTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
-    /**
-     * Laminas_Filter_StringToLower object
-     *
-     * @var StringToUpperFilter
-     */
-    protected $_filter;
-    // @codingStandardsIgnoreEnd
+    private StringToUpperFilter $filter;
 
-    /**
-     * Creates a new Laminas_Filter_StringToUpper object for each test method
-     */
     public function setUp(): void
     {
-        $this->_filter = new StringToUpperFilter();
+        $this->filter = new StringToUpperFilter();
     }
 
     /**
@@ -35,7 +25,7 @@ class StringToUpperTest extends TestCase
      */
     public function testBasic(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             'STRING' => 'STRING',
             'ABC1@3' => 'ABC1@3',
@@ -43,7 +33,7 @@ class StringToUpperTest extends TestCase
         ];
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -53,20 +43,16 @@ class StringToUpperTest extends TestCase
      */
     public function testWithEncoding(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             'ü'     => 'Ü',
             'ñ'     => 'Ñ',
             'üñ123' => 'ÜÑ123',
         ];
 
-        try {
-            $filter->setEncoding('UTF-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $filter->setEncoding('UTF-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -74,7 +60,7 @@ class StringToUpperTest extends TestCase
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('is not supported');
-        $this->_filter->setEncoding('aaaaa');
+        $this->filter->setEncoding('aaaaa');
     }
 
     /**
@@ -88,13 +74,9 @@ class StringToUpperTest extends TestCase
             'üñ123' => 'ÜÑ123',
         ];
 
-        try {
-            $filter = new StringToUpperFilter(['encoding' => 'UTF-8']);
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $filter = new StringToUpperFilter(['encoding' => 'UTF-8']);
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -103,30 +85,26 @@ class StringToUpperTest extends TestCase
      */
     public function testCaseInsensitiveEncoding(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             'ü'     => 'Ü',
             'ñ'     => 'Ñ',
             'üñ123' => 'ÜÑ123',
         ];
 
-        try {
-            $filter->setEncoding('UTF-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
+        $filter->setEncoding('UTF-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
+        }
 
-            $this->_filter->setEncoding('utf-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
+        $this->filter->setEncoding('utf-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
+        }
 
-            $this->_filter->setEncoding('UtF-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $this->filter->setEncoding('UtF-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -135,10 +113,11 @@ class StringToUpperTest extends TestCase
      */
     public function testDetectMbInternalEncoding(): void
     {
-        $this->assertSame(mb_internal_encoding(), $this->_filter->getEncoding());
+        self::assertSame(mb_internal_encoding(), $this->filter->getEncoding());
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -155,9 +134,9 @@ class StringToUpperTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
-        $this->assertSame($input, $this->_filter->filter($input));
+        self::assertSame($input, $this->filter->filter($input));
     }
 
     /**

--- a/test/StringTrimTest.php
+++ b/test/StringTrimTest.php
@@ -12,12 +12,8 @@ use function utf8_encode;
 
 class StringTrimTest extends TestCase
 {
-    /** @var StringTrim */
-    protected $filter;
+    private StringTrim $filter;
 
-    /**
-     * Creates a new Laminas\Filter\StringTrim object for each test method
-     */
     public function setUp(): void
     {
         $this->filter = new StringTrim();
@@ -35,18 +31,16 @@ class StringTrimTest extends TestCase
             "\ns\t"  => 's',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
     /**
      * Ensures that the filter follows expected behavior
-     *
-     * @return void
      */
-    public function testUtf8()
+    public function testUtf8(): void
     {
-        $this->assertSame('a', $this->filter->filter(utf8_encode("\xa0a\xa0")));
+        self::assertSame('a', $this->filter->filter(utf8_encode("\xa0a\xa0")));
     }
 
     /**
@@ -54,7 +48,7 @@ class StringTrimTest extends TestCase
      */
     public function testGetCharList(): void
     {
-        $this->assertSame(null, $this->filter->getCharList());
+        self::assertSame(null, $this->filter->getCharList());
     }
 
     /**
@@ -63,7 +57,7 @@ class StringTrimTest extends TestCase
     public function testSetCharList(): void
     {
         $this->filter->setCharList('&');
-        $this->assertSame('&', $this->filter->getCharList());
+        self::assertSame('&', $this->filter->getCharList());
     }
 
     /**
@@ -73,52 +67,53 @@ class StringTrimTest extends TestCase
     {
         $filter = $this->filter;
         $filter->setCharList('&');
-        $this->assertSame('a&b', $filter('&&a&b&&'));
+        self::assertSame('a&b', $filter('&&a&b&&'));
     }
 
     /**
      * @group Laminas-7183
      */
-    public function testLaminas7183()
+    public function testLaminas7183(): void
     {
         $filter = $this->filter;
-        $this->assertSame('Зенд', $filter('Зенд'));
+        self::assertSame('Зенд', $filter('Зенд'));
     }
 
     /**
      * @group Laminas-170
      */
-    public function testLaminas170()
+    public function testLaminas170(): void
     {
         $filter = $this->filter;
-        $this->assertSame('Расчет', $filter('Расчет'));
+        self::assertSame('Расчет', $filter('Расчет'));
     }
 
     /**
      * @group Laminas-7902
      */
-    public function testLaminas7902()
+    public function testLaminas7902(): void
     {
         $filter = $this->filter;
-        $this->assertSame('/', $filter('/'));
+        self::assertSame('/', $filter('/'));
     }
 
     /**
      * @group Laminas-10891
      */
-    public function testLaminas10891()
+    public function testLaminas10891(): void
     {
         $filter = $this->filter;
-        $this->assertSame('Зенд', $filter('   Зенд   '));
-        $this->assertSame('Зенд', $filter('Зенд   '));
-        $this->assertSame('Зенд', $filter('   Зенд'));
+        self::assertSame('Зенд', $filter('   Зенд   '));
+        self::assertSame('Зенд', $filter('Зенд   '));
+        self::assertSame('Зенд', $filter('   Зенд'));
 
         $trimCharlist = " \t\n\r\x0B・。";
         $filter       = new StringTrim($trimCharlist);
-        $this->assertSame('Зенд', $filter->filter('。  Зенд  。'));
+        self::assertSame('Зенд', $filter->filter('。  Зенд  。'));
     }
 
-    public function getNonStringValues()
+    /** @return list<array{0: mixed}> */
+    public function getNonStringValues(): array
     {
         return [
             [1],
@@ -134,10 +129,10 @@ class StringTrimTest extends TestCase
     /**
      * @dataProvider getNonStringValues
      */
-    public function testShouldNotFilterNonStringValues($value): void
+    public function testShouldNotFilterNonStringValues(mixed $value): void
     {
         $filtered = $this->filter->filter($value);
-        $this->assertSame($value, $filtered);
+        self::assertSame($value, $filtered);
     }
 
     /**
@@ -149,9 +144,9 @@ class StringTrimTest extends TestCase
     {
         $filter = $this->filter;
         $filter->setCharList('0');
-        $this->assertSame('a0b', $filter('00a0b00'));
+        self::assertSame('a0b', $filter('00a0b00'));
 
         $filter->setCharList('');
-        $this->assertSame('str', $filter(' str '));
+        self::assertSame('str', $filter(' str '));
     }
 }

--- a/test/StripNewlinesTest.php
+++ b/test/StripNewlinesTest.php
@@ -30,7 +30,7 @@ class StripNewlinesTest extends TestCase
             "Some text\nthat we have\r\nstuff in" => 'Some textthat we havestuff in',
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -41,10 +41,11 @@ class StripNewlinesTest extends TestCase
             "Some text\nthat we have\r\nstuff in" => 'Some textthat we havestuff in',
             "Some text\n"                         => 'Some text',
         ];
-        $this->assertSame(array_values($expected), $filter(array_keys($expected)));
+        self::assertSame(array_values($expected), $filter(array_keys($expected)));
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -55,11 +56,11 @@ class StripNewlinesTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new StripNewlinesFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 
     /**
@@ -77,12 +78,11 @@ class StripNewlinesTest extends TestCase
 
     /**
      * @dataProvider returnNonStringScalarValues
-     * @param int|float|bool $input
      */
-    public function testShouldFilterNonStringScalarValues($input): void
+    public function testShouldFilterNonStringScalarValues(float|bool|int $input): void
     {
         $filter = new StripNewlinesFilter();
 
-        $this->assertSame((string) $input, $filter($input));
+        self::assertSame((string) $input, $filter($input));
     }
 }

--- a/test/StripTagsTest.php
+++ b/test/StripTagsTest.php
@@ -12,21 +12,11 @@ use function iconv;
 
 class StripTagsTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
-    /**
-     * Laminas_Filter_StripTags object
-     *
-     * @var StripTagsFilter
-     */
-    protected $_filter;
-    // @codingStandardsIgnoreEnd
+    private StripTagsFilter $filter;
 
-    /**
-     * Creates a new Laminas_Filter_StripTags object for each test method
-     */
     public function setUp(): void
     {
-        $this->_filter = new StripTagsFilter();
+        $this->filter = new StripTagsFilter();
     }
 
     /**
@@ -34,7 +24,7 @@ class StripTagsTest extends TestCase
      */
     public function testGetTagsAllowed(): void
     {
-        $this->assertSame([], $this->_filter->getTagsAllowed());
+        self::assertSame([], $this->filter->getTagsAllowed());
     }
 
     /**
@@ -42,8 +32,8 @@ class StripTagsTest extends TestCase
      */
     public function testSetTagsAllowedString(): void
     {
-        $this->_filter->setTagsAllowed('b');
-        $this->assertSame(['b' => []], $this->_filter->getTagsAllowed());
+        $this->filter->setTagsAllowed('b');
+        self::assertSame(['b' => []], $this->filter->getTagsAllowed());
     }
 
     /**
@@ -56,13 +46,13 @@ class StripTagsTest extends TestCase
             'a'   => 'href',
             'div' => ['id', 'class'],
         ];
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $tagsAllowedExpected = [
             'b'   => [],
             'a'   => ['href' => null],
             'div' => ['id' => null, 'class' => null],
         ];
-        $this->assertSame($tagsAllowedExpected, $this->_filter->getTagsAllowed());
+        self::assertSame($tagsAllowedExpected, $this->filter->getTagsAllowed());
     }
 
     /**
@@ -70,7 +60,7 @@ class StripTagsTest extends TestCase
      */
     public function testGetAttributesAllowed(): void
     {
-        $this->assertSame([], $this->_filter->getAttributesAllowed());
+        self::assertSame([], $this->filter->getAttributesAllowed());
     }
 
     /**
@@ -78,8 +68,8 @@ class StripTagsTest extends TestCase
      */
     public function testSetAttributesAllowedString(): void
     {
-        $this->_filter->setAttributesAllowed('class');
-        $this->assertSame(['class' => null], $this->_filter->getAttributesAllowed());
+        $this->filter->setAttributesAllowed('class');
+        self::assertSame(['class' => null], $this->filter->getAttributesAllowed());
     }
 
     /**
@@ -93,65 +83,57 @@ class StripTagsTest extends TestCase
             'ok' => 'String',
             null,
         ];
-        $this->_filter->setAttributesAllowed($attributesAllowed);
+        $this->filter->setAttributesAllowed($attributesAllowed);
         $attributesAllowedExpected = [
             'class'  => null,
             'int'    => null,
             'string' => null,
         ];
-        $this->assertSame($attributesAllowedExpected, $this->_filter->getAttributesAllowed());
+        self::assertSame($attributesAllowedExpected, $this->filter->getAttributesAllowed());
     }
 
     /**
      * Ensures that a single unclosed tag is stripped in its entirety
-     *
-     * @return void
      */
-    public function testFilterTagUnclosed1()
+    public function testFilterTagUnclosed1(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '<a href="http://example.com" Some Text';
         $expected = '';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that a single tag is stripped
-     *
-     * @return void
      */
-    public function testFilterTag1()
+    public function testFilterTag1(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '<a href="example.com">foo</a>';
         $expected = 'foo';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that singly nested tags are stripped
-     *
-     * @return void
      */
-    public function testFilterTagNest1()
+    public function testFilterTagNest1(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '<a href="example.com"><b>foo</b></a>';
         $expected = 'foo';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that two successive tags are stripped
-     *
-     * @return void
      */
-    public function testFilterTag2()
+    public function testFilterTag2(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '<a href="example.com">foo</a><b>bar</b>';
         $expected = 'foobar';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -159,11 +141,11 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagAllowedBackwardCompatible(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '<BR><Br><bR><br/><br  /><br / ></br></bR>';
         $expected = '<br><br><br><br /><br /><br></br></br>';
-        $this->_filter->setTagsAllowed('br');
-        $this->assertSame($expected, $filter($input));
+        $this->filter->setTagsAllowed('br');
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -171,10 +153,10 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagPrefixGt(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '2 > 1 === true<br/>';
         $expected = '2  1 === true';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -182,10 +164,10 @@ class StripTagsTest extends TestCase
      */
     public function testFilterGt(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '2 > 1 === true ==> $object->property';
         $expected = '2  1 === true == $object-property';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -193,10 +175,10 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagWrappedGt(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '2 > 1 === true <==> $object->property';
         $expected = '2  1 === true  $object-property';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -204,12 +186,12 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagAllowedAttribute(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = 'img';
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $input    = '<IMG alt="foo" />';
         $expected = '<img />';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -217,14 +199,14 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagAllowedAttributeAllowed(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'img' => 'alt',
         ];
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $input    = '<IMG ALT="FOO" />';
         $expected = '<img alt="FOO" />';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -234,14 +216,14 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagAllowedAttributeAllowedGt(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'img' => 'alt',
         ];
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $input    = '<img alt="$object->property" />';
         $expected = '<img>property" /';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -249,14 +231,14 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagAllowedAttributeAllowedGtEscaped(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'img' => 'alt',
         ];
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $input    = '<img alt="$object-&gt;property" />';
         $expected = '<img alt="$object-&gt;property" />';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -265,14 +247,14 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagAllowedAttributeAllowedValueUnclosed(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'img' => ['alt', 'height', 'src', 'width'],
         ];
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $input    = '<img src="image.png" alt="square height="100" width="100" />';
         $expected = '<img src="image.png" alt="square height=" width="100" />';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -280,32 +262,30 @@ class StripTagsTest extends TestCase
      */
     public function testFilterTagAllowedAttributeAllowedValueMissing(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'input' => ['checked', 'name', 'type'],
         ];
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $input    = '<input name="foo" type="checkbox" checked />';
         $expected = '<input name="foo" type="checkbox" />';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
      * Ensures that the filter works properly for the data reported on fw-general on 2007-05-26
      *
      * @see    http://www.nabble.com/question-about-tag-filter-p10813688s16154.html
-     *
-     * @return void
      */
-    public function testFilter20070526()
+    public function testFilter20070526(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'object' => ['width', 'height'],
             'param'  => ['name', 'value'],
             'embed'  => ['src', 'type', 'wmode', 'width', 'height'],
         ];
-        $this->_filter->setTagsAllowed($tagsAllowed);
+        $this->filter->setTagsAllowed($tagsAllowed);
         $input    = '<object width="425" height="350"><param name="movie" value="http://www.example.com/path/to/movie">'
                . '</param><param name="wmode" value="transparent"></param><embed '
                . 'src="http://www.example.com/path/to/movie" type="application/x-shockwave-flash" '
@@ -314,7 +294,7 @@ class StripTagsTest extends TestCase
                . '</param><param name="wmode" value="transparent"></param><embed '
                . 'src="http://www.example.com/path/to/movie" type="application/x-shockwave-flash" '
                . 'wmode="transparent" width="425" height="350"></embed></object>';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -322,10 +302,10 @@ class StripTagsTest extends TestCase
      */
     public function testFilterComment(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = '<!-- a comment -->';
         $expected = '';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -333,10 +313,10 @@ class StripTagsTest extends TestCase
      */
     public function testFilterCommentWrapped(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = 'foo<!-- a comment -->bar';
         $expected = 'foobar';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -346,14 +326,14 @@ class StripTagsTest extends TestCase
      */
     public function testClosingAngleBracketInAllowedAttributeValue(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'a' => 'href',
         ];
         $filter->setTagsAllowed($tagsAllowed);
         $input    = '<a href="Some &gt; Text">';
         $expected = '<a href="Some &gt; Text">';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -364,13 +344,13 @@ class StripTagsTest extends TestCase
      */
     public function testAllowedAttributeValueMayEndWithEquals(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = [
             'element' => 'attribute',
         ];
         $filter->setTagsAllowed($tagsAllowed);
         $input = '<element attribute="a=">contents</element>';
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 
     /**
@@ -378,14 +358,14 @@ class StripTagsTest extends TestCase
      */
     public function testDisallowedAttributesSplitOverMultipleLinesShouldBeStripped(): void
     {
-        $filter      = $this->_filter;
+        $filter      = $this->filter;
         $tagsAllowed = ['a' => 'href'];
         $filter->setTagsAllowed($tagsAllowed);
         $input    = '<a href="https://getlaminas.org/issues" onclick
 =
     "alert(&quot;Gotcha&quot;); return false;">https://getlaminas.org/issues</a>';
         $filtered = $filter($input);
-        $this->assertStringNotContainsString('onclick', $filtered);
+        self::assertStringNotContainsString('onclick', $filtered);
     }
 
     /**
@@ -393,15 +373,15 @@ class StripTagsTest extends TestCase
      */
     public function testFilterIsoChars(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = 'äöü<!-- a comment -->äöü';
         $expected = 'äöüäöü';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
 
         $input  = 'äöü<!-- a comment -->äöü';
         $input  = iconv("UTF-8", "ISO-8859-1", $input);
         $output = $filter($input);
-        $this->assertNotEmpty($output);
+        self::assertNotEmpty($output);
     }
 
     /**
@@ -409,15 +389,15 @@ class StripTagsTest extends TestCase
      */
     public function testFilterIsoCharsInComment(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = 'äöü<!--üßüßüß-->äöü';
         $expected = 'äöüäöü';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
 
         $input  = 'äöü<!-- a comment -->äöü';
         $input  = iconv("UTF-8", "ISO-8859-1", $input);
         $output = $filter($input);
-        $this->assertNotEmpty($output);
+        self::assertNotEmpty($output);
     }
 
     /**
@@ -425,10 +405,10 @@ class StripTagsTest extends TestCase
      */
     public function testFilterSplitCommentTags(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = 'äöü<!-->üßüßüß<-->äöü';
         $expected = 'äöüäöü';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -436,10 +416,10 @@ class StripTagsTest extends TestCase
      */
     public function testCommentWithTagInSameLine(): void
     {
-        $filter   = $this->_filter;
+        $filter   = $this->filter;
         $input    = 'test <!-- testcomment --> test <div>div-content</div>';
         $expected = 'test  test div-content';
-        $this->assertSame($expected, $filter($input));
+        self::assertSame($expected, $filter($input));
     }
 
     /**
@@ -451,7 +431,7 @@ class StripTagsTest extends TestCase
 
         $input    = 'test <a /> test <div>div-content</div>';
         $expected = 'test <a /> test div-content';
-        $this->assertSame($expected, $filter->filter($input));
+        self::assertSame($expected, $filter->filter($input));
     }
 
     /**
@@ -468,10 +448,11 @@ class StripTagsTest extends TestCase
 
         $input    = '<img width="10" height="10" src=\'wont_be_matched.jpg\'>';
         $expected = '<img width="10" height="10" src=\'wont_be_matched.jpg\'>';
-        $this->assertSame($expected, $filter->filter($input));
+        self::assertSame($expected, $filter->filter($input));
     }
 
-    public function badCommentProvider()
+    /** @return list<array{0: string, 1: string}> */
+    public function badCommentProvider(): array
     {
         return [
             ['A <!--> B', 'A '], // Should be treated as just an open
@@ -490,12 +471,10 @@ class StripTagsTest extends TestCase
 
     /**
      * @dataProvider badCommentProvider
-     * @param string $input
-     * @param string $expected
      */
-    public function testBadCommentTags($input, $expected): void
+    public function testBadCommentTags(string $input, string $expected): void
     {
-        $this->assertSame($expected, $this->_filter->filter($input));
+        self::assertSame($expected, $this->filter->filter($input));
     }
 
      /**
@@ -505,7 +484,7 @@ class StripTagsTest extends TestCase
     {
         $input    = 'text<!-- not closed comment at the end';
         $expected = 'text';
-        $this->assertSame($expected, $this->_filter->filter($input));
+        self::assertSame($expected, $this->filter->filter($input));
     }
 
     /**
@@ -516,13 +495,14 @@ class StripTagsTest extends TestCase
         $input    = '<li data-disallowed="no!" data-name="Test User" data-id="11223"></li>';
         $expected = '<li data-name="Test User" data-id="11223"></li>';
 
-        $this->_filter->setTagsAllowed('li');
-        $this->_filter->setAttributesAllowed(['data-id', 'data-name']);
+        $this->filter->setTagsAllowed('li');
+        $this->filter->setAttributesAllowed(['data-id', 'data-name']);
 
-        $this->assertSame($expected, $this->_filter->filter($input));
+        self::assertSame($expected, $this->filter->filter($input));
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -539,20 +519,20 @@ class StripTagsTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
-        $this->assertSame($input, $this->_filter->filter($input));
+        self::assertSame($input, $this->filter->filter($input));
     }
 
     /**
      * @link https://github.com/zendframework/zf2/issues/5465
      */
-    public function testAttributeValueofZeroIsNotRemoved(): void
+    public function testAttributeValueOfZeroIsNotRemoved(): void
     {
         $input    = '<div id="0" data-custom="0" class="bogus"></div>';
         $expected = '<div id="0" data-custom="0"></div>';
-        $this->_filter->setTagsAllowed('div');
-        $this->_filter->setAttributesAllowed(['id', 'data-custom']);
-        $this->assertSame($expected, $this->_filter->filter($input));
+        $this->filter->setTagsAllowed('div');
+        $this->filter->setAttributesAllowed(['id', 'data-custom']);
+        self::assertSame($expected, $this->filter->filter($input));
     }
 }

--- a/test/TestAsset/Alpha.php
+++ b/test/TestAsset/Alpha.php
@@ -12,7 +12,7 @@ use function preg_replace;
 
 class Alpha extends AbstractFilter
 {
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value) && ! is_array($value)) {
             return $value;

--- a/test/ToFloatTest.php
+++ b/test/ToFloatTest.php
@@ -10,7 +10,8 @@ use stdClass;
 
 class ToFloatTest extends TestCase
 {
-    public function filterableValuesProvider()
+    /** @return array<string, array{0: mixed, 1: float}> */
+    public function filterableValuesProvider(): array
     {
         return [
             'string word' => ['string', 0.0],
@@ -32,16 +33,15 @@ class ToFloatTest extends TestCase
      * Ensures that the filter follows expected behavior
      *
      * @dataProvider filterableValuesProvider
-     * @param mixed $input
-     * @param string $expectedOutput
      */
-    public function testCanFilterScalarValuesAsExpected($input, $expectedOutput): void
+    public function testCanFilterScalarValuesAsExpected(mixed $input, float $expectedOutput): void
     {
         $filter = new ToFloatFilter();
-        $this->assertSame($expectedOutput, $filter($input));
+        self::assertSame($expectedOutput, $filter($input));
     }
 
-    public function unfilterableValuesProvider()
+    /** @return array<string, array{0: mixed}> */
+    public function unfilterableValuesProvider(): array
     {
         return [
             'null'   => [null],
@@ -57,11 +57,10 @@ class ToFloatTest extends TestCase
 
     /**
      * @dataProvider unfilterableValuesProvider
-     * @param mixed $input
      */
-    public function testReturnsUnfilterableInputVerbatim($input): void
+    public function testReturnsUnfilterableInputVerbatim(mixed $input): void
     {
         $filter = new ToFloatFilter();
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/ToIntTest.php
+++ b/test/ToIntTest.php
@@ -27,11 +27,12 @@ class ToIntTest extends TestCase
             '-0.9'   => 0,
         ];
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -48,10 +49,10 @@ class ToIntTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new ToIntFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/ToNullTest.php
+++ b/test/ToNullTest.php
@@ -20,33 +20,29 @@ class ToNullTest extends TestCase
             'type' => ToNullFilter::TYPE_INTEGER,
         ]);
 
-        $this->assertSame(ToNullFilter::TYPE_INTEGER, $filter->getType());
+        self::assertSame(ToNullFilter::TYPE_INTEGER, $filter->getType());
     }
 
     public function testConstructorParams(): void
     {
         $filter = new ToNullFilter(ToNullFilter::TYPE_INTEGER);
 
-        $this->assertSame(ToNullFilter::TYPE_INTEGER, $filter->getType());
+        self::assertSame(ToNullFilter::TYPE_INTEGER, $filter->getType());
     }
 
     /**
-     * @param mixed $value
-     * @param bool  $expected
      * @dataProvider defaultTestProvider
      */
-    public function testDefault($value, $expected): void
+    public function testDefault(mixed $value, mixed $expected): void
     {
         $filter = new ToNullFilter();
-        $this->assertSame($expected, $filter->filter($value));
+        self::assertSame($expected, $filter->filter($value));
     }
 
     /**
-     * @param int $type
-     * @param array $testData
      * @dataProvider typeTestProvider
      */
-    public function testTypes($type, $testData): void
+    public function testTypes(int $type, array $testData): void
     {
         $filter = new ToNullFilter($type);
         foreach ($testData as $data) {
@@ -58,7 +54,7 @@ class ToNullTest extends TestCase
                 var_export($expected, true),
                 $type
             );
-            $this->assertSame($expected, $filter->filter($value), $message);
+            self::assertSame($expected, $filter->filter($value), $message);
         }
     }
 
@@ -67,7 +63,7 @@ class ToNullTest extends TestCase
      * @param array $testData
      * @dataProvider combinedTypeTestProvider
      */
-    public function testCombinedTypes($typeData, $testData): void
+    public function testCombinedTypes(array $typeData, array $testData): void
     {
         foreach ($typeData as $type) {
             $filter = new ToNullFilter(['type' => $type]);
@@ -80,7 +76,7 @@ class ToNullTest extends TestCase
                     var_export($expected, true),
                     var_export($type, true)
                 );
-                $this->assertSame($expected, $filter->filter($value), $message);
+                self::assertSame($expected, $filter->filter($value), $message);
             }
         }
     }
@@ -96,23 +92,22 @@ class ToNullTest extends TestCase
     public function testGettingDefaultType(): void
     {
         $filter = new ToNullFilter();
-        $this->assertSame(63, $filter->getType());
+        self::assertSame(63, $filter->getType());
     }
 
     /**
      * Ensures that providing a duplicate initializing type results in the expected type
      *
-     * @param mixed $type Type to duplicate initialization
-     * @param mixed $expected Expected resulting type
      * @dataProvider duplicateTypeProvider
      */
-    public function testDuplicateInitializationResultsInCorrectType($type, $expected): void
+    public function testDuplicateInitializationResultsInCorrectType(int|string $type, int $expected): void
     {
         $filter = new ToNullFilter([$type, $type]);
-        $this->assertSame($expected, $filter->getType());
+        self::assertSame($expected, $filter->getType());
     }
 
-    public static function duplicateTypeProvider()
+    /** @return list<array{0: int|string, 1: int}> */
+    public static function duplicateTypeProvider(): array
     {
         return [
             [ToNullFilter::TYPE_BOOLEAN, ToNullFilter::TYPE_BOOLEAN],
@@ -132,7 +127,8 @@ class ToNullTest extends TestCase
         ];
     }
 
-    public static function defaultTestProvider()
+    /** @return list<array{0: mixed, 1: mixed}> */
+    public static function defaultTestProvider(): array
     {
         return [
             [null, null],
@@ -151,7 +147,8 @@ class ToNullTest extends TestCase
         ];
     }
 
-    public static function typeTestProvider()
+    /** @return list<array{0: int, 1: array}> */
+    public static function typeTestProvider(): array
     {
         return [
             [
@@ -283,7 +280,8 @@ class ToNullTest extends TestCase
         ];
     }
 
-    public static function combinedTypeTestProvider()
+    /** @return list<array[]> */
+    public static function combinedTypeTestProvider(): array
     {
         return [
             [

--- a/test/UpperCaseWordsTest.php
+++ b/test/UpperCaseWordsTest.php
@@ -16,21 +16,11 @@ use function mb_internal_encoding;
  */
 class UpperCaseWordsTest extends TestCase
 {
-    // @codingStandardsIgnoreStart
-    /**
-     * Laminas_Filter_UpperCaseWords object
-     *
-     * @var UpperCaseWordsFilter
-     */
-    protected $_filter;
-    // @codingStandardsIgnoreEnd
+    private UpperCaseWordsFilter $filter;
 
-    /**
-     * Creates a new Laminas_Filter_UpperCaseWords object for each test method
-     */
     public function setUp(): void
     {
-        $this->_filter = new UpperCaseWordsFilter();
+        $this->filter = new UpperCaseWordsFilter();
     }
 
     /**
@@ -38,7 +28,7 @@ class UpperCaseWordsTest extends TestCase
      */
     public function testBasic(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             'string' => 'String',
             'aBc1@3' => 'Abc1@3',
@@ -46,7 +36,7 @@ class UpperCaseWordsTest extends TestCase
         ];
 
         foreach ($valuesExpected as $input => $output) {
-            $this->assertSame($output, $filter($input));
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -56,20 +46,16 @@ class UpperCaseWordsTest extends TestCase
      */
     public function testWithEncoding(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             '√º'      => '√º',
             '√±'      => '√±',
             '√º√±123' => '√º√±123',
         ];
 
-        try {
-            $filter->setEncoding('UTF-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $filter->setEncoding('UTF-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -77,7 +63,7 @@ class UpperCaseWordsTest extends TestCase
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('is not supported');
-        $this->_filter->setEncoding('aaaaa');
+        $this->filter->setEncoding('aaaaa');
     }
 
     /**
@@ -91,15 +77,11 @@ class UpperCaseWordsTest extends TestCase
             '√º√±123' => '√º√±123',
         ];
 
-        try {
-            $filter = new UpperCaseWordsFilter([
-                'encoding' => 'UTF-8',
-            ]);
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $filter = new UpperCaseWordsFilter([
+            'encoding' => 'UTF-8',
+        ]);
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -108,30 +90,26 @@ class UpperCaseWordsTest extends TestCase
      */
     public function testCaseInsensitiveEncoding(): void
     {
-        $filter         = $this->_filter;
+        $filter         = $this->filter;
         $valuesExpected = [
             '√º'      => '√º',
             '√±'      => '√±',
             '√º√±123' => '√º√±123',
         ];
 
-        try {
-            $filter->setEncoding('UTF-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
+        $filter->setEncoding('UTF-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
+        }
 
-            $this->_filter->setEncoding('utf-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
+        $this->filter->setEncoding('utf-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
+        }
 
-            $this->_filter->setEncoding('UtF-8');
-            foreach ($valuesExpected as $input => $output) {
-                $this->assertSame($output, $filter($input));
-            }
-        } catch (Exception\ExtensionNotLoadedException $e) {
-            $this->assertContains('mbstring is required', $e->getMessage());
+        $this->filter->setEncoding('UtF-8');
+        foreach ($valuesExpected as $input => $output) {
+            self::assertSame($output, $filter($input));
         }
     }
 
@@ -140,10 +118,11 @@ class UpperCaseWordsTest extends TestCase
      */
     public function testDetectMbInternalEncoding(): void
     {
-        $this->assertSame(mb_internal_encoding(), $this->_filter->getEncoding());
+        self::assertSame(mb_internal_encoding(), $this->filter->getEncoding());
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -161,10 +140,9 @@ class UpperCaseWordsTest extends TestCase
 
     /**
      * @dataProvider returnUnfilteredDataProvider
-     * @param mixed $input
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
-        $this->assertSame($input, $this->_filter->filter($input));
+        self::assertSame($input, $this->filter->filter($input));
     }
 }

--- a/test/UriNormalizeTest.php
+++ b/test/UriNormalizeTest.php
@@ -13,11 +13,11 @@ class UriNormalizeTest extends TestCase
     /**
      * @dataProvider abnormalUriProvider
      */
-    public function testUrisAreNormalized($url, $expected): void
+    public function testUrisAreNormalized(string $url, string $expected): void
     {
         $filter = new UriNormalize();
         $result = $filter->filter($url);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
     public function testDefaultSchemeAffectsNormalization(): void
@@ -28,14 +28,15 @@ class UriNormalizeTest extends TestCase
     /**
      * @dataProvider enforcedSchemeTestcaseProvider
      */
-    public function testEnforcedScheme($scheme, $input, $expected): void
+    public function testEnforcedScheme(string $scheme, string $input, string $expected): void
     {
         $filter = new UriNormalize(['enforcedScheme' => $scheme]);
         $result = $filter->filter($input);
-        $this->assertSame($expected, $result);
+        self::assertSame($expected, $result);
     }
 
-    public static function abnormalUriProvider()
+    /** @return list<array{0: string, 1: string}> */
+    public static function abnormalUriProvider(): array
     {
         return [
             ['http://www.example.com', 'http://www.example.com/'],
@@ -47,7 +48,8 @@ class UriNormalizeTest extends TestCase
         ];
     }
 
-    public static function enforcedSchemeTestcaseProvider()
+    /** @return list<string[]> */
+    public static function enforcedSchemeTestcaseProvider(): array
     {
         return [
             ['ftp', 'http://www.example.com', 'http://www.example.com/'], // no effect - this one has a scheme
@@ -59,7 +61,8 @@ class UriNormalizeTest extends TestCase
         ];
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -76,10 +79,10 @@ class UriNormalizeTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new UriNormalize();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 }

--- a/test/WhitelistTest.php
+++ b/test/WhitelistTest.php
@@ -6,23 +6,16 @@ namespace LaminasTest\Filter;
 
 use Laminas\Filter\AllowList;
 use Laminas\Filter\FilterPluginManager;
-use Laminas\Filter\Whitelist as WhitelistFilter;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 
 class WhitelistTest extends TestCase
 {
-    public function testConstructor(): void
-    {
-        $filter = new WhitelistFilter();
-        $this->assertInstanceOf(AllowList::class, $filter);
-    }
-
     public function testWithPluginManager(): void
     {
         $pluginManager = new FilterPluginManager(new ServiceManager());
         $filter        = $pluginManager->get('whitelist');
 
-        $this->assertInstanceOf(AllowList::class, $filter);
+        self::assertInstanceOf(AllowList::class, $filter);
     }
 }

--- a/test/Word/CamelCaseToDashTest.php
+++ b/test/Word/CamelCaseToDashTest.php
@@ -15,7 +15,7 @@ class CamelCaseToDashTest extends TestCase
         $filter   = new CamelCaseToDashFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Camel-Cased-Words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Camel-Cased-Words', $filtered);
     }
 }

--- a/test/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
+++ b/test/Word/CamelCaseToSeparatorNoPcreUnicodeTest.php
@@ -13,13 +13,12 @@ use ReflectionProperty;
  */
 class CamelCaseToSeparatorNoPcreUnicodeTest extends CamelCaseToSeparatorTest
 {
-    protected $reflection;
+    protected ReflectionProperty $reflection;
 
     public function setUp(): void
     {
         if (! StringUtils::hasPcreUnicodeSupport()) {
-            $this->markTestSkipped('PCRE is not compiled with Unicode support');
-            return;
+            self::markTestSkipped('PCRE is not compiled with Unicode support');
         }
 
         $this->reflection = new ReflectionProperty(StringUtils::class, 'hasPcreUnicodeSupport');

--- a/test/Word/CamelCaseToSeparatorTest.php
+++ b/test/Word/CamelCaseToSeparatorTest.php
@@ -16,8 +16,8 @@ class CamelCaseToSeparatorTest extends TestCase
         $filter   = new CamelCaseToSeparatorFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Camel Cased Words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Camel Cased Words', $filtered);
     }
 
     public function testFilterSeparatesCamelCasedWordsWithProvidedSeparator(): void
@@ -26,8 +26,8 @@ class CamelCaseToSeparatorTest extends TestCase
         $filter   = new CamelCaseToSeparatorFilter(':-#');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Camel:-#Cased:-#Words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Camel:-#Cased:-#Words', $filtered);
     }
 
     public function testFilterSeperatesMultipleUppercasedLettersAndUnderscores(): void
@@ -36,8 +36,8 @@ class CamelCaseToSeparatorTest extends TestCase
         $filter   = new CamelCaseToSeparatorFilter('_');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('These_Are_SOME_Camel_CASED_Words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('These_Are_SOME_Camel_CASED_Words', $filtered);
     }
 
     public function testFilterSupportArray(): void
@@ -51,11 +51,12 @@ class CamelCaseToSeparatorTest extends TestCase
 
         $filtered = $filter($input);
 
-        $this->assertNotEquals($input, $filtered);
-        $this->assertSame(['Camel Cased Words', 'something Different'], $filtered);
+        self::assertNotEquals($input, $filtered);
+        self::assertSame(['Camel Cased Words', 'something Different'], $filtered);
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -66,11 +67,11 @@ class CamelCaseToSeparatorTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new CamelCaseToSeparatorFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 
     /**
@@ -88,12 +89,11 @@ class CamelCaseToSeparatorTest extends TestCase
 
     /**
      * @dataProvider returnNonStringScalarValues
-     * @param int|float|bool $input
      */
-    public function testShouldFilterNonStringScalarValues($input): void
+    public function testShouldFilterNonStringScalarValues(int|float|bool $input): void
     {
         $filter = new CamelCaseToSeparatorFilter();
 
-        $this->assertSame((string) $input, $filter($input));
+        self::assertSame((string) $input, $filter($input));
     }
 }

--- a/test/Word/CamelCaseToUnderscoreTest.php
+++ b/test/Word/CamelCaseToUnderscoreTest.php
@@ -15,31 +15,31 @@ class CamelCaseToUnderscoreTest extends TestCase
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Camel_Cased_Words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Camel_Cased_Words', $filtered);
     }
 
-    public function testFilterSeperatingNumbersToUnterscore(): void
+    public function testFilterSeparatingNumbersToUnderscore(): void
     {
         $string   = 'PaTitle';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Pa_Title', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Pa_Title', $filtered);
 
         $string   = 'Pa2Title';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Pa2_Title', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Pa2_Title', $filtered);
 
         $string   = 'Pa2aTitle';
         $filter   = new CamelCaseToUnderscoreFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Pa2a_Title', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Pa2a_Title', $filtered);
     }
 }

--- a/test/Word/DashToCamelCaseTest.php
+++ b/test/Word/DashToCamelCaseTest.php
@@ -15,7 +15,7 @@ class DashToCamelCaseTest extends TestCase
         $filter   = new DashToCamelCaseFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('CamelCasedWords', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('CamelCasedWords', $filtered);
     }
 }

--- a/test/Word/DashToSeparatorTest.php
+++ b/test/Word/DashToSeparatorTest.php
@@ -16,8 +16,8 @@ class DashToSeparatorTest extends TestCase
         $filter   = new DashToSeparatorFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash separated words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash separated words', $filtered);
     }
 
     public function testFilterSeparatesDashedWordsWithSomeString(): void
@@ -26,8 +26,8 @@ class DashToSeparatorTest extends TestCase
         $filter   = new DashToSeparatorFilter(':-:');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash:-:separated:-:words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash:-:separated:-:words', $filtered);
     }
 
     public function testFilterSupportArray(): void
@@ -41,11 +41,12 @@ class DashToSeparatorTest extends TestCase
 
         $filtered = $filter($input);
 
-        $this->assertNotEquals($input, $filtered);
-        $this->assertSame(['dash separated words', 'something different'], $filtered);
+        self::assertNotEquals($input, $filtered);
+        self::assertSame(['dash separated words', 'something different'], $filtered);
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -56,11 +57,11 @@ class DashToSeparatorTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new DashToSeparatorFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 
     /**
@@ -78,12 +79,11 @@ class DashToSeparatorTest extends TestCase
 
     /**
      * @dataProvider returnNonStringScalarValues
-     * @param int|float|bool $input
      */
-    public function testShouldFilterNonStringScalarValues($input): void
+    public function testShouldFilterNonStringScalarValues(float|bool|int $input): void
     {
         $filter = new DashToSeparatorFilter();
 
-        $this->assertSame((string) $input, $filter($input));
+        self::assertSame((string) $input, $filter($input));
     }
 }

--- a/test/Word/DashToUnderscoreTest.php
+++ b/test/Word/DashToUnderscoreTest.php
@@ -15,7 +15,7 @@ class DashToUnderscoreTest extends TestCase
         $filter   = new DashToUnderscoreFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash_separated_words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash_separated_words', $filtered);
     }
 }

--- a/test/Word/SeparatorToCamelCaseTest.php
+++ b/test/Word/SeparatorToCamelCaseTest.php
@@ -18,8 +18,8 @@ class SeparatorToCamelCaseTest extends TestCase
         $filter   = new SeparatorToCamelCaseFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('CamelCasedWords', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('CamelCasedWords', $filtered);
     }
 
     public function testFilterSeparatesCamelCasedWordsWithProvidedSeparator(): void
@@ -28,8 +28,8 @@ class SeparatorToCamelCaseTest extends TestCase
         $filter   = new SeparatorToCamelCaseFilter(':-:');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('CamelCasedWords', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('CamelCasedWords', $filtered);
     }
 
     /**
@@ -38,15 +38,15 @@ class SeparatorToCamelCaseTest extends TestCase
     public function testFilterSeparatesUniCodeCamelCasedWordsWithProvidedSeparator(): void
     {
         if (! extension_loaded('mbstring')) {
-            $this->markTestSkipped('Extension mbstring not available');
+            self::markTestSkipped('Extension mbstring not available');
         }
 
         $string   = 'camel:-:cased:-:Words';
         $filter   = new SeparatorToCamelCaseFilter(':-:');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('CamelCasedWords', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('CamelCasedWords', $filtered);
     }
 
     /**
@@ -55,15 +55,15 @@ class SeparatorToCamelCaseTest extends TestCase
     public function testFilterSeparatesUniCodeCamelCasedUserWordsWithProvidedSeparator(): void
     {
         if (! extension_loaded('mbstring')) {
-            $this->markTestSkipped('Extension mbstring not available');
+            self::markTestSkipped('Extension mbstring not available');
         }
 
         $string   = 'test šuma';
         $filter   = new SeparatorToCamelCaseFilter(' ');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('TestŠuma', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('TestŠuma', $filtered);
     }
 
     /**
@@ -75,8 +75,8 @@ class SeparatorToCamelCaseTest extends TestCase
         $filter   = new SeparatorToCamelCaseFilter('_');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('User2User', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('User2User', $filtered);
     }
 
     public function testFilterSupportArray(): void
@@ -90,11 +90,12 @@ class SeparatorToCamelCaseTest extends TestCase
 
         $filtered = $filter($input);
 
-        $this->assertNotEquals($input, $filtered);
-        $this->assertSame(['CamelCasedWords', 'SomethingDifferent'], $filtered);
+        self::assertNotEquals($input, $filtered);
+        self::assertSame(['CamelCasedWords', 'SomethingDifferent'], $filtered);
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -105,11 +106,11 @@ class SeparatorToCamelCaseTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new SeparatorToCamelCaseFilter();
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 
     /**
@@ -127,12 +128,11 @@ class SeparatorToCamelCaseTest extends TestCase
 
     /**
      * @dataProvider returnNonStringScalarValues
-     * @param int|float|bool $input
      */
-    public function testShouldFilterNonStringScalarValues($input): void
+    public function testShouldFilterNonStringScalarValues(float|bool|int $input): void
     {
         $filter = new SeparatorToCamelCaseFilter();
 
-        $this->assertSame((string) $input, $filter($input));
+        self::assertSame((string) $input, $filter($input));
     }
 }

--- a/test/Word/SeparatorToDashTest.php
+++ b/test/Word/SeparatorToDashTest.php
@@ -15,8 +15,8 @@ class SeparatorToDashTest extends TestCase
         $filter   = new SeparatorToDashFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash-separated-words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash-separated-words', $filtered);
     }
 
     public function testFilterSeparatesDashedWordsWithSomeString(): void
@@ -25,7 +25,7 @@ class SeparatorToDashTest extends TestCase
         $filter   = new SeparatorToDashFilter('=');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash-separated-words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash-separated-words', $filtered);
     }
 }

--- a/test/Word/SeparatorToSeparatorTest.php
+++ b/test/Word/SeparatorToSeparatorTest.php
@@ -16,8 +16,8 @@ class SeparatorToSeparatorTest extends TestCase
         $filter   = new SeparatorToSeparatorFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash-separated-words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash-separated-words', $filtered);
     }
 
     public function testFilterSupportArray(): void
@@ -30,8 +30,8 @@ class SeparatorToSeparatorTest extends TestCase
         ];
         $filtered = $filter($input);
 
-        $this->assertNotEquals($input, $filtered);
-        $this->assertSame([
+        self::assertNotEquals($input, $filtered);
+        self::assertSame([
             'dash-separated-words',
             '=test-something',
         ], $filtered);
@@ -43,8 +43,8 @@ class SeparatorToSeparatorTest extends TestCase
         $filter   = new SeparatorToSeparatorFilter('=');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash-separated-words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash-separated-words', $filtered);
     }
 
     public function testFilterSeparatesWordsWithSearchAndReplacementSpecified(): void
@@ -53,11 +53,12 @@ class SeparatorToSeparatorTest extends TestCase
         $filter   = new SeparatorToSeparatorFilter('=', '?');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('dash?separated?words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('dash?separated?words', $filtered);
     }
 
-    public function returnUnfilteredDataProvider()
+    /** @return list<array{0: mixed}> */
+    public function returnUnfilteredDataProvider(): array
     {
         return [
             [null],
@@ -68,11 +69,11 @@ class SeparatorToSeparatorTest extends TestCase
     /**
      * @dataProvider returnUnfilteredDataProvider
      */
-    public function testReturnUnfiltered($input): void
+    public function testReturnUnfiltered(mixed $input): void
     {
         $filter = new SeparatorToSeparatorFilter('=', '?');
 
-        $this->assertSame($input, $filter($input));
+        self::assertSame($input, $filter($input));
     }
 
     /**
@@ -90,12 +91,11 @@ class SeparatorToSeparatorTest extends TestCase
 
     /**
      * @dataProvider returnNonStringScalarValues
-     * @param int|float|bool $input
      */
-    public function testShouldFilterNonStringScalarValues($input): void
+    public function testShouldFilterNonStringScalarValues(float|bool|int $input): void
     {
         $filter = new SeparatorToSeparatorFilter('=', '?');
 
-        $this->assertSame((string) $input, $filter($input));
+        self::assertSame((string) $input, $filter($input));
     }
 }

--- a/test/Word/UnderscoreToCamelCaseTest.php
+++ b/test/Word/UnderscoreToCamelCaseTest.php
@@ -15,8 +15,8 @@ class UnderscoreToCamelCaseTest extends TestCase
         $filter   = new UnderscoreToCamelCaseFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('CamelCasedWords', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('CamelCasedWords', $filtered);
     }
 
     /**
@@ -28,32 +28,32 @@ class UnderscoreToCamelCaseTest extends TestCase
 
         $string   = 'laminas_project';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('LaminasProject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('LaminasProject', $filtered);
 
         $string   = 'laminas_Project';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('LaminasProject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('LaminasProject', $filtered);
 
         $string   = 'laminasProject';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('LaminasProject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('LaminasProject', $filtered);
 
         $string   = 'laminasproject';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Laminasproject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Laminasproject', $filtered);
 
         $string   = '_laminasproject';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('Laminasproject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('Laminasproject', $filtered);
 
         $string   = '_laminas_project';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('LaminasProject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('LaminasProject', $filtered);
     }
 }

--- a/test/Word/UnderscoreToDashTest.php
+++ b/test/Word/UnderscoreToDashTest.php
@@ -15,7 +15,7 @@ class UnderscoreToDashTest extends TestCase
         $filter   = new UnderscoreToDashFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('underscore-separated-words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('underscore-separated-words', $filtered);
     }
 }

--- a/test/Word/UnderscoreToSeparatorTest.php
+++ b/test/Word/UnderscoreToSeparatorTest.php
@@ -15,8 +15,8 @@ class UnderscoreToSeparatorTest extends TestCase
         $filter   = new UnderscoreToSeparatorFilter();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('underscore separated words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('underscore separated words', $filtered);
     }
 
     public function testFilterSeparatesCamelCasedWordsProvidedSeparator(): void
@@ -25,7 +25,7 @@ class UnderscoreToSeparatorTest extends TestCase
         $filter   = new UnderscoreToSeparatorFilter(':=:');
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('underscore:=:separated:=:words', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('underscore:=:separated:=:words', $filtered);
     }
 }

--- a/test/Word/UnderscoreToStudlyCaseTest.php
+++ b/test/Word/UnderscoreToStudlyCaseTest.php
@@ -15,8 +15,8 @@ class UnderscoreToStudlyCaseTest extends TestCase
         $filter   = new UnderscoreToStudlyCase();
         $filtered = $filter($string);
 
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('studlyCasedWords', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('studlyCasedWords', $filtered);
     }
 
     public function testSomeFilterValues(): void
@@ -25,31 +25,31 @@ class UnderscoreToStudlyCaseTest extends TestCase
 
         $string   = 'laminas_project';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('laminasProject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('laminasProject', $filtered);
 
         $string   = 'laminas_Project';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('laminasProject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('laminasProject', $filtered);
 
         $string   = 'laminasProject';
         $filtered = $filter($string);
-        $this->assertSame('laminasProject', $filtered);
+        self::assertSame('laminasProject', $filtered);
 
         $string   = 'laminas';
         $filtered = $filter($string);
-        $this->assertSame('laminas', $filtered);
+        self::assertSame('laminas', $filtered);
 
         $string   = '_laminas';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('laminas', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('laminas', $filtered);
 
         $string   = '_laminas_project';
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame('laminasProject', $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame('laminasProject', $filtered);
     }
 
     public function testFiltersArray(): void
@@ -58,8 +58,8 @@ class UnderscoreToStudlyCaseTest extends TestCase
 
         $string   = ['laminas_project', '_laminas_project'];
         $filtered = $filter($string);
-        $this->assertNotEquals($string, $filtered);
-        $this->assertSame(['laminasProject', 'laminasProject'], $filtered);
+        self::assertNotEquals($string, $filtered);
+        self::assertSame(['laminasProject', 'laminasProject'], $filtered);
     }
 
     public function testWithEmpties(): void
@@ -68,10 +68,10 @@ class UnderscoreToStudlyCaseTest extends TestCase
 
         $string   = '';
         $filtered = $filter($string);
-        $this->assertSame('', $filtered);
+        self::assertSame('', $filtered);
 
         $string   = ['', 'Laminas_Project'];
         $filtered = $filter($string);
-        $this->assertSame(['', 'laminasProject'], $filtered);
+        self::assertSame(['', 'laminasProject'], $filtered);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

- Consistent static assertions to improve volume of errors present in common IDEs
- Many general improvements to static analysis with a decent reduction in the baseline
- Re-enable some skipped tests
- `mbstring` is a hard requirement
