### PR TITLE
Deprecate `lzf`, `rar` and `snappy` compression adapters

### DIFF
--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+#
+# @todo The compression adapters that require these non-standard extensions have been deprecated for removal in 3.0
+#       This file can be removed along with the adapters.
+#
+
 WORKING_DIRECTORY=$2
 JOB=$3
 PHP_VERSION=$(echo "${JOB}" | jq -r '.php')

--- a/docs/book/standard-filters.md
+++ b/docs/book/standard-filters.md
@@ -412,10 +412,10 @@ The following compression formats are supported by their own adapter:
 
 - **Bz2**
 - **Gz**
-- **Lzf**
-- **Rar**
 - **Tar**
 - **Zip**
+- **Lzf**
+- **Rar**
 
 Each compression format has different capabilities as described below. All
 compression filters may be used in approximately the same ways, and differ
@@ -624,6 +624,10 @@ accepts an array of all options.
 
 ### Lzf Adapter
 
+> ### Deprecated Adapter
+>
+> This compression adapter has been deprecated for removal in version 3.0. Please consider an alternative compression format such as `gz` or `bz2`
+
 The Lzf Adapter can compress and decompress:
 
 - Strings
@@ -637,6 +641,10 @@ This adapter makes use of PHP's Lzf extension.
 There are no options available to customize this adapter.
 
 ### Rar Adapter
+
+> ### Deprecated Adapter
+>
+> This compression adapter has been deprecated for removal in version 3.0. Please consider an alternative compression format such as `gz` or `bz2`
 
 The Rar Adapter can compress and decompress:
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -42,9 +42,6 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Boolean.php">
-    <DocblockTypeContradiction occurrences="1">
-      <code>gettype($translations)</code>
-    </DocblockTypeContradiction>
     <MixedArgumentTypeCoercion occurrences="1">
       <code>$typeOrOptions</code>
     </MixedArgumentTypeCoercion>
@@ -67,9 +64,8 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $flag</code>
     </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType occurrences="2">
+    <RedundantConditionGivenDocblockType occurrences="1">
       <code>is_int($value)</code>
-      <code>is_object($translations)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Callback.php">
@@ -892,20 +888,12 @@
     </PossiblyUndefinedVariable>
   </file>
   <file src="src/FilterChain.php">
-    <DocblockTypeContradiction occurrences="2">
-      <code>gettype($callback)</code>
-      <code>gettype($options)</code>
-    </DocblockTypeContradiction>
     <MixedPropertyTypeCoercion occurrences="1">
       <code>new PriorityQueue()</code>
     </MixedPropertyTypeCoercion>
     <MoreSpecificImplementedParamType occurrences="1">
       <code>$options</code>
     </MoreSpecificImplementedParamType>
-    <RedundantConditionGivenDocblockType occurrences="2">
-      <code>is_object($callback)</code>
-      <code>is_object($options)</code>
-    </RedundantConditionGivenDocblockType>
     <RedundantFunctionCall occurrences="1">
       <code>strtolower</code>
     </RedundantFunctionCall>
@@ -1268,12 +1256,6 @@
       <code>$matches</code>
       <code>$matches</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="4">
-      <code>static fn($matches) =&gt; mb_strtoupper($matches[1], 'UTF-8')</code>
-      <code>static fn($matches) =&gt; mb_strtoupper($matches[2], 'UTF-8')</code>
-      <code>static fn($matches) =&gt; strtoupper($matches[1])</code>
-      <code>static fn($matches) =&gt; strtoupper($matches[2])</code>
-    </MissingClosureReturnType>
     <MixedArgument occurrences="4">
       <code>$matches[1]</code>
       <code>$matches[1]</code>
@@ -1403,7 +1385,23 @@
       <code>null</code>
     </NullArgument>
   </file>
+  <file src="test/Compress/LzfTest.php">
+    <DeprecatedClass occurrences="2">
+      <code>new Lzf()</code>
+      <code>new Lzf()</code>
+    </DeprecatedClass>
+  </file>
   <file src="test/Compress/RarTest.php">
+    <DeprecatedClass occurrences="11">
+      <code>new RarCompression()</code>
+      <code>new RarCompression()</code>
+      <code>new RarCompression()</code>
+      <code>new RarCompression()</code>
+      <code>new RarCompression()</code>
+      <code>new RarCompression()</code>
+      <code>new RarCompression()</code>
+      <code>new RarCompression()</code>
+    </DeprecatedClass>
     <InvalidReturnStatement occurrences="1">
       <code>true</code>
     </InvalidReturnStatement>
@@ -1415,6 +1413,14 @@
     </UndefinedDocblockClass>
   </file>
   <file src="test/Compress/SnappyTest.php">
+    <DeprecatedClass occurrences="6">
+      <code>new SnappyCompression()</code>
+      <code>new SnappyCompression()</code>
+      <code>new SnappyCompression()</code>
+      <code>new SnappyCompression()</code>
+      <code>new SnappyCompression()</code>
+      <code>new SnappyCompression()</code>
+    </DeprecatedClass>
     <MissingParamType occurrences="2">
       <code>$errno</code>
       <code>$errstr</code>
@@ -1720,8 +1726,7 @@
       <code>$value</code>
       <code>$value</code>
     </MissingClosureParamType>
-    <MissingClosureReturnType occurrences="3">
-      <code>static fn($container) =&gt; $filter</code>
+    <MissingClosureReturnType occurrences="2">
       <code>static fn($value) =&gt; $value</code>
       <code>static fn($value) =&gt; $value</code>
     </MissingClosureReturnType>
@@ -1739,15 +1744,13 @@
     <MissingReturnType occurrences="1">
       <code>_testOptions</code>
     </MissingReturnType>
-    <MixedArgument occurrences="8">
+    <MixedArgument occurrences="6">
       <code>$options['rules'][':action']</code>
       <code>$options['rules'][':controller']</code>
       <code>$rule</code>
       <code>$rule</code>
-      <code>$rules['action'][$key]</code>
       <code>$rules['controller']</code>
       <code>$rules['controller']</code>
-      <code>$rules['controller'][$key]</code>
     </MixedArgument>
     <MixedAssignment occurrences="6">
       <code>$filtered</code>

--- a/src/Compress/Lzf.php
+++ b/src/Compress/Lzf.php
@@ -12,6 +12,9 @@ use function lzf_decompress;
 
 /**
  * Compression adapter for Lzf
+ *
+ * @deprecated Since 2.28. This adapter will be removed in version 3.0 of this component. Other compression formats
+ *             remain available.
  */
 class Lzf implements CompressionAlgorithmInterface
 {

--- a/src/Compress/Rar.php
+++ b/src/Compress/Rar.php
@@ -22,6 +22,9 @@ use const DIRECTORY_SEPARATOR;
 /**
  * Compression adapter for Rar
  *
+ * @deprecated Since 2.28. This adapter will be removed in version 3.0 of this component. Other compression formats
+ *             remain available.
+ *
  * @psalm-type Options = array{
  *     callback: callable|null,
  *     archive: string|null,

--- a/src/Compress/Snappy.php
+++ b/src/Compress/Snappy.php
@@ -13,6 +13,9 @@ use function snappy_uncompress;
 
 /**
  * Compression adapter for php snappy (http://code.google.com/p/php-snappy/)
+ *
+ * @deprecated Since 2.28. This adapter will be removed in version 3.0 of this component. Other compression formats
+ *             remain available.
  */
 class Snappy implements CompressionAlgorithmInterface
 {


### PR DESCRIPTION
Closes #79
