### PR TITLE
Boolean filter constructor should accept int mask of types

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.3.0@b6faa3e96b8eb50ec71384c53799b8a107236bb6">
+<files psalm-version="5.4.0@62db5d4f6a7ae0a20f7cc5a4952d730272fc0863">
   <file src="src/AbstractDateDropdown.php">
     <MissingReturnType occurrences="1">
       <code>filterable</code>
@@ -1373,9 +1373,6 @@
     <ArgumentTypeCoercion occurrences="1">
       <code>$type</code>
     </ArgumentTypeCoercion>
-    <InvalidArgument occurrences="1">
-      <code>true</code>
-    </InvalidArgument>
     <MixedArgument occurrences="4">
       <code>$value</code>
       <code>$value</code>

--- a/src/Boolean.php
+++ b/src/Boolean.php
@@ -69,7 +69,8 @@ class Boolean extends AbstractFilter
     ];
 
     /**
-     * @param self::TYPE_*|value-of<self::CONSTANTS>|list<self::TYPE_*>|Options|iterable|null $typeOrOptions
+     * phpcs:ignore Generic.Files.LineLength.TooLong
+     * @param self::TYPE_*|value-of<self::CONSTANTS>|list<self::TYPE_*>|int-mask-of<self::TYPE_*>|Options|iterable|null $typeOrOptions
      * @param bool  $casting
      * @param array $translations
      */
@@ -102,7 +103,7 @@ class Boolean extends AbstractFilter
     /**
      * Set boolean types
      *
-     * @param  self::TYPE_*|value-of<self::CONSTANTS>|list<self::TYPE_*>|null $type
+     * @param  self::TYPE_*|int-mask-of<self::TYPE_*>|value-of<self::CONSTANTS>|list<self::TYPE_*>|null $type
      * @throws Exception\InvalidArgumentException
      * @return self
      */

--- a/test/BooleanTest.php
+++ b/test/BooleanTest.php
@@ -119,6 +119,7 @@ class BooleanTest extends TestCase
         $filter = new BooleanFilter();
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown type value');
+        /** @psalm-suppress InvalidScalarArgument */
         $filter->setType(true);
     }
 

--- a/test/StaticAnalysis/BooleanFilterChecks.php
+++ b/test/StaticAnalysis/BooleanFilterChecks.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Filter\StaticAnalysis;
+
+use Laminas\Filter;
+
+final class BooleanFilterChecks
+{
+    public function constructorAcceptsSingleTypeConstant(): Filter\Boolean
+    {
+        return new Filter\Boolean(Filter\Boolean::TYPE_FLOAT);
+    }
+
+    public function constructorAcceptsListOfConstants(): Filter\Boolean
+    {
+        return new Filter\Boolean([
+            Filter\Boolean::TYPE_EMPTY_ARRAY,
+            Filter\Boolean::TYPE_FALSE_STRING,
+        ]);
+    }
+
+    public function constructorAcceptsIntMaskOfConstants(): Filter\Boolean
+    {
+        return new Filter\Boolean(Filter\Boolean::TYPE_ALL ^ Filter\Boolean::TYPE_FLOAT);
+    }
+
+    public function constructorAcceptsNamedType(): Filter\Boolean
+    {
+        return new Filter\Boolean('localized');
+    }
+
+    public function constructorAcceptsOptionsArray(): Filter\Boolean
+    {
+        return new Filter\Boolean([
+            'type'    => Filter\Boolean::TYPE_FALSE_STRING | Filter\Boolean::TYPE_FLOAT,
+            'casting' => false,
+        ]);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes

### Description

Closes #95 

`Boolean::setType()` also required the same.

Targeting next minor because a release should be imminent.