### PR TITLE
Compiling the snappy extension is breaking CI

### DIFF
--- a/.laminas-ci/pre-install.sh
+++ b/.laminas-ci/pre-install.sh
@@ -23,15 +23,15 @@ echo "extension=lzf.so" >> /etc/php/"${PHP_VERSION}"/cli/php.ini
 #pecl install rar
 #echo "extension=rar.so" >> /etc/php/"${PHP_VERSION}"/cli/php.ini
 
-# Install snappy
-git clone --recursive --depth=1 https://github.com/kjdev/php-ext-snappy.git
-cd php-ext-snappy || exit 1;
-phpize
-./configure
-make
-make install
-
-echo "extension=snappy.so" >> /etc/php/"${PHP_VERSION}"/cli/php.ini
+# Install snappy - May 2023 - Extension no longer compiles
+# git clone --recursive --depth=1 https://github.com/kjdev/php-ext-snappy.git
+# cd php-ext-snappy || exit 1;
+# phpize
+# ./configure
+# make
+# make install
+#
+# echo "extension=snappy.so" >> /etc/php/"${PHP_VERSION}"/cli/php.ini
 
 # Debug output
 php --ri lzf


### PR DESCRIPTION
It's not worth fixing the build of the snappy extension given that it's deprecated for removal ASAP.

The failed build is causing `extension not found` errors which in turn is causing `phpcs` to fail.

The build has been failing with these errors for a while so tests have just been skipped anyway.

|    Q          |   A
|-------------- | ------
| QA            | yes

