### PR TITLE
Add `mixed` parameter and return types to `FilterInterface`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
+        "laminas/laminas-i18n": "^2.23",
         "laminas/laminas-uri": "^2.11.0",
         "pear/archive_tar": "^1.4.14",
         "phpunit/phpunit": "^10.4.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "beb092d5157d4cf71a38e327c6e516de",
+    "content-hash": "3f4686c4189829a5f5d1cb46e574da8b",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -1053,6 +1053,91 @@
                 }
             ],
             "time": "2023-10-10T08:35:13+00:00"
+        },
+        {
+            "name": "laminas/laminas-i18n",
+            "version": "2.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-i18n.git",
+                "reference": "970a2775732d56b89434ec283577096887e68167"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/970a2775732d56b89434ec283577096887e68167",
+                "reference": "970a2775732d56b89434ec283577096887e68167",
+                "shasum": ""
+            },
+            "require": {
+                "ext-intl": "*",
+                "laminas/laminas-servicemanager": "^3.21.0",
+                "laminas/laminas-stdlib": "^3.0",
+                "php": "~8.1.0 || ~8.2.0"
+            },
+            "conflict": {
+                "laminas/laminas-view": "<2.20.0",
+                "zendframework/zend-i18n": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^3.10.1",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.2.0",
+                "laminas/laminas-cache-storage-deprecated-factory": "^1.1",
+                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-config": "^3.8.0",
+                "laminas/laminas-eventmanager": "^3.10",
+                "laminas/laminas-filter": "^2.31",
+                "laminas/laminas-validator": "^2.30.1",
+                "laminas/laminas-view": "^2.27",
+                "phpunit/phpunit": "^10.1.3",
+                "psalm/plugin-phpunit": "^0.18.4",
+                "vimeo/psalm": "^5.11"
+            },
+            "suggest": {
+                "laminas/laminas-cache": "You should install this package to cache the translations",
+                "laminas/laminas-config": "You should install this package to use the INI translation format",
+                "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
+                "laminas/laminas-filter": "You should install this package to use the provided filters",
+                "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",
+                "laminas/laminas-validator": "You should install this package to use the provided validators",
+                "laminas/laminas-view": "You should install this package to use the provided view helpers"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\I18n",
+                    "config-provider": "Laminas\\I18n\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\I18n\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provide translations for your application, and filter and validate internationalized values",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "i18n",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-i18n/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-i18n/issues",
+                "rss": "https://github.com/laminas/laminas-i18n/releases.atom",
+                "source": "https://github.com/laminas/laminas-i18n"
+            },
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2023-10-09T12:00:55+00:00"
         },
         {
             "name": "laminas/laminas-uri",
@@ -4654,7 +4739,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+        "php": "~8.1.0 || ~8.2.0",
         "ext-mbstring": "*"
     },
     "platform-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3f4686c4189829a5f5d1cb46e574da8b",
+    "content-hash": "4725652ff0b79f76f2859d8244db2db3",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -1056,41 +1056,41 @@
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.23.1",
+            "version": "2.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "970a2775732d56b89434ec283577096887e68167"
+                "reference": "4f23433e415b14c4d66a7d7d1983c5890ac9ed2a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/970a2775732d56b89434ec283577096887e68167",
-                "reference": "970a2775732d56b89434ec283577096887e68167",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/4f23433e415b14c4d66a7d7d1983c5890ac9ed2a",
+                "reference": "4f23433e415b14c4d66a7d7d1983c5890ac9ed2a",
                 "shasum": ""
             },
             "require": {
                 "ext-intl": "*",
                 "laminas/laminas-servicemanager": "^3.21.0",
                 "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.1.0 || ~8.2.0"
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
             },
             "conflict": {
                 "laminas/laminas-view": "<2.20.0",
                 "zendframework/zend-i18n": "*"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^3.10.1",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.2.0",
+                "laminas/laminas-cache": "^3.11.0",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.3.0",
                 "laminas/laminas-cache-storage-deprecated-factory": "^1.1",
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-config": "^3.8.0",
-                "laminas/laminas-eventmanager": "^3.10",
-                "laminas/laminas-filter": "^2.31",
-                "laminas/laminas-validator": "^2.30.1",
-                "laminas/laminas-view": "^2.27",
-                "phpunit/phpunit": "^10.1.3",
+                "laminas/laminas-config": "^3.9.0",
+                "laminas/laminas-eventmanager": "^3.12",
+                "laminas/laminas-filter": "^2.33",
+                "laminas/laminas-validator": "^2.41",
+                "laminas/laminas-view": "^2.32",
+                "phpunit/phpunit": "^10.4.2",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.11"
+                "vimeo/psalm": "^5.15.0"
             },
             "suggest": {
                 "laminas/laminas-cache": "You should install this package to cache the translations",
@@ -1137,7 +1137,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-09T12:00:55+00:00"
+            "time": "2023-11-06T09:22:50+00:00"
         },
         {
             "name": "laminas/laminas-uri",
@@ -1199,16 +1199,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.41.0",
+            "version": "2.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "ca27df621e12cbd4c138dab7abf3e7e5692c582c"
+                "reference": "a5221732b2ff6df59908bbf2eb274ed3688665bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/ca27df621e12cbd4c138dab7abf3e7e5692c582c",
-                "reference": "ca27df621e12cbd4c138dab7abf3e7e5692c582c",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/a5221732b2ff6df59908bbf2eb274ed3688665bc",
+                "reference": "a5221732b2ff6df59908bbf2eb274ed3688665bc",
                 "shasum": ""
             },
             "require": {
@@ -1279,7 +1279,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-30T08:22:19+00:00"
+            "time": "2023-11-06T09:13:00+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4739,7 +4739,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0",
+        "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
         "ext-mbstring": "*"
     },
     "platform-dev": [],

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="5.15.0@5c774aca4746caf3d239d9c8cadb9f882ca29352">
   <file src="src/AbstractDateDropdown.php">
-    <MissingReturnType>
-      <code>filterable</code>
-    </MissingReturnType>
     <MixedArgumentTypeCoercion>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
@@ -11,15 +8,6 @@
       <code>setNullOnAllEmpty</code>
       <code>setNullOnEmpty</code>
     </PossiblyUnusedMethod>
-    <PropertyNotSetInConstructor>
-      <code>$expectedInputs</code>
-    </PropertyNotSetInConstructor>
-    <RedundantCondition>
-      <code><![CDATA[array_reduce($value, self::class . '::reduce', true)]]></code>
-    </RedundantCondition>
-    <TypeDoesNotContainType>
-      <code><![CDATA[array_reduce($value, self::class . '::reduce', false)]]></code>
-    </TypeDoesNotContainType>
   </file>
   <file src="src/AbstractFilter.php">
     <DocblockTypeContradiction>
@@ -36,15 +24,6 @@
     </PossiblyInvalidPropertyAssignmentValue>
     <RedundantConditionGivenDocblockType>
       <code>is_object($options)</code>
-    </RedundantConditionGivenDocblockType>
-  </file>
-  <file src="src/AbstractUnicode.php">
-    <RedundantCondition>
-      <code>assert(is_string($encoding))</code>
-      <code>is_string($encoding)</code>
-    </RedundantCondition>
-    <RedundantConditionGivenDocblockType>
-      <code>is_string($encoding)</code>
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/AllowList.php">
@@ -367,16 +346,18 @@
     <MixedArgumentTypeCoercion>
       <code>$value</code>
     </MixedArgumentTypeCoercion>
-  </file>
-  <file src="src/Decompress.php">
-    <DocblockTypeContradiction>
-      <code>! is_string($value)</code>
-    </DocblockTypeContradiction>
     <MixedReturnStatement>
       <code>$value</code>
     </MixedReturnStatement>
+  </file>
+  <file src="src/Decompress.php">
+    <MixedInferredReturnType>
+      <code>string</code>
+    </MixedInferredReturnType>
+    <MixedReturnStatement>
+      <code><![CDATA[$this->filter($value)]]></code>
+    </MixedReturnStatement>
     <MoreSpecificImplementedParamType>
-      <code>$value</code>
       <code>$value</code>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
@@ -403,7 +384,6 @@
   </file>
   <file src="src/File/Rename.php">
     <DocblockTypeContradiction>
-      <code><![CDATA[! is_scalar($value) && ! is_array($value)]]></code>
       <code>is_array($options)</code>
       <code>is_array($options)</code>
     </DocblockTypeContradiction>
@@ -449,18 +429,10 @@
     </MixedAssignment>
     <MixedInferredReturnType>
       <code>string</code>
-      <code>string|array</code>
     </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code>$uploadData</code>
-      <code>$uploadData</code>
-      <code>$value</code>
     </MixedReturnStatement>
-    <MoreSpecificImplementedParamType>
-      <code>$value</code>
-    </MoreSpecificImplementedParamType>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$rename['randomize']]]></code>
     </PossiblyUndefinedArrayOffset>
@@ -644,30 +616,6 @@
     <PossiblyUnusedProperty>
       <code>$shareByDefault</code>
     </PossiblyUnusedProperty>
-    <UndefinedClass>
-      <code>Alnum</code>
-      <code>Alnum</code>
-      <code>Alnum</code>
-      <code>Alnum</code>
-      <code>Alnum</code>
-      <code>Alpha</code>
-      <code>Alpha</code>
-      <code>Alpha</code>
-      <code>Alpha</code>
-      <code>Alpha</code>
-      <code>NumberFormat</code>
-      <code>NumberFormat</code>
-      <code>NumberFormat</code>
-      <code>NumberFormat</code>
-      <code>NumberFormat</code>
-      <code>NumberFormat</code>
-      <code>NumberParse</code>
-      <code>NumberParse</code>
-      <code>NumberParse</code>
-      <code>NumberParse</code>
-      <code>NumberParse</code>
-      <code>NumberParse</code>
-    </UndefinedClass>
   </file>
   <file src="src/FilterPluginManagerFactory.php">
     <ArgumentTypeCoercion>
@@ -733,7 +681,7 @@
       <code>$spec[0]</code>
     </InvalidArrayAccess>
     <InvalidArrayOffset>
-      <code><![CDATA[$source[ltrim($sourceName, ':')]]]></code>
+      <code><![CDATA[$value[ltrim($sourceName, ':')]]]></code>
     </InvalidArrayOffset>
     <MixedArgument>
       <code><![CDATA[$options['pluginManager']]]></code>
@@ -744,8 +692,8 @@
       <code>$processedPart</code>
       <code>$rule</code>
       <code>$rules[$spec]</code>
-      <code>$source[$ruleName]</code>
       <code>$spec</code>
+      <code>$value[$ruleName]</code>
     </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code>$sourceName</code>
@@ -761,11 +709,11 @@
       <code>$ruleFilter</code>
       <code>$ruleValue</code>
       <code>$sourceValue</code>
-      <code><![CDATA[$source[ltrim($sourceName, ':')]]]></code>
       <code><![CDATA[$temp['rules']]]></code>
       <code><![CDATA[$temp['target']]]></code>
       <code><![CDATA[$temp['targetReplacementIdentifier']]]></code>
       <code><![CDATA[$temp['throwTargetExceptionsOn']]]></code>
+      <code><![CDATA[$value[ltrim($sourceName, ':')]]]></code>
     </MixedAssignment>
     <MixedFunctionCall>
       <code>$ruleFilter($processedPart)</code>
@@ -782,14 +730,15 @@
       <code><![CDATA[$this->rules[$spec][$index]]]></code>
     </MixedReturnStatement>
     <MixedStringOffsetAssignment>
-      <code><![CDATA[$source[ltrim($sourceName, ':')]]]></code>
+      <code><![CDATA[$value[ltrim($sourceName, ':')]]]></code>
     </MixedStringOffsetAssignment>
     <MoreSpecificImplementedParamType>
-      <code>$source</code>
+      <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <ParamNameMismatch>
-      <code>$source</code>
-    </ParamNameMismatch>
+    <PossiblyUnusedParam>
+      <code>$reference</code>
+      <code>$target</code>
+    </PossiblyUnusedParam>
     <PossiblyUnusedReturnValue>
       <code>self</code>
     </PossiblyUnusedReturnValue>
@@ -807,10 +756,6 @@
       <code>(string) $target</code>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
-    <UnusedParam>
-      <code>$reference</code>
-      <code>$target</code>
-    </UnusedParam>
   </file>
   <file src="src/Module.php">
     <MissingReturnType>
@@ -827,9 +772,6 @@
     </UnusedClass>
   </file>
   <file src="src/PregReplace.php">
-    <ArgumentTypeCoercion>
-      <code>$pattern</code>
-    </ArgumentTypeCoercion>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_array($pattern) && ! is_string($pattern)]]></code>
       <code><![CDATA[! is_array($replacement) && ! is_string($replacement)]]></code>
@@ -843,9 +785,6 @@
     </MixedArgument>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$this->options['pattern']]]></code>
-      <code><![CDATA[$this->options['pattern']]]></code>
-      <code><![CDATA[$this->options['pattern']]]></code>
-      <code><![CDATA[$this->options['replacement']]]></code>
       <code><![CDATA[$this->options['replacement']]]></code>
     </PossiblyUndefinedArrayOffset>
     <PossiblyUnusedReturnValue>
@@ -904,9 +843,6 @@
     </PossiblyUndefinedArrayOffset>
   </file>
   <file src="src/StripTags.php">
-    <DocblockTypeContradiction>
-      <code>is_scalar($value)</code>
-    </DocblockTypeContradiction>
     <MixedArgument>
       <code><![CDATA[$options['allowAttribs']]]></code>
       <code><![CDATA[$options['allowTags']]]></code>
@@ -923,16 +859,9 @@
       <code><![CDATA[$temp['allowComments']]]></code>
       <code><![CDATA[$temp['allowTags']]]></code>
     </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code>$value</code>
-    </MoreSpecificImplementedParamType>
     <PossiblyUndefinedVariable>
       <code>$temp</code>
     </PossiblyUndefinedVariable>
-    <RedundantCastGivenDocblockType>
-      <code>(string) $value</code>
-      <code>(string) $value</code>
-    </RedundantCastGivenDocblockType>
     <RedundantConditionGivenDocblockType>
       <code>is_array($options)</code>
     </RedundantConditionGivenDocblockType>
@@ -945,9 +874,6 @@
       <code><![CDATA[$typeOrOptions === '']]></code>
       <code><![CDATA[$typeOrOptions === '']]></code>
     </DocblockTypeContradiction>
-    <MoreSpecificImplementedParamType>
-      <code>$value</code>
-    </MoreSpecificImplementedParamType>
     <PossiblyNullArgument>
       <code>$type</code>
     </PossiblyNullArgument>
@@ -988,12 +914,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Word/AbstractSeparator.php">
-    <DocblockTypeContradiction>
-      <code>is_string($separator)</code>
-    </DocblockTypeContradiction>
-    <MixedOperand>
-      <code>$separator</code>
-    </MixedOperand>
     <PossiblyInvalidArgument>
       <code>$separator</code>
     </PossiblyInvalidArgument>
@@ -1003,10 +923,6 @@
     <PossiblyUnusedMethod>
       <code>getSeparator</code>
     </PossiblyUnusedMethod>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_array($separator) && isset($separator['separator']) && is_string($separator['separator'])]]></code>
-      <code><![CDATA[is_string($separator['separator'])]]></code>
-    </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/Word/SeparatorToCamelCase.php">
     <MissingClosureParamType>
@@ -1251,6 +1167,32 @@
       <code>1234</code>
       <code>1234</code>
     </InvalidArgument>
+    <PossiblyNullArgument>
+      <code><![CDATA[$this->newDir]]></code>
+      <code><![CDATA[$this->newDir]]></code>
+      <code><![CDATA[$this->newDirFile]]></code>
+      <code><![CDATA[$this->newFile]]></code>
+      <code><![CDATA[$this->newFile]]></code>
+      <code><![CDATA[$this->newFile]]></code>
+      <code><![CDATA[$this->newFile]]></code>
+      <code><![CDATA[$this->newFile]]></code>
+      <code><![CDATA[$this->newFile]]></code>
+      <code><![CDATA[$this->newFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->oldFile]]></code>
+      <code><![CDATA[$this->origFile]]></code>
+      <code><![CDATA[$this->tmpPath]]></code>
+    </PossiblyNullArgument>
+    <PossiblyNullOperand>
+      <code><![CDATA[$this->tmpPath]]></code>
+      <code><![CDATA[$this->tmpPath]]></code>
+    </PossiblyNullOperand>
     <PossiblyUnusedMethod>
       <code>returnUnfilteredDataProvider</code>
     </PossiblyUnusedMethod>
@@ -1316,10 +1258,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/InflectorTest.php">
-    <DocblockTypeContradiction>
-      <code>assertNull</code>
-      <code>assertSame</code>
-    </DocblockTypeContradiction>
     <InvalidCast>
       <code>$rule</code>
       <code>$rule</code>
@@ -1360,6 +1298,9 @@
       <code>$rules</code>
       <code>$rules</code>
     </PossiblyFalseArgument>
+    <UnusedPsalmSuppress>
+      <code>UnusedVariable</code>
+    </UnusedPsalmSuppress>
     <UnusedVariable>
       <code>$filtered</code>
       <code>$rule</code>
@@ -1433,7 +1374,6 @@
   <file src="test/StripTagsTest.php">
     <MixedArgument>
       <code>$filtered</code>
-      <code>$input</code>
     </MixedArgument>
     <MixedAssignment>
       <code>$filtered</code>
@@ -1481,11 +1421,6 @@
     <InvalidArgument>
       <code>true</code>
     </InvalidArgument>
-    <MixedArgument>
-      <code>$value</code>
-      <code>$value</code>
-      <code>$value</code>
-    </MixedArgument>
     <MixedArrayAccess>
       <code>$expected</code>
       <code>$expected</code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -735,10 +735,6 @@
     <MoreSpecificImplementedParamType>
       <code>$value</code>
     </MoreSpecificImplementedParamType>
-    <PossiblyUnusedParam>
-      <code>$reference</code>
-      <code>$target</code>
-    </PossiblyUnusedParam>
     <PossiblyUnusedReturnValue>
       <code>self</code>
     </PossiblyUnusedReturnValue>
@@ -756,6 +752,10 @@
       <code>(string) $target</code>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
+    <UnusedParam>
+      <code>$reference</code>
+      <code>$target</code>
+    </UnusedParam>
   </file>
   <file src="src/Module.php">
     <MissingReturnType>
@@ -1167,32 +1167,6 @@
       <code>1234</code>
       <code>1234</code>
     </InvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->newDir]]></code>
-      <code><![CDATA[$this->newDir]]></code>
-      <code><![CDATA[$this->newDirFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->origFile]]></code>
-      <code><![CDATA[$this->tmpPath]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullOperand>
-      <code><![CDATA[$this->tmpPath]]></code>
-      <code><![CDATA[$this->tmpPath]]></code>
-    </PossiblyNullOperand>
     <PossiblyUnusedMethod>
       <code>returnUnfilteredDataProvider</code>
     </PossiblyUnusedMethod>
@@ -1258,6 +1232,10 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/InflectorTest.php">
+    <DocblockTypeContradiction>
+      <code>assertNull</code>
+      <code>assertSame</code>
+    </DocblockTypeContradiction>
     <InvalidCast>
       <code>$rule</code>
       <code>$rule</code>
@@ -1298,9 +1276,6 @@
       <code>$rules</code>
       <code>$rules</code>
     </PossiblyFalseArgument>
-    <UnusedPsalmSuppress>
-      <code>UnusedVariable</code>
-    </UnusedPsalmSuppress>
     <UnusedVariable>
       <code>$filtered</code>
       <code>$rule</code>

--- a/src/AbstractDateDropdown.php
+++ b/src/AbstractDateDropdown.php
@@ -18,34 +18,29 @@ use function vsprintf;
  *     null_on_all_empty?: bool,
  *     ...
  * }
+ * @psalm-type InputArray = array<string, string>
  * @template TOptions of Options
  * @template-extends AbstractFilter<TOptions>
+ * @template TInput of array
  */
 abstract class AbstractDateDropdown extends AbstractFilter
 {
     /**
      * If true, the filter will return null if any date field is empty
-     *
-     * @var bool
      */
-    protected $nullOnEmpty = false;
+    protected bool $nullOnEmpty = false;
 
     /**
      * If true, the filter will return null if all date fields are empty
-     *
-     * @var bool
      */
-    protected $nullOnAllEmpty = false;
+    protected bool $nullOnAllEmpty = false;
 
     /**
      * Sprintf format string to use for formatting the date, fields will be used in alphabetical order.
-     *
-     * @var string
      */
-    protected $format = '';
+    protected string $format = '';
 
-    /** @var int */
-    protected $expectedInputs;
+    protected int $expectedInputs = 0;
 
     /**
      * @param mixed $options If array or Traversable, passes value to
@@ -59,37 +54,29 @@ abstract class AbstractDateDropdown extends AbstractFilter
     }
 
     /**
-     * @param bool $nullOnAllEmpty
-     * @return self
+     * @return $this
      */
-    public function setNullOnAllEmpty($nullOnAllEmpty)
+    public function setNullOnAllEmpty(bool $nullOnAllEmpty): self
     {
         $this->nullOnAllEmpty = $nullOnAllEmpty;
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isNullOnAllEmpty()
+    public function isNullOnAllEmpty(): bool
     {
         return $this->nullOnAllEmpty;
     }
 
     /**
-     * @param bool $nullOnEmpty
-     * @return self
+     * @return $this
      */
-    public function setNullOnEmpty($nullOnEmpty)
+    public function setNullOnEmpty(bool $nullOnEmpty): self
     {
         $this->nullOnEmpty = $nullOnEmpty;
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isNullOnEmpty()
+    public function isNullOnEmpty(): bool
     {
         return $this->nullOnEmpty;
     }
@@ -98,12 +85,10 @@ abstract class AbstractDateDropdown extends AbstractFilter
      * Attempts to filter an array of date/time information to a formatted
      * string.
      *
-     * @param  mixed $value input to the filter
-     * @return mixed|string|null
      * @throws Exception\RuntimeException If filtering $value is impossible.
-     * @psalm-return ($value is array ? string|null : mixed)
+     * @psalm-return ($value is InputArray ? string : mixed|null)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_array($value)) {
             // nothing to do
@@ -113,14 +98,14 @@ abstract class AbstractDateDropdown extends AbstractFilter
         // Convert the date to a specific format
         if (
             $this->isNullOnEmpty()
-            && array_reduce($value, self::class . '::reduce', false)
+            && array_reduce($value, [self::class, 'reduce'], false)
         ) {
             return null;
         }
 
         if (
             $this->isNullOnAllEmpty()
-            && array_reduce($value, self::class . '::reduce', true)
+            && array_reduce($value, [self::class, 'reduce'], true)
         ) {
             return null;
         }
@@ -128,9 +113,7 @@ abstract class AbstractDateDropdown extends AbstractFilter
         $this->filterable($value);
 
         ksort($value);
-        $value = vsprintf($this->format, $value);
-
-        return $value;
+        return vsprintf($this->format, $value);
     }
 
     /**
@@ -138,8 +121,9 @@ abstract class AbstractDateDropdown extends AbstractFilter
      *
      * @param array $value
      * @throws Exception\RuntimeException
+     * @psalm-assert TInput $value
      */
-    protected function filterable($value)
+    protected function filterable(array $value): void
     {
         if (count($value) !== $this->expectedInputs) {
             throw new Exception\RuntimeException(
@@ -154,12 +138,8 @@ abstract class AbstractDateDropdown extends AbstractFilter
 
     /**
      * Reduce to a single value
-     *
-     * @param string $soFar
-     * @param string $value
-     * @return bool
      */
-    public static function reduce($soFar, $value)
+    private static function reduce(string $soFar, string|null $value): bool
     {
         return $soFar || empty($value);
     }

--- a/src/AbstractDateDropdown.php
+++ b/src/AbstractDateDropdown.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Filter;
 
 use function array_reduce;
+use function assert;
 use function count;
 use function is_array;
 use function is_iterable;
@@ -111,6 +112,7 @@ abstract class AbstractDateDropdown extends AbstractFilter
         }
 
         $this->filterable($value);
+        assert(is_array($value));
 
         ksort($value);
         return vsprintf($this->format, $value);
@@ -121,7 +123,6 @@ abstract class AbstractDateDropdown extends AbstractFilter
      *
      * @param array $value
      * @throws Exception\RuntimeException
-     * @psalm-assert TInput $value
      */
     protected function filterable(array $value): void
     {

--- a/src/AbstractFilter.php
+++ b/src/AbstractFilter.php
@@ -95,9 +95,8 @@ abstract class AbstractFilter implements FilterInterface
      * Proxies to {@link filter()}
      *
      * @throws Exception\ExceptionInterface If filtering $value is impossible.
-     * @return mixed
      */
-    public function __invoke(mixed $value)
+    public function __invoke(mixed $value): mixed
     {
         return $this->filter($value);
     }

--- a/src/AbstractUnicode.php
+++ b/src/AbstractUnicode.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Filter;
 
 use function array_map;
-use function assert;
 use function in_array;
-use function is_string;
 use function mb_internal_encoding;
 use function mb_list_encodings;
 use function sprintf;
@@ -25,12 +23,11 @@ abstract class AbstractUnicode extends AbstractFilter
     /**
      * Set the input encoding for the given string
      *
-     * @param  string|null $encoding
-     * @return self
      * @throws Exception\InvalidArgumentException
      * @throws Exception\ExtensionNotLoadedException
+     * @return $this
      */
-    public function setEncoding($encoding = null)
+    public function setEncoding(?string $encoding = null): self
     {
         if ($encoding !== null) {
             $encoding    = strtolower($encoding);
@@ -49,16 +46,12 @@ abstract class AbstractUnicode extends AbstractFilter
 
     /**
      * Returns the set encoding
-     *
-     * @return string
      */
-    public function getEncoding()
+    public function getEncoding(): string
     {
         $encoding = $this->options['encoding'] ?? null;
-        assert($encoding === null || is_string($encoding));
         if ($encoding === null) {
-            $encoding = mb_internal_encoding();
-            assert(is_string($encoding));
+            $encoding                  = mb_internal_encoding();
             $this->options['encoding'] = $encoding;
         }
 

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -58,7 +58,7 @@ class AllowList extends AbstractFilter
     }
 
     /**
-     * Set the list of items to white-list.
+     * Set the list of items to allow
      *
      * @param array|Traversable $list
      */
@@ -72,7 +72,7 @@ class AllowList extends AbstractFilter
     }
 
     /**
-     * Get the list of items to white-list
+     * Get the list of items to allow
      *
      * @return array
      */
@@ -84,7 +84,11 @@ class AllowList extends AbstractFilter
     /**
      * {@inheritDoc}
      *
-     * Will return $value if its present in the white-list. If $value is rejected then it will return null.
+     * Will return $value if its present in the allow-list. If $value is rejected then it will return null.
+     *
+     * @template T
+     * @param T $value
+     * @return T|null
      */
     public function filter(mixed $value): mixed
     {

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -86,7 +86,7 @@ class AllowList extends AbstractFilter
      *
      * Will return $value if its present in the white-list. If $value is rejected then it will return null.
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return in_array($value, $this->getList(), $this->getStrict()) ? $value : null;
     }

--- a/src/BaseName.php
+++ b/src/BaseName.php
@@ -21,11 +21,9 @@ class BaseName extends AbstractFilter
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @psalm-return ($value is scalar ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/Boolean.php
+++ b/src/Boolean.php
@@ -207,7 +207,6 @@ class Boolean extends AbstractFilter
      * Returns a boolean representation of $value
      *
      * @param  null|array|bool|float|int|string $value
-     * @return bool|mixed
      */
     public function filter(mixed $value): mixed
     {

--- a/src/Boolean.php
+++ b/src/Boolean.php
@@ -209,7 +209,7 @@ class Boolean extends AbstractFilter
      * @param  null|array|bool|float|int|string $value
      * @return bool|mixed
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         $type    = $this->getType();
         $casting = $this->getCasting();

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -101,10 +101,10 @@ class Callback extends AbstractFilter
     /**
      * Calls the filter per callback
      *
-     * @param  mixed $value Options for the set callable
+     * @param mixed $value Options for the set callable
      * @return mixed Result from the filter which was called
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         $params = (array) $this->options['callback_params'];
         array_unshift($params, $value);

--- a/src/Compress.php
+++ b/src/Compress.php
@@ -211,11 +211,11 @@ class Compress extends AbstractFilter
      *
      * Compresses the content $value with the defined settings
      *
-     * @param  mixed $value Content to compress
-     * @return string|mixed The compressed content
+     * @param mixed $value Content to compress
+     * @return mixed The compressed content
      * @psalm-return ($value is string ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_string($value)) {
             return $value;

--- a/src/DataUnitFormatter.php
+++ b/src/DataUnitFormatter.php
@@ -212,11 +212,9 @@ final class DataUnitFormatter extends AbstractFilter
      *
      * If the value provided is not numeric, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @psalm-return ($value is numeric ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_numeric($value)) {
             return $value;

--- a/src/DateSelect.php
+++ b/src/DateSelect.php
@@ -10,19 +10,20 @@ namespace Laminas\Filter;
  *     null_on_all_empty?: bool,
  *     ...
  * }
+ * @psalm-type InputArray = array{
+ *      year: numeric,
+ *      month: numeric,
+ *      day: numeric,
+ * }
  * @template TOptions of Options
- * @template-extends AbstractDateDropdown<TOptions>
+ * @template-extends AbstractDateDropdown<TOptions, InputArray>
  * @final
  */
 class DateSelect extends AbstractDateDropdown
 {
     /**
      * Year-Month-Day
-     *
-     * @var string
      */
-    protected $format = '%3$s-%2$s-%1$s';
-
-    /** @var int */
-    protected $expectedInputs = 3;
+    protected string $format      = '%3$s-%2$s-%1$s';
+    protected int $expectedInputs = 3;
 }

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -58,9 +58,8 @@ class DateTimeFormatter extends AbstractFilter
      *
      * @param  DateTime|string|int|mixed $value
      * @throws Exception\InvalidArgumentException
-     * @return string|mixed
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         try {
             $result = $this->normalizeDateTime($value);

--- a/src/DateTimeSelect.php
+++ b/src/DateTimeSelect.php
@@ -14,28 +14,28 @@ use function vsprintf;
  *     null_on_all_empty?: bool,
  *     ...
  * }
+ * @psalm-type InputArray = array{
+ *     year: numeric,
+ *     month: numeric,
+ *     day: numeric,
+ *     hour: numeric,
+ *     minute: numeric,
+ *     second: numeric
+ * }
  * @template TOptions of Options
- * @template-extends AbstractDateDropdown<TOptions>
+ * @template-extends AbstractDateDropdown<TOptions, InputArray>
  * @final
  */
 class DateTimeSelect extends AbstractDateDropdown
 {
     /**
      * Year-Month-Day Hour:Min:Sec
-     *
-     * @var string
      */
-    protected $format = '%6$s-%4$s-%1$s %2$s:%3$s:%5$s';
+    protected string $format      = '%6$s-%4$s-%1$s %2$s:%3$s:%5$s';
+    protected int $expectedInputs = 6;
 
-    /** @var int */
-    protected $expectedInputs = 6;
-
-    /**
-     * @param mixed $value
-     * @return array|mixed|null|string
-     * @throws Exception\RuntimeException
-     */
-    public function filter($value)
+    /** @inheritDoc */
+    public function filter(mixed $value): mixed
     {
         if (! is_array($value)) {
             // nothing to do
@@ -53,7 +53,7 @@ class DateTimeSelect extends AbstractDateDropdown
                 || (isset($value['second']) && empty($value['second']))
             )
         ) {
-            return;
+            return null;
         }
 
         if (
@@ -64,11 +64,11 @@ class DateTimeSelect extends AbstractDateDropdown
                 && empty($value['day'])
                 && empty($value['hour'])
                 && empty($value['minute'])
-                && (! isset($value['second']) || empty($value['second']))
+                && empty($value['second'])
             )
         ) {
             // Cannot handle this value
-            return;
+            return null;
         }
 
         if (! isset($value['second'])) {
@@ -79,8 +79,6 @@ class DateTimeSelect extends AbstractDateDropdown
 
         ksort($value);
 
-        $value = vsprintf($this->format, $value);
-
-        return $value;
+        return vsprintf($this->format, $value);
     }
 }

--- a/src/Decompress.php
+++ b/src/Decompress.php
@@ -21,7 +21,7 @@ class Decompress extends Compress
      * @param  string $value Content to decompress
      * @return string The decompressed content
      */
-    public function __invoke($value)
+    public function __invoke(mixed $value): mixed
     {
         return $this->filter($value);
     }
@@ -31,10 +31,10 @@ class Decompress extends Compress
      *
      * Decompresses the content $value with the defined settings
      *
-     * @param  string $value Content to decompress
-     * @return string The decompressed content
+     * @param mixed $value Content to decompress
+     * @return mixed The decompressed content
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_string($value) && $value !== null) {
             return $value;

--- a/src/DenyList.php
+++ b/src/DenyList.php
@@ -86,7 +86,7 @@ class DenyList extends AbstractFilter
      *
      * Will return null if $value is present in the black-list. If $value is NOT present then it will return $value.
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return in_array($value, $this->getList(), $this->getStrict()) ? null : $value;
     }

--- a/src/Digits.php
+++ b/src/Digits.php
@@ -25,11 +25,9 @@ class Digits extends AbstractFilter
      *
      * If the value provided is not integer, float or string, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @psalm-return ($value is int|float|string ? numeric-string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (is_int($value)) {
             return (string) $value;

--- a/src/Dir.php
+++ b/src/Dir.php
@@ -19,11 +19,9 @@ class Dir extends AbstractFilter
      *
      * Returns dirname($value)
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @psalm-return ($value is scalar ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/File/LowerCase.php
+++ b/src/File/LowerCase.php
@@ -24,12 +24,12 @@ class LowerCase extends StringToLower
      *
      * Does a lowercase on the content of the given file
      *
-     * @param  mixed $value Full path of file to change or $_FILES data array
-     * @return string|mixed The given $value
+     * @param mixed $value Full path of file to change or $_FILES data array
+     * @return mixed The given $value
      * @throws Exception\InvalidArgumentException
      * @throws Exception\RuntimeException
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value) && ! is_array($value)) {
             return $value;

--- a/src/File/Rename.php
+++ b/src/File/Rename.php
@@ -177,11 +177,11 @@ class Rename extends Filter\AbstractFilter
      * Renames the file $value to the new name set before
      * Returns the file $value, removing all but digit characters
      *
-     * @param  string|array $value Full path of file to change or $_FILES data array
+     * @param mixed $value Full path of file to change or $_FILES data array
+     * @return mixed The new filename which has been set
      * @throws Exception\RuntimeException
-     * @return string|array The new filename which has been set
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value) && ! is_array($value)) {
             return $value;

--- a/src/File/RenameUpload.php
+++ b/src/File/RenameUpload.php
@@ -229,7 +229,7 @@ class RenameUpload extends AbstractFilter
      *     - UploadedFileInterface for UploadedFileInterface $value
      * @throws Exception\RuntimeException
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         // PSR-7 uploaded file
         if ($value instanceof UploadedFileInterface) {

--- a/src/File/UpperCase.php
+++ b/src/File/UpperCase.php
@@ -27,7 +27,7 @@ class UpperCase extends StringToUpper
      * @throws Exception\RuntimeException
      * @throws Exception\InvalidArgumentException
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value) && ! is_array($value)) {
             return $value;

--- a/src/FilterChain.php
+++ b/src/FilterChain.php
@@ -233,11 +233,9 @@ class FilterChain extends AbstractFilter implements Countable, IteratorAggregate
      *
      * Filters are run in the order in which they were added to the chain (FIFO)
      *
-     * @param  mixed $value
-     * @return mixed
      * @psalm-suppress MixedAssignment values are always mixed
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         $valueFiltered = $value;
         foreach ($this as $filter) {

--- a/src/FilterInterface.php
+++ b/src/FilterInterface.php
@@ -9,9 +9,9 @@ interface FilterInterface
     /**
      * Returns the result of filtering $value
      *
-     * @param  mixed $value
      * @throws Exception\RuntimeException If filtering $value is impossible.
-     * @return mixed
      */
-    public function filter($value);
+    public function filter(mixed $value): mixed;
+
+    public function __invoke(mixed $value): mixed;
 }

--- a/src/HtmlEntities.php
+++ b/src/HtmlEntities.php
@@ -190,12 +190,10 @@ class HtmlEntities extends AbstractFilter
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @throws Exception\DomainException On encoding mismatches.
      * @psalm-return ($value is scalar ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -407,7 +407,7 @@ class Inflector extends AbstractFilter
     /**
      * Inflect
      *
-     * @param  string|array $source
+     * @param  string|array $value
      * @throws Exception\RuntimeException
      */
     public function filter(mixed $value): mixed

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -409,29 +409,28 @@ class Inflector extends AbstractFilter
      *
      * @param  string|array $source
      * @throws Exception\RuntimeException
-     * @return string
      */
-    public function filter($source)
+    public function filter(mixed $value): mixed
     {
         // clean source
-        foreach ((array) $source as $sourceName => $sourceValue) {
-            $source[ltrim($sourceName, ':')] = $sourceValue;
+        foreach ((array) $value as $sourceName => $sourceValue) {
+            $value[ltrim($sourceName, ':')] = $sourceValue;
         }
 
         $pregQuotedTargetReplacementIdentifier = preg_quote($this->targetReplacementIdentifier, '#');
         $processedParts                        = [];
 
         foreach ($this->rules as $ruleName => $ruleValue) {
-            if (isset($source[$ruleName])) {
+            if (isset($value[$ruleName])) {
                 if (is_string($ruleValue)) {
                     // overriding the set rule
                     $processedParts['#' . $pregQuotedTargetReplacementIdentifier . $ruleName . '#'] = str_replace(
                         '\\',
                         '\\\\',
-                        $source[$ruleName]
+                        $value[$ruleName]
                     );
                 } elseif (is_array($ruleValue)) {
-                    $processedPart = $source[$ruleName];
+                    $processedPart = $value[$ruleName];
                     foreach ($ruleValue as $ruleFilter) {
                         $processedPart = $ruleFilter($processedPart);
                     }

--- a/src/MonthSelect.php
+++ b/src/MonthSelect.php
@@ -10,19 +10,19 @@ namespace Laminas\Filter;
  *     null_on_all_empty?: bool,
  *     ...
  * }
+ * @psalm-type InputArray = array{
+ *       year: numeric,
+ *       month: numeric,
+ *  }
  * @template TOptions of Options
- * @template-extends AbstractDateDropdown<TOptions>
+ * @template-extends AbstractDateDropdown<TOptions, InputArray>
  * @final
  */
 class MonthSelect extends AbstractDateDropdown
 {
     /**
      * Year-Month
-     *
-     * @var string
      */
-    protected $format = '%2$s-%1$s';
-
-    /** @var int */
-    protected $expectedInputs = 2;
+    protected string $format      = '%2$s-%1$s';
+    protected int $expectedInputs = 2;
 }

--- a/src/PregReplace.php
+++ b/src/PregReplace.php
@@ -140,11 +140,9 @@ class PregReplace extends AbstractFilter
     /**
      * Perform regexp replacement as filter
      *
-     * @param  mixed $value
-     * @return mixed
      * @throws Exception\RuntimeException
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
             $value,

--- a/src/PregReplace.php
+++ b/src/PregReplace.php
@@ -21,7 +21,7 @@ use function str_contains;
 
 /**
  * @psalm-type Options = array{
- *     pattern?: string|list<string>|null,
+ *     pattern?: non-empty-string|list<non-empty-string>|null,
  *     replacement?: string|list<string>,
  * }
  * @extends AbstractFilter<Options>
@@ -67,7 +67,7 @@ class PregReplace extends AbstractFilter
      *
      * @see preg_replace()
      *
-     * @param  string|list<string> $pattern - same as the first argument of preg_replace
+     * @param  non-empty-string|list<non-empty-string> $pattern - same as the first argument of preg_replace
      * @return self
      * @throws Exception\InvalidArgumentException
      */
@@ -98,7 +98,7 @@ class PregReplace extends AbstractFilter
     /**
      * Get currently set match pattern
      *
-     * @return string|list<string>|null
+     * @return non-empty-string|list<non-empty-string>|null
      */
     public function getPattern()
     {
@@ -156,17 +156,16 @@ class PregReplace extends AbstractFilter
      */
     private function filterNormalizedValue($value)
     {
-        if ($this->options['pattern'] === null) {
+        $pattern = $this->options['pattern'] ?? null;
+        if ($pattern === null) {
             throw new Exception\RuntimeException(sprintf(
                 'Filter %s does not have a valid pattern set',
                 static::class
             ));
         }
 
-        /** @var string|string[] $pattern */
-        $pattern = $this->options['pattern'];
         /** @var string|string[] $replacement */
-        $replacement = $this->options['replacement'];
+        $replacement = $this->options['replacement'] ?? '';
 
         return preg_replace($pattern, $replacement, $value);
     }

--- a/src/RealPath.php
+++ b/src/RealPath.php
@@ -83,11 +83,9 @@ class RealPath extends AbstractFilter
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @psalm-return ($value is string ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_string($value)) {
             return $value;

--- a/src/StringPrefix.php
+++ b/src/StringPrefix.php
@@ -76,7 +76,7 @@ class StringPrefix extends AbstractFilter
     /**
      * {@inheritdoc}
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/StringSuffix.php
+++ b/src/StringSuffix.php
@@ -77,7 +77,7 @@ class StringSuffix extends AbstractFilter
     /**
      * {@inheritdoc}
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/StringToLower.php
+++ b/src/StringToLower.php
@@ -34,11 +34,9 @@ class StringToLower extends AbstractUnicode
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @param mixed $value
-     * @return string|mixed
      * @psalm-return ($value is string ? string : $value)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/StringToUpper.php
+++ b/src/StringToUpper.php
@@ -34,11 +34,9 @@ class StringToUpper extends AbstractUnicode
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @psalm-return ($value is scalar ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/StringTrim.php
+++ b/src/StringTrim.php
@@ -73,11 +73,9 @@ class StringTrim extends AbstractFilter
      *
      * Returns the string $value with characters stripped from the beginning and end
      *
-     * @param  mixed $value
-     * @return string|mixed
      * @psalm-return ($value is string ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_string($value)) {
             return $value;

--- a/src/StripNewlines.php
+++ b/src/StripNewlines.php
@@ -19,11 +19,8 @@ class StripNewlines extends AbstractFilter
      * Defined by Laminas\Filter\FilterInterface
      *
      * Returns $value without newline control characters
-     *
-     * @param  mixed $value
-     * @return mixed
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
             $value,

--- a/src/StripTags.php
+++ b/src/StripTags.php
@@ -218,7 +218,7 @@ class StripTags extends AbstractFilter
         $dataFiltered = '';
         // Parse the input data iteratively as regular pre-tag text followed by a
         // tag; either may be empty strings
-        preg_match_all('/([^<]*)(<?[^>]*>?)/', (string) $value, $matches);
+        preg_match_all('/([^<]*)(<?[^>]*>?)/', $value, $matches);
 
         // Iterate over each set of matches
         foreach ($matches[1] as $index => $preTag) {

--- a/src/StripTags.php
+++ b/src/StripTags.php
@@ -190,11 +190,9 @@ class StripTags extends AbstractFilter
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @todo   improve docblock descriptions
-     * @param  string $value
-     * @return string|mixed
+     * @psalm-return ($value is scalar ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/ToFloat.php
+++ b/src/ToFloat.php
@@ -20,11 +20,9 @@ class ToFloat extends AbstractFilter
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return float|mixed
      * @psalm-return ($value is scalar ? float : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/ToInt.php
+++ b/src/ToInt.php
@@ -20,11 +20,9 @@ class ToInt extends AbstractFilter
      *
      * If the value provided is non-scalar, the value will remain unfiltered
      *
-     * @param  mixed $value
-     * @return int|mixed
      * @psalm-return ($value is scalar ? int : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/ToNull.php
+++ b/src/ToNull.php
@@ -129,11 +129,8 @@ class ToNull extends AbstractFilter
      *
      * Returns null representation of $value, if value is empty and matches
      * types that should be considered null.
-     *
-     * @param  null|array|bool|float|int|string $value
-     * @return null|mixed
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         $type = $this->getType();
 

--- a/src/UpperCaseWords.php
+++ b/src/UpperCaseWords.php
@@ -44,10 +44,10 @@ final class UpperCaseWords extends AbstractUnicode
      * If the value provided is not a string, the value will remain unfiltered
      *
      * @param  string|mixed $value
-     * @return string|mixed
+     * @return mixed
      * @psalm-return ($value is string ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_string($value)) {
             return $value;

--- a/src/UriNormalize.php
+++ b/src/UriNormalize.php
@@ -90,11 +90,8 @@ class UriNormalize extends AbstractFilter
 
     /**
      * Filter the URL by normalizing it and applying a default scheme if set
-     *
-     * @param  mixed $value
-     * @return mixed|string
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value)) {
             return $value;

--- a/src/Word/AbstractSeparator.php
+++ b/src/Word/AbstractSeparator.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace Laminas\Filter\Word;
 
 use Laminas\Filter\AbstractFilter;
-use Laminas\Filter\Exception;
 
 use function is_array;
-use function is_string;
 
 /**
+ * @internal
+ *
  * @psalm-type Options = array{
  *     separator?: string,
  *     ...
@@ -20,15 +20,14 @@ use function is_string;
  */
 abstract class AbstractSeparator extends AbstractFilter
 {
-    /** @var string */
-    protected $separator = ' ';
+    protected string $separator = ' ';
 
     /**
      * @param Options|string $separator Space by default
      */
-    public function __construct($separator = ' ')
+    public function __construct(string|array $separator = ' ')
     {
-        if (is_array($separator) && isset($separator['separator']) && is_string($separator['separator'])) {
+        if (is_array($separator) && isset($separator['separator'])) {
             $this->setSeparator($separator['separator']);
 
             return;
@@ -37,28 +36,14 @@ abstract class AbstractSeparator extends AbstractFilter
         $this->setSeparator($separator);
     }
 
-    /**
-     * Sets a new separator
-     *
-     * @param  string $separator Separator
-     * @return self
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setSeparator($separator)
+    /** @return $this */
+    public function setSeparator(string $separator): self
     {
-        if (! is_string($separator)) {
-            throw new Exception\InvalidArgumentException('"' . $separator . '" is not a valid separator.');
-        }
         $this->separator = $separator;
         return $this;
     }
 
-    /**
-     * Returns the actual set separator
-     *
-     * @return string
-     */
-    public function getSeparator()
+    public function getSeparator(): string
     {
         return $this->separator;
     }

--- a/src/Word/AbstractSeparator.php
+++ b/src/Word/AbstractSeparator.php
@@ -9,8 +9,6 @@ use Laminas\Filter\AbstractFilter;
 use function is_array;
 
 /**
- * @internal
- *
  * @psalm-type Options = array{
  *     separator?: string,
  *     ...

--- a/src/Word/CamelCaseToSeparator.php
+++ b/src/Word/CamelCaseToSeparator.php
@@ -19,11 +19,7 @@ use function preg_replace;
  */
 class CamelCaseToSeparator extends AbstractSeparator
 {
-    /**
-     * @param mixed $value
-     * @return mixed
-     */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
             $value,
@@ -35,7 +31,7 @@ class CamelCaseToSeparator extends AbstractSeparator
      * @param  string|string[] $value
      * @return string|string[]
      */
-    private function filterNormalizedValue($value)
+    private function filterNormalizedValue(string|array $value): string|array
     {
         if (StringUtils::hasPcreUnicodeSupport()) {
             $pattern     = ['#(?<=(?:\p{Lu}))(\p{Lu}\p{Ll})#', '#(?<=(?:\p{Ll}|\p{Nd}))(\p{Lu})#'];

--- a/src/Word/DashToSeparator.php
+++ b/src/Word/DashToSeparator.php
@@ -19,11 +19,7 @@ use function str_replace;
  */
 class DashToSeparator extends AbstractSeparator
 {
-    /**
-     * @param mixed $value
-     * @return mixed
-     */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
             $value,

--- a/src/Word/SeparatorToCamelCase.php
+++ b/src/Word/SeparatorToCamelCase.php
@@ -22,11 +22,7 @@ use function strtoupper;
  */
 class SeparatorToCamelCase extends AbstractSeparator
 {
-    /**
-     * @param mixed $value
-     * @return mixed
-     */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
             $value,

--- a/src/Word/SeparatorToSeparator.php
+++ b/src/Word/SeparatorToSeparator.php
@@ -86,11 +86,9 @@ class SeparatorToSeparator extends AbstractFilter
      *
      * Returns the string $value, replacing the searched separators with the defined ones
      *
-     * @param  string|mixed $value
-     * @return mixed
      * @psalm-return ($value is string ? string : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
             $value,

--- a/src/Word/UnderscoreToStudlyCase.php
+++ b/src/Word/UnderscoreToStudlyCase.php
@@ -27,11 +27,9 @@ class UnderscoreToStudlyCase extends UnderscoreToCamelCase
     /**
      * Defined by Laminas\Filter\Filter
      *
-     * @param  mixed $value
-     * @return string|array
      * @psalm-return ($value is scalar ? string : $value is array ? array : mixed)
      */
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         if (! is_scalar($value) && ! is_array($value)) {
             return $value;

--- a/test/AbstractUnicodeTest.php
+++ b/test/AbstractUnicodeTest.php
@@ -23,8 +23,7 @@ class AbstractUnicodeTest extends TestCase
         parent::setUp();
 
         $this->filter = new class extends AbstractUnicode {
-            /** @param mixed $value */
-            public function filter($value): string
+            public function filter(mixed $value): mixed
             {
                 assert(is_string($value));
                 return strtolower($value);

--- a/test/TestAsset/LowerCase.php
+++ b/test/TestAsset/LowerCase.php
@@ -11,7 +11,7 @@ use function strtolower;
 /** @template-extends AbstractFilter<array{}> */
 class LowerCase extends AbstractFilter
 {
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return strtolower($value);
     }

--- a/test/TestAsset/StripUpperCase.php
+++ b/test/TestAsset/StripUpperCase.php
@@ -11,7 +11,7 @@ use function preg_replace;
 /** @template-extends AbstractFilter<array{}> */
 class StripUpperCase extends AbstractFilter
 {
-    public function filter($value)
+    public function filter(mixed $value): mixed
     {
         return preg_replace('/[A-Z]/', '', $value);
     }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

Adds parameter and return type of `mixed` to `FilterInterface::filter()` and all implementations.

Some additional property/parameter/return types have been added but avoided where possible.

The plan here is to add types everywhere in another patch later on.
