### PR TITLE
Mark all filters as `@final` where possible

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -486,7 +486,7 @@
   </file>
   <file src="src/Encrypt.php">
     <DeprecatedInterface>
-      <code>Encrypt</code>
+      <code>Encrypt\EncryptionAlgorithmInterface</code>
     </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code>! is_string($value)</code>
@@ -693,9 +693,6 @@
       <code>Filter\Decrypt</code>
       <code>parent::filter($content)</code>
     </DeprecatedClass>
-    <DeprecatedInterface>
-      <code>Decrypt</code>
-    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_scalar($value) && ! is_array($value)]]></code>
     </DocblockTypeContradiction>
@@ -752,9 +749,6 @@
       <code>Filter\Encrypt</code>
       <code>parent::filter($content)</code>
     </DeprecatedClass>
-    <DeprecatedInterface>
-      <code>Encrypt</code>
-    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_scalar($value) && ! is_array($value)]]></code>
     </DocblockTypeContradiction>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -56,6 +56,11 @@
       <code>(bool) $strict</code>
     </RedundantCastGivenDocblockType>
   </file>
+  <file src="src/Blacklist.php">
+    <InvalidExtendClass>
+      <code>DenyList</code>
+    </InvalidExtendClass>
+  </file>
   <file src="src/Boolean.php">
     <ArgumentTypeCoercion>
       <code>$typeOrOptions</code>
@@ -480,6 +485,9 @@
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Encrypt.php">
+    <DeprecatedInterface>
+      <code>Encrypt</code>
+    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code>! is_string($value)</code>
     </DocblockTypeContradiction>
@@ -685,6 +693,9 @@
       <code>Filter\Decrypt</code>
       <code>parent::filter($content)</code>
     </DeprecatedClass>
+    <DeprecatedInterface>
+      <code>Decrypt</code>
+    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_scalar($value) && ! is_array($value)]]></code>
     </DocblockTypeContradiction>
@@ -741,6 +752,9 @@
       <code>Filter\Encrypt</code>
       <code>parent::filter($content)</code>
     </DeprecatedClass>
+    <DeprecatedInterface>
+      <code>Encrypt</code>
+    </DeprecatedInterface>
     <DocblockTypeContradiction>
       <code><![CDATA[! is_scalar($value) && ! is_array($value)]]></code>
     </DocblockTypeContradiction>
@@ -1211,10 +1225,6 @@
     <ParamNameMismatch>
       <code>$source</code>
     </ParamNameMismatch>
-    <PossiblyUnusedParam>
-      <code>$reference</code>
-      <code>$target</code>
-    </PossiblyUnusedParam>
     <PossiblyUnusedReturnValue>
       <code>self</code>
     </PossiblyUnusedReturnValue>
@@ -1232,6 +1242,10 @@
       <code>(string) $target</code>
       <code>(string) $value</code>
     </RedundantCastGivenDocblockType>
+    <UnusedParam>
+      <code>$reference</code>
+      <code>$target</code>
+    </UnusedParam>
   </file>
   <file src="src/Module.php">
     <MissingReturnType>
@@ -1404,6 +1418,11 @@
       <code>setDefaultScheme</code>
       <code>setEnforcedScheme</code>
     </PossiblyUnusedMethod>
+  </file>
+  <file src="src/Whitelist.php">
+    <InvalidExtendClass>
+      <code>AllowList</code>
+    </InvalidExtendClass>
   </file>
   <file src="src/Word/AbstractSeparator.php">
     <DocblockTypeContradiction>
@@ -1695,32 +1714,6 @@
       <code>1234</code>
       <code>1234</code>
     </InvalidArgument>
-    <PossiblyNullArgument>
-      <code><![CDATA[$this->newDir]]></code>
-      <code><![CDATA[$this->newDir]]></code>
-      <code><![CDATA[$this->newDirFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->newFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->oldFile]]></code>
-      <code><![CDATA[$this->origFile]]></code>
-      <code><![CDATA[$this->tmpPath]]></code>
-    </PossiblyNullArgument>
-    <PossiblyNullOperand>
-      <code><![CDATA[$this->tmpPath]]></code>
-      <code><![CDATA[$this->tmpPath]]></code>
-    </PossiblyNullOperand>
     <PossiblyUnusedMethod>
       <code>returnUnfilteredDataProvider</code>
     </PossiblyUnusedMethod>
@@ -1786,6 +1779,10 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/InflectorTest.php">
+    <DocblockTypeContradiction>
+      <code>assertNull</code>
+      <code>assertSame</code>
+    </DocblockTypeContradiction>
     <InvalidCast>
       <code>$rule</code>
       <code>$rule</code>

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -17,6 +17,7 @@ use function is_array;
  *     ...
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class AllowList extends AbstractFilter
 {

--- a/src/BaseName.php
+++ b/src/BaseName.php
@@ -10,6 +10,7 @@ use function is_scalar;
 /**
  * @psalm-type Options = array{}
  * @extends AbstractFilter<Options>
+ * @final
  */
 class BaseName extends AbstractFilter
 {

--- a/src/Boolean.php
+++ b/src/Boolean.php
@@ -25,6 +25,7 @@ use function strtolower;
  *     translations?: array,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class Boolean extends AbstractFilter
 {

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -19,6 +19,7 @@ use function is_string;
  *     ...
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class Callback extends AbstractFilter
 {

--- a/src/Compress/Bz2.php
+++ b/src/Compress/Bz2.php
@@ -25,6 +25,7 @@ use function str_contains;
  *     archive?: string|null,
  * }
  * @extends AbstractCompressionAlgorithm<Options>
+ * @final
  */
 class Bz2 extends AbstractCompressionAlgorithm
 {

--- a/src/Compress/Gz.php
+++ b/src/Compress/Gz.php
@@ -36,6 +36,7 @@ use const SEEK_END;
  *     archive?: string|null,
  * }
  * @extends AbstractCompressionAlgorithm<Options>
+ * @final
  */
 class Gz extends AbstractCompressionAlgorithm
 {

--- a/src/Compress/Tar.php
+++ b/src/Compress/Tar.php
@@ -30,6 +30,7 @@ use const DIRECTORY_SEPARATOR;
  *     mode?: 'gz'|'bz2'|null,
  * }
  * @extends AbstractCompressionAlgorithm<Options>
+ * @final
  */
 class Tar extends AbstractCompressionAlgorithm
 {

--- a/src/Compress/Zip.php
+++ b/src/Compress/Zip.php
@@ -33,6 +33,7 @@ use const DIRECTORY_SEPARATOR;
  *     target?: string|null,
  * }
  * @extends AbstractCompressionAlgorithm<Options>
+ * @final
  */
 class Zip extends AbstractCompressionAlgorithm
 {

--- a/src/DataUnitFormatter.php
+++ b/src/DataUnitFormatter.php
@@ -22,6 +22,7 @@ use function strtolower;
  *     prefixes?: list<string>,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 final class DataUnitFormatter extends AbstractFilter
 {

--- a/src/DateSelect.php
+++ b/src/DateSelect.php
@@ -12,6 +12,7 @@ namespace Laminas\Filter;
  * }
  * @template TOptions of Options
  * @template-extends AbstractDateDropdown<TOptions>
+ * @final
  */
 class DateSelect extends AbstractDateDropdown
 {

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -17,6 +17,7 @@ use function is_string;
  *     ...
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class DateTimeFormatter extends AbstractFilter
 {

--- a/src/DateTimeSelect.php
+++ b/src/DateTimeSelect.php
@@ -16,6 +16,7 @@ use function vsprintf;
  * }
  * @template TOptions of Options
  * @template-extends AbstractDateDropdown<TOptions>
+ * @final
  */
 class DateTimeSelect extends AbstractDateDropdown
 {

--- a/src/Decompress.php
+++ b/src/Decompress.php
@@ -8,6 +8,8 @@ use function is_string;
 
 /**
  * Decompresses a given string
+ *
+ * @final
  */
 class Decompress extends Compress
 {

--- a/src/DenyList.php
+++ b/src/DenyList.php
@@ -17,6 +17,7 @@ use function is_array;
  *     ...
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class DenyList extends AbstractFilter
 {

--- a/src/Digits.php
+++ b/src/Digits.php
@@ -14,6 +14,7 @@ use function preg_replace;
 /**
  * @psalm-type Options = array{}
  * @extends AbstractFilter<Options>
+ * @final
  */
 class Digits extends AbstractFilter
 {

--- a/src/Dir.php
+++ b/src/Dir.php
@@ -10,6 +10,7 @@ use function is_scalar;
 /**
  * @psalm-type Options = array{}
  * @extends AbstractFilter<Options>
+ * @final
  */
 class Dir extends AbstractFilter
 {

--- a/src/Encrypt.php
+++ b/src/Encrypt.php
@@ -28,7 +28,6 @@ use function ucfirst;
  *     ...
  * }
  * @extends AbstractFilter<Options>
- * @psalm-suppress DeprecatedInterface
  */
 class Encrypt extends AbstractFilter
 {

--- a/src/File/Decrypt.php
+++ b/src/File/Decrypt.php
@@ -19,8 +19,6 @@ use function is_writable;
  *
  * @deprecated Since 2.24.0. This filter will be removed in 3.0. You are encouraged to use an alternative encryption
  *             library and write your own filter.
- *
- * @psalm-suppress DeprecatedInterface
  */
 class Decrypt extends Filter\Decrypt
 {

--- a/src/File/Encrypt.php
+++ b/src/File/Encrypt.php
@@ -19,8 +19,6 @@ use function is_writable;
  *
  * @deprecated Since 2.24.0. This filter will be removed in 3.0. You are encouraged to use an alternative encryption
  *             library and write your own filter.
- *
- * @psalm-suppress DeprecatedInterface
  */
 class Encrypt extends Filter\Encrypt
 {

--- a/src/File/LowerCase.php
+++ b/src/File/LowerCase.php
@@ -16,6 +16,7 @@ use function is_scalar;
 use function is_string;
 use function is_writable;
 
+/** @final */
 class LowerCase extends StringToLower
 {
     /**

--- a/src/File/Rename.php
+++ b/src/File/Rename.php
@@ -33,6 +33,7 @@ use const DIRECTORY_SEPARATOR;
  * }
  * @template TOptions of Options
  * @template-extends Filter\AbstractFilter<TOptions>
+ * @final
  */
 class Rename extends Filter\AbstractFilter
 {

--- a/src/File/UpperCase.php
+++ b/src/File/UpperCase.php
@@ -14,6 +14,7 @@ use function is_array;
 use function is_scalar;
 use function is_writable;
 
+/** @final */
 class UpperCase extends StringToUpper
 {
     /**

--- a/src/HtmlEntities.php
+++ b/src/HtmlEntities.php
@@ -26,6 +26,7 @@ use const ENT_QUOTES;
  *     ...
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class HtmlEntities extends AbstractFilter
 {

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -35,6 +35,7 @@ use function str_replace;
  *     pluginManager?: FilterPluginManager,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class Inflector extends AbstractFilter
 {

--- a/src/MonthSelect.php
+++ b/src/MonthSelect.php
@@ -12,6 +12,7 @@ namespace Laminas\Filter;
  * }
  * @template TOptions of Options
  * @template-extends AbstractDateDropdown<TOptions>
+ * @final
  */
 class MonthSelect extends AbstractDateDropdown
 {

--- a/src/PregReplace.php
+++ b/src/PregReplace.php
@@ -25,6 +25,7 @@ use function str_contains;
  *     replacement?: string|list<string>,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class PregReplace extends AbstractFilter
 {

--- a/src/RealPath.php
+++ b/src/RealPath.php
@@ -29,6 +29,7 @@ use const PHP_OS;
  * }
  * @template TOptions of Options
  * @extends AbstractFilter<TOptions>
+ * @final
  */
 class RealPath extends AbstractFilter
 {

--- a/src/StringPrefix.php
+++ b/src/StringPrefix.php
@@ -15,6 +15,7 @@ use function sprintf;
  *     prefix?: null|string,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class StringPrefix extends AbstractFilter
 {

--- a/src/StringSuffix.php
+++ b/src/StringSuffix.php
@@ -15,6 +15,7 @@ use function sprintf;
  *     suffix?: null|string,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class StringSuffix extends AbstractFilter
 {

--- a/src/StringTrim.php
+++ b/src/StringTrim.php
@@ -16,6 +16,7 @@ use function strlen;
  *     charlist?: string|null,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class StringTrim extends AbstractFilter
 {

--- a/src/StripNewlines.php
+++ b/src/StripNewlines.php
@@ -11,6 +11,7 @@ use function str_replace;
 /**
  * @psalm-type Options = array{}
  * @extends AbstractFilter<Options>
+ * @final
  */
 class StripNewlines extends AbstractFilter
 {

--- a/src/StripTags.php
+++ b/src/StripTags.php
@@ -31,6 +31,7 @@ use function trim;
  *     ...
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class StripTags extends AbstractFilter
 {

--- a/src/ToFloat.php
+++ b/src/ToFloat.php
@@ -9,6 +9,7 @@ use function is_scalar;
 /**
  * @psalm-type Options = array{}
  * @extends AbstractFilter<Options>
+ * @final
  */
 class ToFloat extends AbstractFilter
 {

--- a/src/ToInt.php
+++ b/src/ToInt.php
@@ -9,6 +9,7 @@ use function is_scalar;
 /**
  * @psalm-type Options = array{}
  * @extends AbstractFilter<Options>
+ * @final
  */
 class ToInt extends AbstractFilter
 {

--- a/src/ToNull.php
+++ b/src/ToNull.php
@@ -21,6 +21,7 @@ use function sprintf;
  *     type?: int-mask-of<self::TYPE_*>,
  * }
  * @extends AbstractFilter<Options>
+ * @final
  */
 class ToNull extends AbstractFilter
 {

--- a/src/UriNormalize.php
+++ b/src/UriNormalize.php
@@ -23,6 +23,7 @@ use function str_contains;
  * }
  * @template TOptions of Options
  * @template-extends AbstractFilter<TOptions>
+ * @final
  */
 class UriNormalize extends AbstractFilter
 {

--- a/src/Word/CamelCaseToDash.php
+++ b/src/Word/CamelCaseToDash.php
@@ -11,6 +11,7 @@ namespace Laminas\Filter\Word;
  * }
  * @template TOptions of Options
  * @extends CamelCaseToSeparator<TOptions>
+ * @final
  */
 class CamelCaseToDash extends CamelCaseToSeparator
 {

--- a/src/Word/CamelCaseToUnderscore.php
+++ b/src/Word/CamelCaseToUnderscore.php
@@ -11,6 +11,7 @@ namespace Laminas\Filter\Word;
  * }
  * @template TOptions of Options
  * @extends CamelCaseToSeparator<TOptions>
+ * @final
  */
 class CamelCaseToUnderscore extends CamelCaseToSeparator
 {

--- a/src/Word/DashToCamelCase.php
+++ b/src/Word/DashToCamelCase.php
@@ -11,6 +11,7 @@ namespace Laminas\Filter\Word;
  * }
  * @template TOptions of Options
  * @extends SeparatorToCamelCase<TOptions>
+ * @final
  */
 class DashToCamelCase extends SeparatorToCamelCase
 {

--- a/src/Word/DashToSeparator.php
+++ b/src/Word/DashToSeparator.php
@@ -15,6 +15,7 @@ use function str_replace;
  * }
  * @template TOptions of Options
  * @extends AbstractSeparator<TOptions>
+ * @final
  */
 class DashToSeparator extends AbstractSeparator
 {

--- a/src/Word/DashToUnderscore.php
+++ b/src/Word/DashToUnderscore.php
@@ -12,6 +12,7 @@ namespace Laminas\Filter\Word;
  * }
  * @template TOptions of Options
  * @template-extends SeparatorToSeparator<TOptions>
+ * @final
  */
 class DashToUnderscore extends SeparatorToSeparator
 {

--- a/src/Word/SeparatorToDash.php
+++ b/src/Word/SeparatorToDash.php
@@ -12,6 +12,7 @@ namespace Laminas\Filter\Word;
  * }
  * @template TOptions of Options
  * @template-extends SeparatorToSeparator<TOptions>
+ * @final
  */
 class SeparatorToDash extends SeparatorToSeparator
 {

--- a/src/Word/Service/SeparatorToSeparatorFactory.php
+++ b/src/Word/Service/SeparatorToSeparatorFactory.php
@@ -16,6 +16,7 @@ use function is_array;
 use function iterator_to_array;
 use function sprintf;
 
+/** @final */
 class SeparatorToSeparatorFactory implements FactoryInterface
 {
     /**

--- a/src/Word/UnderscoreToDash.php
+++ b/src/Word/UnderscoreToDash.php
@@ -12,6 +12,7 @@ namespace Laminas\Filter\Word;
  * }
  * @template TOptions of Options
  * @template-extends SeparatorToSeparator<TOptions>
+ * @final
  */
 class UnderscoreToDash extends SeparatorToSeparator
 {

--- a/src/Word/UnderscoreToStudlyCase.php
+++ b/src/Word/UnderscoreToStudlyCase.php
@@ -20,6 +20,7 @@ use function mb_substr;
  * }
  * @template TOptions of Options
  * @template-extends UnderscoreToCamelCase<TOptions>
+ * @final
  */
 class UnderscoreToStudlyCase extends UnderscoreToCamelCase
 {

--- a/test/File/RenameTest.php
+++ b/test/File/RenameTest.php
@@ -26,12 +26,12 @@ use const DIRECTORY_SEPARATOR;
 
 class RenameTest extends TestCase
 {
-    private ?string $tmpPath    = null;
-    private ?string $origFile   = null;
-    private ?string $oldFile    = null;
-    private ?string $newFile    = null;
-    private ?string $newDir     = null;
-    private ?string $newDirFile = null;
+    private string $tmpPath;
+    private string $origFile;
+    private string $oldFile;
+    private string $newFile;
+    private string $newDir;
+    private string $newDirFile;
 
     /**
      * Sets the path to test files
@@ -353,9 +353,6 @@ class RenameTest extends TestCase
 
     public function testAddSameFileAgainAndOverwriteExistingTarget(): void
     {
-        self::assertIsString($this->oldFile);
-        self::assertIsString($this->newFile);
-
         $filter = new FileRename([
             'source' => $this->oldFile,
             'target' => $this->newDir,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| New Feature   | yes
| QA            | yes

### Description

In order to reduce future BC break surface area, we would benefit from marking all code, where possible as final in v3.0. This patch adds `@final` to all filters that are not already extended within this lib.