### PR TITLE
Refactor `AllowList` Filter, Add generic template to `FilterInterface`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -23,15 +23,6 @@
       <code><![CDATA[is_object($options)]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="src/AllowList.php">
-    <PossiblyUnusedMethod>
-      <code><![CDATA[setList]]></code>
-      <code><![CDATA[setStrict]]></code>
-    </PossiblyUnusedMethod>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $strict]]></code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="src/Callback.php">
     <MixedFunctionCall>
       <code><![CDATA[call_user_func_array($this->options['callback'], $params)]]></code>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -775,17 +775,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/AllowListTest.php">
-    <InvalidArgument>
-      <code><![CDATA[$strict]]></code>
-    </InvalidArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$expected]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$data]]></code>
-      <code><![CDATA[[$value, $expected]]]></code>
-    </MixedAssignment>
     <PossiblyUnusedMethod>
       <code><![CDATA[defaultTestProvider]]></code>
       <code><![CDATA[listTestProvider]]></code>
@@ -1083,25 +1072,10 @@
       <code><![CDATA[returnUnfilteredDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="test/TestAsset/Alpha.php">
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$value]]></code>
-    </MixedArgumentTypeCoercion>
-  </file>
   <file src="test/TestAsset/CallbackClass.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[objectCallbackWithParams]]></code>
     </PossiblyUnusedMethod>
-  </file>
-  <file src="test/TestAsset/LowerCase.php">
-    <MixedArgument>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-  </file>
-  <file src="test/TestAsset/StripUpperCase.php">
-    <MixedArgument>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
   </file>
   <file src="test/ToFloatTest.php">
     <PossiblyUnusedMethod>

--- a/src/AbstractFilter.php
+++ b/src/AbstractFilter.php
@@ -21,6 +21,7 @@ use function ucwords;
 
 /**
  * @template TOptions of array
+ * @implements FilterInterface<mixed>
  */
 abstract class AbstractFilter implements FilterInterface
 {

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -8,7 +8,6 @@ use Laminas\Stdlib\ArrayUtils;
 
 use function array_values;
 use function in_array;
-use function is_array;
 
 /**
  * @psalm-type Options = array{
@@ -18,71 +17,16 @@ use function is_array;
  */
 final class AllowList implements FilterInterface
 {
-    private bool $strict = false;
+    private readonly bool $strict;
     /** @var list<mixed> */
-    private array $list = [];
+    private readonly array $list;
 
-    /**
-     * @param Options $options
-     */
+    /** @param Options $options */
     public function __construct(array $options = [])
     {
-        $this->setOptions($options);
-    }
-
-    /**
-     * @param Options $options
-     * @return $this
-     */
-    public function setOptions(array $options = []): self
-    {
-        $strict = $options['strict'] ?? false;
-        $list   = $options['list'] ?? [];
-
-        $this->setStrict($strict);
-        $this->setList($list);
-
-        return $this;
-    }
-
-    /**
-     * Determine whether the in_array() call should be "strict" or not. See in_array docs.
-     */
-    public function setStrict(bool $strict): void
-    {
-        $this->strict = $strict;
-    }
-
-    /**
-     * Returns whether the in_array() call should be "strict" or not. See in_array docs.
-     */
-    public function getStrict(): bool
-    {
-        return $this->strict;
-    }
-
-    /**
-     * Set the list of items to allow
-     *
-     * @param iterable<array-key, mixed> $list
-     */
-    public function setList(iterable $list = []): void
-    {
-        if (! is_array($list)) {
-            $list = ArrayUtils::iteratorToArray($list);
-        }
-
-        $this->list = array_values($list);
-    }
-
-    /**
-     * Get the list of items to allow
-     *
-     * @return list<mixed>
-     */
-    public function getList(): array
-    {
-        return $this->list;
+        $this->strict = $options['strict'] ?? false;
+        $list         = ArrayUtils::iteratorToArray($options['list'] ?? []);
+        $this->list   = array_values($list);
     }
 
     /**

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -14,6 +14,7 @@ use function in_array;
  *     strict?: bool,
  *     list?: iterable<array-key, mixed>,
  * }
+ * @implements FilterInterface<null>
  */
 final class AllowList implements FilterInterface
 {
@@ -33,10 +34,6 @@ final class AllowList implements FilterInterface
      * {@inheritDoc}
      *
      * Will return $value if its present in the allow-list. If $value is rejected then it will return null.
-     *
-     * @template T
-     * @param T $value
-     * @return T|null
      */
     public function filter(mixed $value): mixed
     {
@@ -44,11 +41,9 @@ final class AllowList implements FilterInterface
     }
 
     /**
-     * Will return $value if its present in the allow-list. If $value is rejected then it will return null.
+     * {@inheritDoc}
      *
-     * @template T
-     * @param T $value
-     * @return T|null
+     * Will return $value if its present in the allow-list. If $value is rejected then it will return null.
      */
     public function __invoke(mixed $value): mixed
     {

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -12,7 +12,7 @@ use function in_array;
 /**
  * @psalm-type Options = array{
  *     strict?: bool,
- *     list: iterable<array-key, mixed>,
+ *     list?: iterable<array-key, mixed>,
  * }
  * @implements FilterInterface<null>
  */
@@ -23,7 +23,7 @@ final class AllowList implements FilterInterface
     private readonly array $list;
 
     /** @param Options $options */
-    public function __construct(array $options)
+    public function __construct(array $options = [])
     {
         $this->strict = $options['strict'] ?? false;
         $list         = ArrayUtils::iteratorToArray($options['list'] ?? []);

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -12,7 +12,7 @@ use function in_array;
 /**
  * @psalm-type Options = array{
  *     strict?: bool,
- *     list?: iterable<array-key, mixed>,
+ *     list: iterable<array-key, mixed>,
  * }
  * @implements FilterInterface<null>
  */
@@ -23,7 +23,7 @@ final class AllowList implements FilterInterface
     private readonly array $list;
 
     /** @param Options $options */
-    public function __construct(array $options = [])
+    public function __construct(array $options)
     {
         $this->strict = $options['strict'] ?? false;
         $list         = ArrayUtils::iteratorToArray($options['list'] ?? []);

--- a/src/BaseName.php
+++ b/src/BaseName.php
@@ -7,15 +7,16 @@ namespace Laminas\Filter;
 use function basename;
 use function is_string;
 
-/** @psalm-immutable */
+/**
+ * @psalm-immutable
+ * @implements FilterInterface<string>
+ */
 final class BaseName implements FilterInterface
 {
     /**
      * Returns basename($value).
      *
      * If the value provided is non-string, the value will remain unfiltered
-     *
-     * @psalm-return ($value is string ? string : mixed)
      */
     public function filter(mixed $value): mixed
     {

--- a/src/Boolean.php
+++ b/src/Boolean.php
@@ -30,6 +30,7 @@ use function strtolower;
  *     casting: bool,
  *     translations: array<string, bool>,
  * }
+ * @implements FilterInterface<bool>
  */
 final class Boolean implements FilterInterface
 {

--- a/src/FilterInterface.php
+++ b/src/FilterInterface.php
@@ -4,14 +4,26 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
+/** @template TFilteredValue */
 interface FilterInterface
 {
     /**
      * Returns the result of filtering $value
      *
+     * @template T
+     * @param T $value
+     * @return TFilteredValue|T
      * @throws Exception\RuntimeException If filtering $value is impossible.
      */
     public function filter(mixed $value): mixed;
 
+    /**
+     * Returns the result of filtering $value
+     *
+     * @template T
+     * @param T $value
+     * @return TFilteredValue|T
+     * @throws Exception\RuntimeException If filtering $value is impossible.
+     */
     public function __invoke(mixed $value): mixed;
 }

--- a/src/ForceUriScheme.php
+++ b/src/ForceUriScheme.php
@@ -16,6 +16,7 @@ use function sprintf;
 
 /**
  * @psalm-type Options = array{scheme: non-empty-string}
+ * @implements FilterInterface<string>
  */
 final class ForceUriScheme implements FilterInterface
 {

--- a/test/AllowListTest.php
+++ b/test/AllowListTest.php
@@ -33,7 +33,7 @@ class AllowListTest extends TestCase
 
     public function testConstructorDefaults(): void
     {
-        $filter = new AllowListFilter(['list' => ['a', 'b', 'c']]);
+        $filter = new AllowListFilter();
         self::assertNull($filter->filter('anything'));
     }
 

--- a/test/AllowListTest.php
+++ b/test/AllowListTest.php
@@ -33,7 +33,7 @@ class AllowListTest extends TestCase
 
     public function testConstructorDefaults(): void
     {
-        $filter = new AllowListFilter();
+        $filter = new AllowListFilter(['list' => ['a', 'b', 'c']]);
         self::assertNull($filter->filter('anything'));
     }
 
@@ -80,7 +80,7 @@ class AllowListTest extends TestCase
     #[DataProvider('defaultTestProvider')]
     public function testFilterWillReturnNullForAnyValueWhenNoListHasBeenSupplied(mixed $value): void
     {
-        $filter = new AllowListFilter();
+        $filter = new AllowListFilter(['list' => []]);
         self::assertNull($filter->filter($value));
     }
 

--- a/test/StaticAnalysis/AllowListChecks.php
+++ b/test/StaticAnalysis/AllowListChecks.php
@@ -11,15 +11,23 @@ final class AllowListChecks
 {
     public function filterReturnTypeIsUnionOfInputAndNull(int $value): int|null
     {
-        $filter = new AllowList();
+        $filter = new AllowList(['list' => [1, 2, 3]]);
 
         return $filter->filter($value);
     }
 
     public function invokeReturnTypeIsUnionOfInputAndNull(int $value): int|null
     {
-        $filter = new AllowList();
+        $filter = new AllowList(['list' => [1, 2, 3]]);
 
         return $filter($value);
+    }
+
+    /** @return 99|null */
+    public function testTypesAreRestrictedToExpectedValues(): int|null
+    {
+        $filter = new AllowList(['list' => [1, 2, 3]]);
+
+        return $filter->filter(99);
     }
 }

--- a/test/StaticAnalysis/AllowListChecks.php
+++ b/test/StaticAnalysis/AllowListChecks.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Filter\StaticAnalysis;
+
+use Laminas\Filter\AllowList;
+
+/** @psalm-suppress UnusedClass */
+final class AllowListChecks
+{
+    public function filterReturnTypeIsUnionOfInputAndNull(int $value): int|null
+    {
+        $filter = new AllowList();
+
+        return $filter->filter($value);
+    }
+
+    public function invokeReturnTypeIsUnionOfInputAndNull(int $value): int|null
+    {
+        $filter = new AllowList();
+
+        return $filter($value);
+    }
+}

--- a/test/TestAsset/Alpha.php
+++ b/test/TestAsset/Alpha.php
@@ -4,21 +4,27 @@ declare(strict_types=1);
 
 namespace LaminasTest\Filter\TestAsset;
 
-use Laminas\Filter\AbstractFilter;
+use Laminas\Filter\FilterInterface;
 
-use function is_array;
-use function is_scalar;
+use function is_string;
 use function preg_replace;
 
-/** @template-extends AbstractFilter<array{}> */
-class Alpha extends AbstractFilter
+/** @implements FilterInterface<string> */
+class Alpha implements FilterInterface
 {
+    /** @inheritDoc */
     public function filter(mixed $value): mixed
     {
-        if (! is_scalar($value) && ! is_array($value)) {
+        if (! is_string($value)) {
             return $value;
         }
 
         return preg_replace('/[^a-zA-Z\s]/', '', $value);
+    }
+
+    /** @inheritDoc */
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }

--- a/test/TestAsset/LowerCase.php
+++ b/test/TestAsset/LowerCase.php
@@ -4,15 +4,27 @@ declare(strict_types=1);
 
 namespace LaminasTest\Filter\TestAsset;
 
-use Laminas\Filter\AbstractFilter;
+use Laminas\Filter\FilterInterface;
 
+use function is_string;
 use function strtolower;
 
-/** @template-extends AbstractFilter<array{}> */
-class LowerCase extends AbstractFilter
+/** @implements FilterInterface<string> */
+class LowerCase implements FilterInterface
 {
+    /** @inheritDoc */
     public function filter(mixed $value): mixed
     {
+        if (! is_string($value)) {
+            return $value;
+        }
+
         return strtolower($value);
+    }
+
+    /** @inheritDoc */
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }

--- a/test/TestAsset/StrRepeatFilterInterface.php
+++ b/test/TestAsset/StrRepeatFilterInterface.php
@@ -8,6 +8,7 @@ use Laminas\Filter\FilterInterface;
 
 use function str_repeat;
 
+/** @implements FilterInterface<string> */
 class StrRepeatFilterInterface implements FilterInterface
 {
     public function filter(mixed $value): mixed

--- a/test/TestAsset/StripUpperCase.php
+++ b/test/TestAsset/StripUpperCase.php
@@ -4,15 +4,27 @@ declare(strict_types=1);
 
 namespace LaminasTest\Filter\TestAsset;
 
-use Laminas\Filter\AbstractFilter;
+use Laminas\Filter\FilterInterface;
 
+use function is_string;
 use function preg_replace;
 
-/** @template-extends AbstractFilter<array{}> */
-class StripUpperCase extends AbstractFilter
+/** @implements FilterInterface<string> */
+class StripUpperCase implements FilterInterface
 {
+    /** @inheritDoc */
     public function filter(mixed $value): mixed
     {
+        if (! is_string($value)) {
+            return $value;
+        }
+
         return preg_replace('/[A-Z]/', '', $value);
+    }
+
+    /** @inheritDoc */
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }


### PR DESCRIPTION
This patch is indicative of the plans for all the shipped filters where feasible:

- Removes inheritance
- Private properties instead of protected
- Native return types
- Native parameter types
- Options can no longer be Traversable

The reason options can no longer be Traversable is because we can rely on static analysis by using the documented array shape. Allowing Traversable will require a lot of type juggling and coercion, and it becomes difficult to know where to stop, for example, given the `strict` option here, previously, at least `bool|int<0,1>|'0'|'1'` were acceptable, so why not also `'y'|'n'|'yes'|'no'|'true'|'false'` too? We can all agree that native types are an improvement, so we might as well get rid of the idea that Options arrays|Traversables can have mixed values too.

### Questions…

#### Option value setters and getters. Can we get rid of them?

It's unlikely that filters are mutated at runtime. Most consumers will be using them via an InputFilter as part of an array spec such as:

```php
[
  'filters' => [
    [
      'name' => AllowList::class,
      'options' => [
        'strict' => true,
        'list' => ['some', 'list'],
      ],
    ],
  ],
];
```

Handling the option values in `__construct` and `setOptions` seems sufficient, and the getters just feel like a testing convenience.

We'll also still have runtime type safety via native property types.

#### Inheritance Removal…

… might be invalid in this case. I can think of 2 reasons why a parent abstract might be useful:

- To provide `__invoke(mixed):mixed` _(without useful type inference)_ that just proxies to `filter()`
- To call `setOptions` during `__construct`.

Therefore, might it be better to strip everything else out of the `AbstractFilter` bar these 2 functions?

#### Introduce an `AcceptsOptionsInterface`

something along the lines of

```php
/** @template Options of array<string, mixed> */
interface AcceptsOptionsInterface {
  
  /** @param Options $options */
  public function setOptions(array $options): self; /** preferably void */
  
}
```

This patch is cut from #117 so it'll be easier to review just https://github.com/laminas/laminas-filter/commit/fab100bcc360cc41c94e8313e66a74ad7b03e2ee in isolation.
