### PR TITLE
Remove dev dependency on `laminas-i18n`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,6 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
-        "laminas/laminas-i18n": "^2.26.0",
         "pear/archive_tar": "^1.4.14",
         "phpunit/phpunit": "^10.5.11",
         "psalm/plugin-phpunit": "^0.19.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a67875aec9e672b030c622d2b87849ff",
+    "content-hash": "dc7ab9e282128061526953709d8bd29f",
     "packages": [
         {
             "name": "laminas/laminas-servicemanager",
@@ -991,91 +991,6 @@
                 }
             ],
             "time": "2023-01-05T15:53:40+00:00"
-        },
-        {
-            "name": "laminas/laminas-i18n",
-            "version": "2.26.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "01738410cb263994d1d192861f642387e7e12ace"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/01738410cb263994d1d192861f642387e7e12ace",
-                "reference": "01738410cb263994d1d192861f642387e7e12ace",
-                "shasum": ""
-            },
-            "require": {
-                "ext-intl": "*",
-                "laminas/laminas-servicemanager": "^3.21.0",
-                "laminas/laminas-stdlib": "^3.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "laminas/laminas-view": "<2.20.0",
-                "zendframework/zend-i18n": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-cache": "^3.12.0",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.3.0",
-                "laminas/laminas-cache-storage-deprecated-factory": "^1.2",
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-config": "^3.9.0",
-                "laminas/laminas-eventmanager": "^3.13",
-                "laminas/laminas-filter": "^2.34",
-                "laminas/laminas-validator": "^2.46",
-                "laminas/laminas-view": "^2.33",
-                "phpunit/phpunit": "^10.5.5",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.18.0"
-            },
-            "suggest": {
-                "laminas/laminas-cache": "You should install this package to cache the translations",
-                "laminas/laminas-config": "You should install this package to use the INI translation format",
-                "laminas/laminas-eventmanager": "You should install this package to use the events in the translator",
-                "laminas/laminas-filter": "You should install this package to use the provided filters",
-                "laminas/laminas-i18n-resources": "This package provides validator and captcha translations",
-                "laminas/laminas-validator": "You should install this package to use the provided validators",
-                "laminas/laminas-view": "You should install this package to use the provided view helpers"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\I18n",
-                    "config-provider": "Laminas\\I18n\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\I18n\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Provide translations for your application, and filter and validate internationalized values",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "i18n",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-i18n/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-i18n/issues",
-                "rss": "https://github.com/laminas/laminas-i18n/releases.atom",
-                "source": "https://github.com/laminas/laminas-i18n"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-01-04T13:49:00+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/src/FilterPluginManager.php
+++ b/src/FilterPluginManager.php
@@ -5,10 +5,6 @@ declare(strict_types=1);
 namespace Laminas\Filter;
 
 use Laminas\Filter\Exception\RuntimeException;
-use Laminas\I18n\Filter\Alnum;
-use Laminas\I18n\Filter\Alpha;
-use Laminas\I18n\Filter\NumberFormat;
-use Laminas\I18n\Filter\NumberParse;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use Laminas\ServiceManager\Factory\InvokableFactory;
@@ -35,18 +31,6 @@ final class FilterPluginManager extends AbstractPluginManager
         'Int'  => ToInt::class,
         'null' => ToNull::class,
         'Null' => ToNull::class,
-
-        // I18n filters
-        'alnum'        => Alnum::class,
-        'Alnum'        => Alnum::class,
-        'alpha'        => Alpha::class,
-        'Alpha'        => Alpha::class,
-        'numberformat' => NumberFormat::class,
-        'numberFormat' => NumberFormat::class,
-        'NumberFormat' => NumberFormat::class,
-        'numberparse'  => NumberParse::class,
-        'numberParse'  => NumberParse::class,
-        'NumberParse'  => NumberParse::class,
 
         // Standard filters
         'allowlist'                  => AllowList::class,
@@ -189,10 +173,6 @@ final class FilterPluginManager extends AbstractPluginManager
         'WordUnderscoreToSeparator'  => Word\UnderscoreToSeparator::class,
 
         // Legacy Zend Framework aliases
-        'Zend\I18n\Filter\Alnum'                  => Alnum::class,
-        'Zend\I18n\Filter\Alpha'                  => Alpha::class,
-        'Zend\I18n\Filter\NumberFormat'           => NumberFormat::class,
-        'Zend\I18n\Filter\NumberParse'            => NumberParse::class,
         'Zend\Filter\BaseName'                    => BaseName::class,
         'Zend\Filter\Boolean'                     => Boolean::class,
         'Zend\Filter\Callback'                    => Callback::class,
@@ -242,10 +222,6 @@ final class FilterPluginManager extends AbstractPluginManager
         'zendfiltertoint'                      => ToInt::class,
         'zendfiltertofloat'                    => ToFloat::class,
         'zendfiltertonull'                     => ToNull::class,
-        'zendi18nfilteralnum'                  => Alnum::class,
-        'zendi18nfilteralpha'                  => Alpha::class,
-        'zendi18nfilternumberformat'           => NumberFormat::class,
-        'zendi18nfilternumberparse'            => NumberParse::class,
         'zendfilterbasename'                   => BaseName::class,
         'zendfilterboolean'                    => Boolean::class,
         'zendfiltercallback'                   => Callback::class,
@@ -296,12 +272,6 @@ final class FilterPluginManager extends AbstractPluginManager
      * @var array
      */
     protected $factories = [
-        // I18n filters
-        Alnum::class        => InvokableFactory::class,
-        Alpha::class        => InvokableFactory::class,
-        NumberFormat::class => InvokableFactory::class,
-        NumberParse::class  => InvokableFactory::class,
-
         // Standard filters
         AllowList::class                   => InvokableFactory::class,
         BaseName::class                    => InvokableFactory::class,
@@ -356,10 +326,6 @@ final class FilterPluginManager extends AbstractPluginManager
         'laminasfiltertoint'                      => InvokableFactory::class,
         'laminasfiltertofloat'                    => InvokableFactory::class,
         'laminasfiltertonull'                     => InvokableFactory::class,
-        'laminasi18nfilteralnum'                  => InvokableFactory::class,
-        'laminasi18nfilteralpha'                  => InvokableFactory::class,
-        'laminasi18nfilternumberformat'           => InvokableFactory::class,
-        'laminasi18nfilternumberparse'            => InvokableFactory::class,
         'laminasfilterbasename'                   => InvokableFactory::class,
         'laminasfilterboolean'                    => InvokableFactory::class,
         'laminasfiltercallback'                   => InvokableFactory::class,

--- a/test/FilterPluginManagerCompatibilityTest.php
+++ b/test/FilterPluginManagerCompatibilityTest.php
@@ -45,10 +45,6 @@ class FilterPluginManagerCompatibilityTest extends TestCase
         foreach ($aliases as $alias => $target) {
             self::assertIsString($alias);
             self::assertIsString($target);
-            // Skipping as laminas-i18n is not required by this package
-            if (strpos($target, '\\I18n\\') !== false) {
-                continue;
-            }
 
             // Skipping as it has required options
             if (strpos($target, 'DataUnitFormatter') !== false) {


### PR DESCRIPTION
Removes the dependency from composer.json and also the plugin manager configuration from the plugin manager.

The filters are setup during inclusion of `i18n` in user projects as outlined in #130

Closes #130
