### PR TITLE
Fixes regression in FilterChain options, allows callback to be an instance of FilterInterface again.

### DIFF
--- a/src/FilterChain.php
+++ b/src/FilterChain.php
@@ -29,7 +29,7 @@ use function strtolower;
  *        priority?: int,
  *    }>,
  *    callbacks?: list<array{
- *        callback: callable(mixed): mixed,
+ *        callback: FilterInterface|callable(mixed): mixed,
  *        priority?: int,
  *    }>
  * }
@@ -87,7 +87,7 @@ class FilterChain extends AbstractFilter implements Countable, IteratorAggregate
                     foreach ($value as $spec) {
                         $callback = $spec['callback'] ?? false;
                         $priority = $spec['priority'] ?? static::DEFAULT_PRIORITY;
-                        if (is_callable($callback)) {
+                        if (is_callable($callback) || $callback instanceof FilterInterface) {
                             $this->attach($callback, $priority);
                         }
                     }

--- a/test/FilterChainTest.php
+++ b/test/FilterChainTest.php
@@ -10,6 +10,7 @@ use Laminas\Filter\PregReplace;
 use Laminas\Filter\StringToLower;
 use Laminas\Filter\StringTrim;
 use Laminas\Filter\StripTags;
+use LaminasTest\Filter\TestAsset\StrRepeatFilterInterface;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
@@ -77,7 +78,7 @@ class FilterChainTest extends TestCase
         $chain  = new FilterChain();
         $chain->setOptions($config);
         $value         = '<a name="foo"> abc </a><img id="bar" />';
-        $valueExpected = 'ABC <IMG ID="BAR" />';
+        $valueExpected = 'ABC <IMG ID="BAR" />ABC <IMG ID="BAR" />';
         self::assertSame($valueExpected, $chain->filter($value));
     }
 
@@ -86,7 +87,7 @@ class FilterChainTest extends TestCase
         $config        = $this->getChainConfig();
         $chain         = new FilterChain($config);
         $value         = '<a name="foo"> abc </a>';
-        $valueExpected = 'ABC';
+        $valueExpected = 'ABCABC';
         self::assertSame($valueExpected, $chain->filter($value));
     }
 
@@ -96,7 +97,7 @@ class FilterChainTest extends TestCase
         $config        = new ArrayIterator($config);
         $chain         = new FilterChain($config);
         $value         = '<a name="foo"> abc </a>';
-        $valueExpected = 'ABC';
+        $valueExpected = 'ABCABC';
         self::assertSame($valueExpected, $chain->filter($value));
     }
 
@@ -117,6 +118,7 @@ class FilterChainTest extends TestCase
         return [
             'callbacks' => [
                 ['callback' => [self::class, 'staticUcaseFilter']],
+                ['callback' => new StrRepeatFilterInterface()],
                 [
                     'priority' => 10000,
                     'callback' => static fn(string $value): string => trim($value),

--- a/test/TestAsset/StrRepeatFilterInterface.php
+++ b/test/TestAsset/StrRepeatFilterInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Filter\TestAsset;
+
+use Laminas\Filter\FilterInterface;
+
+use function str_repeat;
+
+class StrRepeatFilterInterface implements FilterInterface
+{
+    public function filter($value)
+    {
+        return str_repeat((string) $value, 2);
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Fixes regression bug introduced by https://github.com/laminas/laminas-filter/pull/124/files#diff-3a6c9663e22963eb296b993e0b7cc8335c9f7f02f8364fc66385ed7175b5639dL89
The `attach` method can take a `callable` or a `FilterInterface`, however, with the added check on only `is_callable`, this breaks applying filters from classes that implement `FilterInterface`

See https://github.com/magento/magento2/pull/38610 for how this breaks in Magento

This PR fixes this.


<del>I tried to fix new problems psalm reports, but am unable to fix them, some help would be appreciated!</del> Update: fixed, somehow the psalm cache was corrupt during my tests, so my initial fix did work in the end.