### PR TITLE
Remove deprecated `AbstractFilter::hasPcreUnicodeSupport` method

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1095,9 +1095,6 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/PregReplaceTest.php">
-    <DeprecatedMethod>
-      <code><![CDATA[PregReplaceFilter::hasPcreUnicodeSupport()]]></code>
-    </DeprecatedMethod>
     <PossiblyUnusedMethod>
       <code><![CDATA[returnNonStringScalarValues]]></code>
       <code><![CDATA[returnUnfilteredDataProvider]]></code>

--- a/src/AbstractFilter.php
+++ b/src/AbstractFilter.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use Laminas\Stdlib\StringUtils;
 use Traversable;
 
 use function array_key_exists;
@@ -31,16 +30,6 @@ abstract class AbstractFilter implements FilterInterface
      * @var TOptions
      */
     protected $options = [];
-
-    /**
-     * @deprecated Since 2.1.0
-     *
-     * @return bool
-     */
-    public static function hasPcreUnicodeSupport()
-    {
-        return StringUtils::hasPcreUnicodeSupport();
-    }
 
     /**
      * @param  TOptions|iterable $options

--- a/test/PregReplaceTest.php
+++ b/test/PregReplaceTest.php
@@ -10,8 +10,6 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
-use function preg_match;
-
 class PregReplaceTest extends TestCase
 {
     private PregReplaceFilter $filter;
@@ -19,12 +17,6 @@ class PregReplaceTest extends TestCase
     public function setUp(): void
     {
         $this->filter = new PregReplaceFilter();
-    }
-
-    public function testDetectsPcreUnicodeSupport(): void
-    {
-        $enabled = (bool) @preg_match('/\pL/u', 'a');
-        self::assertSame($enabled, PregReplaceFilter::hasPcreUnicodeSupport());
     }
 
     public function testPassingPatternToConstructorSetsPattern(): void


### PR DESCRIPTION
This method has been irrelevant since around PHP 5.3 ish…
