### PR TITLE
Refactor `BaseName` filter

### DIFF
--- a/src/BaseName.php
+++ b/src/BaseName.php
@@ -5,29 +5,29 @@ declare(strict_types=1);
 namespace Laminas\Filter;
 
 use function basename;
-use function is_scalar;
+use function is_string;
 
-/**
- * @psalm-type Options = array{}
- * @extends AbstractFilter<Options>
- */
-final class BaseName extends AbstractFilter
+/** @psalm-immutable */
+final class BaseName implements FilterInterface
 {
     /**
-     * Defined by Laminas\Filter\FilterInterface
-     *
      * Returns basename($value).
      *
-     * If the value provided is non-scalar, the value will remain unfiltered
+     * If the value provided is non-string, the value will remain unfiltered
      *
-     * @psalm-return ($value is scalar ? string : mixed)
+     * @psalm-return ($value is string ? string : mixed)
      */
     public function filter(mixed $value): mixed
     {
-        if (! is_scalar($value)) {
+        if (! is_string($value)) {
             return $value;
         }
 
-        return basename((string) $value);
+        return basename($value);
+    }
+
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }

--- a/test/BaseNameTest.php
+++ b/test/BaseNameTest.php
@@ -31,6 +31,9 @@ class BaseNameTest extends TestCase
     {
         return [
             [null],
+            [1],
+            [2.5],
+            [true],
             [new stdClass()],
             [
                 [


### PR DESCRIPTION
Remove inheritance, return unfiltered values for anything except string. It does not make sense to call basename on `(string) 123` or `(string) true` for example.
