### PR TITLE
Refactor `Boolean` filter

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -32,48 +32,6 @@
       <code><![CDATA[(bool) $strict]]></code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/Boolean.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$typeOrOptions]]></code>
-    </ArgumentTypeCoercion>
-    <DocblockTypeContradiction>
-      <code><![CDATA[! is_array($translations) && ! $translations instanceof Traversable]]></code>
-    </DocblockTypeContradiction>
-    <InvalidNullableReturnType>
-      <code><![CDATA[bool]]></code>
-      <code><![CDATA[int-mask-of<self::TYPE_*>]]></code>
-    </InvalidNullableReturnType>
-    <MixedArrayOffset>
-      <code><![CDATA[$this->options['translations'][$message]]]></code>
-    </MixedArrayOffset>
-    <MixedAssignment>
-      <code><![CDATA[$flag]]></code>
-      <code><![CDATA[$message]]></code>
-    </MixedAssignment>
-    <MoreSpecificImplementedParamType>
-      <code><![CDATA[$value]]></code>
-    </MoreSpecificImplementedParamType>
-    <NullableReturnStatement>
-      <code><![CDATA[$this->options['casting']]]></code>
-      <code><![CDATA[$this->options['type']]]></code>
-    </NullableReturnStatement>
-    <PossiblyNullArgument>
-      <code><![CDATA[$type]]></code>
-    </PossiblyNullArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$this->options['casting']]]></code>
-      <code><![CDATA[$this->options['type']]]></code>
-    </PossiblyUndefinedArrayOffset>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[getTranslations]]></code>
-    </PossiblyUnusedMethod>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(bool) $flag]]></code>
-    </RedundantCastGivenDocblockType>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_int($value)]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="src/Callback.php">
     <MixedFunctionCall>
       <code><![CDATA[call_user_func_array($this->options['callback'], $params)]]></code>
@@ -836,37 +794,6 @@
   <file src="test/BaseNameTest.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[returnUnfilteredDataProvider]]></code>
-    </PossiblyUnusedMethod>
-  </file>
-  <file src="test/BooleanTest.php">
-    <ArgumentTypeCoercion>
-      <code><![CDATA[$type]]></code>
-    </ArgumentTypeCoercion>
-    <MixedArgument>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$expected]]></code>
-      <code><![CDATA[$expected]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArrayAccess>
-    <MixedAssignment>
-      <code><![CDATA[$data]]></code>
-      <code><![CDATA[$data]]></code>
-      <code><![CDATA[$type]]></code>
-      <code><![CDATA[[$value, $expected]]]></code>
-      <code><![CDATA[[$value, $expected]]]></code>
-    </MixedAssignment>
-    <PossiblyUnusedMethod>
-      <code><![CDATA[combinedTypeTestProvider]]></code>
-      <code><![CDATA[defaultTestProvider]]></code>
-      <code><![CDATA[duplicateProvider]]></code>
-      <code><![CDATA[noCastingTestProvider]]></code>
-      <code><![CDATA[typeTestProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/CallbackTest.php">

--- a/src/Boolean.php
+++ b/src/Boolean.php
@@ -4,29 +4,34 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use Laminas\Stdlib\ArrayUtils;
-use Traversable;
-
+use function array_merge;
 use function array_search;
-use function get_debug_type;
+use function assert;
 use function gettype;
+use function in_array;
 use function is_array;
 use function is_bool;
-use function is_float;
 use function is_int;
 use function is_string;
 use function sprintf;
 use function strtolower;
 
 /**
- * @psalm-type Options = array{
- *     type?: int-mask-of<self::TYPE_*>,
+ * @psalm-immutable
+ * phpcs:disable Generic.Files.LineLength
+ * @psalm-type TypeOption = int-mask-of<self::TYPE_*>|list<self::TYPE_*>|list<value-of<self::CONSTANTS>>|value-of<self::CONSTANTS>
+ * @psalm-type OptionsArgument = array{
+ *     type?: TypeOption,
  *     casting?: bool,
- *     translations?: array,
+ *     translations?: array<string, bool>,
  * }
- * @extends AbstractFilter<Options>
+ * @psalm-type Options = array{
+ *     type: int-mask-of<self::TYPE_*>,
+ *     casting: bool,
+ *     translations: array<string, bool>,
+ * }
  */
-final class Boolean extends AbstractFilter
+final class Boolean implements FilterInterface
 {
     public const TYPE_BOOLEAN      = 1;
     public const TYPE_INTEGER      = 2;
@@ -55,161 +60,82 @@ final class Boolean extends AbstractFilter
     ];
 
     /** @var Options */
-    protected $options = [
-        'type'         => self::TYPE_PHP,
-        'casting'      => true,
-        'translations' => [],
-    ];
+    private readonly array $options;
 
     /**
-     * phpcs:ignore Generic.Files.LineLength.TooLong
-     * @param self::TYPE_*|value-of<self::CONSTANTS>|list<self::TYPE_*>|int-mask-of<self::TYPE_*>|Options|iterable|null $typeOrOptions
-     * @param bool  $casting
-     * @param array $translations
+     * @param OptionsArgument $options
      */
-    public function __construct($typeOrOptions = null, $casting = true, $translations = [])
+    public function __construct(array $options = [])
     {
-        if ($typeOrOptions instanceof Traversable) {
-            $typeOrOptions = ArrayUtils::iteratorToArray($typeOrOptions);
-        }
+        $defaults = [
+            'type'         => self::TYPE_PHP,
+            'casting'      => true,
+            'translations' => [],
+        ];
 
-        if (
-            is_array($typeOrOptions) && (
-                isset($typeOrOptions['type'])
-                || isset($typeOrOptions['casting'])
-                || isset($typeOrOptions['translations'])
-            )
-        ) {
-            $this->setOptions($typeOrOptions);
-
-            return;
-        }
-
-        if (is_array($typeOrOptions) || is_int($typeOrOptions) || is_string($typeOrOptions)) {
-            $this->setType($typeOrOptions);
-        }
-
-        $this->setCasting($casting);
-        $this->setTranslations($translations);
+        $options         = array_merge($defaults, $options);
+        $options['type'] = $this->resolveType($options['type']);
+        $this->options   = $options;
     }
 
     /**
-     * Set boolean types
+     * Resolve int-mask type from various options
      *
-     * @param  self::TYPE_*|int-mask-of<self::TYPE_*>|value-of<self::CONSTANTS>|list<self::TYPE_*>|null $type
+     * @param int-mask-of<self::TYPE_*>|list<self::TYPE_*>|list<value-of<self::CONSTANTS>>|value-of<self::CONSTANTS> $type
+     * @return int-mask-of<self::TYPE_*>
      * @throws Exception\InvalidArgumentException
-     * @return self
      */
-    public function setType($type = null)
+    private function resolveType(array|int|string $type): int
     {
+        if (is_int($type) && ($type & self::TYPE_ALL) !== 0) {
+            return $type;
+        }
+
+        if (is_string($type) && in_array($type, self::CONSTANTS, true)) {
+            $type = array_search($type, self::CONSTANTS, true);
+            assert(is_int($type));
+
+            return $type;
+        }
+
         if (is_array($type)) {
             $detected = 0;
             foreach ($type as $value) {
                 if (is_int($value)) {
+                    assert(($value & self::TYPE_ALL) !== 0);
                     $detected |= $value;
-                } elseif (($found = array_search($value, self::CONSTANTS, true)) !== false) {
+                } else {
+                    $found = array_search($value, self::CONSTANTS, true);
+                    assert(is_int($found));
+
                     $detected |= $found;
                 }
             }
 
-            $type = $detected;
-        } elseif (is_string($type) && ($found = array_search($type, self::CONSTANTS, true)) !== false) {
-            $type = $found;
+            /** @psalm-var int-mask-of<self::TYPE_*> */
+            return $detected;
         }
 
-        if (! is_int($type) || ($type < 0) || ($type > self::TYPE_ALL)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Unknown type value "%s" (%s)',
-                $type,
-                gettype($type)
-            ));
-        }
-
-        $this->options['type'] = $type;
-        return $this;
+        throw new Exception\InvalidArgumentException(sprintf(
+            'Unknown type value "%s" (%s)',
+            $type,
+            gettype($type),
+        ));
     }
 
     /**
-     * Returns defined boolean types
-     *
-     * @return int-mask-of<self::TYPE_*>
-     */
-    public function getType()
-    {
-        return $this->options['type'];
-    }
-
-    /**
-     * Set the working mode
-     *
-     * @param  bool $flag When true this filter works like cast
-     *                       When false it recognises only true and false
-     *                       and all other values are returned as is
-     * @return self
-     */
-    public function setCasting($flag = true)
-    {
-        $this->options['casting'] = (bool) $flag;
-        return $this;
-    }
-
-    /**
-     * Returns the casting option
-     *
-     * @return bool
-     */
-    public function getCasting()
-    {
-        return $this->options['casting'];
-    }
-
-    /**
-     * @param  array|Traversable $translations
-     * @throws Exception\InvalidArgumentException
-     * @return self
-     */
-    public function setTranslations($translations)
-    {
-        if (! is_array($translations) && ! $translations instanceof Traversable) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '"%s" expects an array or Traversable; received "%s"',
-                __METHOD__,
-                get_debug_type($translations)
-            ));
-        }
-
-        foreach ($translations as $message => $flag) {
-            $this->options['translations'][$message] = (bool) $flag;
-        }
-
-        return $this;
-    }
-
-    /**
-     * @return array
-     */
-    public function getTranslations()
-    {
-        return $this->options['translations'] ?? [];
-    }
-
-    /**
-     * Defined by Laminas\Filter\FilterInterface
-     *
      * Returns a boolean representation of $value
-     *
-     * @param  null|array|bool|float|int|string $value
      */
     public function filter(mixed $value): mixed
     {
-        $type    = $this->getType();
-        $casting = $this->getCasting();
+        $type    = $this->options['type'];
+        $casting = $this->options['casting'];
 
         // LOCALIZED
         if ($type & self::TYPE_LOCALIZED) {
             if (is_string($value)) {
                 if (isset($this->options['translations'][$value])) {
-                    return (bool) $this->options['translations'][$value];
+                    return $this->options['translations'][$value];
                 }
             }
         }
@@ -220,7 +146,7 @@ final class Boolean extends AbstractFilter
                 return false;
             }
 
-            if (! $casting && is_string($value) && strtolower($value) === 'true') {
+            if (is_string($value) && strtolower($value) === 'true') {
                 return true;
             }
         }
@@ -234,47 +160,47 @@ final class Boolean extends AbstractFilter
 
         // EMPTY_ARRAY (array())
         if ($type & self::TYPE_EMPTY_ARRAY) {
-            if (is_array($value) && $value === []) {
+            if ($value === []) {
                 return false;
             }
         }
 
         // ZERO_STRING ('0')
         if ($type & self::TYPE_ZERO_STRING) {
-            if (is_string($value) && $value === '0') {
+            if ($value === '0') {
                 return false;
             }
 
-            if (! $casting && is_string($value) && $value === '1') {
+            if (! $casting && $value === '1') {
                 return true;
             }
         }
 
         // STRING ('')
         if ($type & self::TYPE_STRING) {
-            if (is_string($value) && $value === '') {
+            if ($value === '') {
                 return false;
             }
         }
 
         // FLOAT (0.0)
         if ($type & self::TYPE_FLOAT) {
-            if (is_float($value) && $value === 0.0) {
+            if ($value === 0.0) {
                 return false;
             }
 
-            if (! $casting && is_float($value) && $value === 1.0) {
+            if (! $casting && $value === 1.0) {
                 return true;
             }
         }
 
         // INTEGER (0)
         if ($type & self::TYPE_INTEGER) {
-            if (is_int($value) && $value === 0) {
+            if ($value === 0) {
                 return false;
             }
 
-            if (! $casting && is_int($value) && $value === 1) {
+            if (! $casting && $value === 1) {
                 return true;
             }
         }
@@ -291,5 +217,10 @@ final class Boolean extends AbstractFilter
         }
 
         return $value;
+    }
+
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }

--- a/test/StaticAnalysis/BooleanFilterChecks.php
+++ b/test/StaticAnalysis/BooleanFilterChecks.php
@@ -11,25 +11,27 @@ final class BooleanFilterChecks
 {
     public function constructorAcceptsSingleTypeConstant(): Filter\Boolean
     {
-        return new Filter\Boolean(Filter\Boolean::TYPE_FLOAT);
+        return new Filter\Boolean(['type' => Filter\Boolean::TYPE_FLOAT]);
     }
 
     public function constructorAcceptsListOfConstants(): Filter\Boolean
     {
         return new Filter\Boolean([
-            Filter\Boolean::TYPE_EMPTY_ARRAY,
-            Filter\Boolean::TYPE_FALSE_STRING,
+            'type' => [
+                Filter\Boolean::TYPE_EMPTY_ARRAY,
+                Filter\Boolean::TYPE_FALSE_STRING,
+            ],
         ]);
     }
 
     public function constructorAcceptsIntMaskOfConstants(): Filter\Boolean
     {
-        return new Filter\Boolean(Filter\Boolean::TYPE_ALL ^ Filter\Boolean::TYPE_FLOAT);
+        return new Filter\Boolean(['type' => Filter\Boolean::TYPE_ALL ^ Filter\Boolean::TYPE_FLOAT]);
     }
 
     public function constructorAcceptsNamedType(): Filter\Boolean
     {
-        return new Filter\Boolean('localized');
+        return new Filter\Boolean(['type' => 'localized']);
     }
 
     public function constructorAcceptsOptionsArray(): Filter\Boolean


### PR DESCRIPTION
- Removes inheritance
- Changes constructor signature to only accept a well-defined array of options
- Removes option getters and setters
- Marks class as immutable
- Fixes all psalm issues in src and tests
- Expands tests

Serves as another example for general direction of filters as per #118

In this case, assuming the template is added to `FilterInterface`, the Boolean filter would get `@implements FilterInterface<bool>`