### PR TITLE
Deprecate the `AbstractUnicode` class

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1285,12 +1285,18 @@
     </DocblockTypeContradiction>
   </file>
   <file src="src/StringToLower.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractUnicode]]></code>
+    </DeprecatedClass>
     <PossiblyInvalidArgument>
       <code><![CDATA[$encodingOrOptions]]></code>
       <code><![CDATA[$encodingOrOptions]]></code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/StringToUpper.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractUnicode]]></code>
+    </DeprecatedClass>
     <PossiblyInvalidArgument>
       <code><![CDATA[$encodingOrOptions]]></code>
       <code><![CDATA[$encodingOrOptions]]></code>
@@ -1344,6 +1350,9 @@
     </RedundantConditionGivenDocblockType>
   </file>
   <file src="src/UpperCaseWords.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractUnicode]]></code>
+    </DeprecatedClass>
     <PossiblyInvalidArgument>
       <code><![CDATA[$encodingOrOptions]]></code>
       <code><![CDATA[$encodingOrOptions]]></code>
@@ -1459,6 +1468,10 @@
     </MixedReturnStatement>
   </file>
   <file src="test/AbstractUnicodeTest.php">
+    <DeprecatedClass>
+      <code><![CDATA[AbstractUnicode]]></code>
+      <code><![CDATA[AbstractUnicode]]></code>
+    </DeprecatedClass>
     <MissingTemplateParam>
       <code><![CDATA[class extends AbstractUnicode {]]></code>
     </MissingTemplateParam>

--- a/src/AbstractUnicode.php
+++ b/src/AbstractUnicode.php
@@ -14,6 +14,9 @@ use function sprintf;
 use function strtolower;
 
 /**
+ * @deprecated Since 2.38.0 This class will be removed in version 3.0 without replacement. All inheritors of this
+ *             class will re-implement the encoding option as a constructor argument without setters and getters.
+ *
  * @psalm-type UnicodeOptions = array{
  *     encoding?: string|null,
  * }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Related to #154 where the class has been deleted.