### PR TITLE
Refactor `Digits` Filter

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -763,7 +763,7 @@
   </file>
   <file src="test/DigitsTest.php">
     <PossiblyUnusedMethod>
-      <code><![CDATA[returnUnfilteredDataProvider]]></code>
+      <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/DirTest.php">

--- a/src/Digits.php
+++ b/src/Digits.php
@@ -4,45 +4,36 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use Laminas\Stdlib\StringUtils;
-
 use function is_float;
 use function is_int;
 use function is_string;
 use function preg_replace;
 
-/**
- * @psalm-type Options = array{}
- * @extends AbstractFilter<Options>
- */
-final class Digits extends AbstractFilter
+/** @implements FilterInterface<numeric-string|''> */
+final class Digits implements FilterInterface
 {
     /**
-     * Defined by Laminas\Filter\FilterInterface
-     *
      * Returns the string $value, removing all but digit characters
      *
      * If the value provided is not integer, float or string, the value will remain unfiltered
      *
-     * @psalm-return ($value is int|float|string ? numeric-string : mixed)
+     * @inheritDoc
      */
     public function filter(mixed $value): mixed
     {
         if (is_int($value)) {
             return (string) $value;
         }
+
         if (! is_float($value) && ! is_string($value)) {
             return $value;
         }
-        $value = (string) $value;
 
-        if (! StringUtils::hasPcreUnicodeSupport()) {
-            // POSIX named classes are not supported, use alternative 0-9 match
-            $pattern = '/[^0-9]/';
-        } else {
-            $pattern = '/[^[:digit:]]/';
-        }
+        return preg_replace('/[^[:digit:]]/', '', (string) $value);
+    }
 
-        return preg_replace($pattern, '', $value);
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

- Remove inheritance and implement `FilterInterface` directly
- Remove checks for Unicode support in PCRE
- Refactor test case with additional tests