### PR TITLE
Add installation guide placeholder for v3

### DIFF
--- a/docs/book/v3/installation.md
+++ b/docs/book/v3/installation.md
@@ -1,0 +1,5 @@
+# This Is Only a Placeholder
+
+The content of this page can be found under:
+
+https://github.com/laminas/documentation-theme/blob/master/theme/pages/installation.html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,6 +17,7 @@ nav:
         - 'Preparing for v3': v2/migration/preparing-for-v3.md
     - v3:
       - Introduction: v3/intro.md
+      - Installation: v3/installation.md
       - Reference:
         - 'Standard Filters': v3/standard-filters.md
         - 'Word Filters': v3/word.md


### PR DESCRIPTION
Included a new 'Installation' section under v3 in the `mkdocs.yml` configuration file. Added a placeholder page for the installation guide referencing the relevant content from an external source.