### PR TITLE
Convert blockquotes to admonitions/call-outs

### DIFF
--- a/docs/book/v3/file.md
+++ b/docs/book/v3/file.md
@@ -3,11 +3,9 @@
 laminas-filter also comes with a set of classes for filtering file contents, and
 performing file operations such as renaming.
 
-> ## $_FILES
->
-> All file filter `filter()` implementations support either a file path string
-> *or* a `$_FILES` array as the supplied argument. When a `$_FILES` array is
-> passed in, the `tmp_name` is used for the file path.
+NOTE: **`$_FILES`**
+All file filter `filter()` implementations support either a file path string *or* a `$_FILES` array as the supplied argument.
+When a `$_FILES` array is passed in, the `tmp_name` is used for the file path.
 
 ## Lowercase
 
@@ -201,7 +199,7 @@ The following set of options are supported:
   to the filter; used to create a new uploaded file representation of the
   renamed file.  (Since 2.9.0)
 
-> ### Using the upload Name is unsafe
+> WARNING: **Using the upload Name is unsafe**
 >
 > Be **very** careful when using the `use_upload_name` option. For instance,
 > extremely bad things could happen if you were to allow uploaded `.php` files
@@ -296,20 +294,11 @@ foreach ($request->getUploadedFiles() as $uploadedFile) {
 }
 ```
 
-> ### PSR-7 Support
+> NOTE: **PSR-7 Support**
 >
-> PSR-7/PSR-17 support has only been available since 2.9.0, and requires a valid
-> [psr/http-factory-implementation](https://packagist.org/providers/psr/http-factory-implementation)
-> in your application, as it relies on the stream and uploaded file factories in
-> order to produce the final `UploadedFileInterface` artifact representing the
-> filtered file.
+> PSR-7/PSR-17 support requires a valid [psr/http-factory-implementation](https://packagist.org/providers/psr/http-factory-implementation) in your application, as it relies on the stream and uploaded file factories in order to produce the final `UploadedFileInterface` artifact representing the filtered file.
 >
-> PSR-17 itself requires PHP 7, so your application will need to be running on
-> PHP 7 in order to use this feature.
->
-> [laminas/laminas-diactoros 2.0](https://docs.laminas.dev/laminas-diactoros/)
-> provides a PSR-17 implementation, but requires PHP 7.1. If you are still on
-> PHP 7.0, either upgrade, or find a compatible psr/http-factory-implementation.
+> [laminas/laminas-diactoros](https://docs.laminas.dev/laminas-diactoros/) provides a PSR-17 implementation.
 
 ## Uppercase
 

--- a/docs/book/v3/inflector.md
+++ b/docs/book/v3/inflector.md
@@ -136,16 +136,11 @@ class Foo
 
 As mentioned in the introduction, there are two types of rules: static and filter-based.
 
-> ### Order is important
->
-> It is important to note that regardless of the method in which you add rules
-> to the inflector, either one-by-one, or all-at-once; the order is very
-> important. More specific names, or names that might contain other rule names,
-> must be added before least specific names. For example, assuming the two rule
-> names `moduleDir` and `module`, the `moduleDir` rule should appear before
-> module since `module` is contained within `moduleDir`. If `module` were added
-> before `moduleDir`, `module` will match part of `moduleDir` and process it
-> leaving `Dir` inside of the target uninflected.
+NOTE: **Order is important**
+It is important to note that regardless of the method in which you add rules to the inflector, either one-by-one, or all-at-once; the order is very important.
+More specific names, or names that might contain other rule names, must be added before least specific names.
+For example, assuming the two rule names `moduleDir` and `module`, the `moduleDir` rule should appear before module since `module` is contained within `moduleDir`.
+If `module` were added before `moduleDir`, `module` will match part of `moduleDir` and process it leaving `Dir` inside of the target uninflected.
 
 ### Static Rules
 

--- a/docs/book/v3/standard-filters.md
+++ b/docs/book/v3/standard-filters.md
@@ -68,12 +68,10 @@ echo $filter->filter('This is (my) content: 123');
 // Returns 'This is my content 123'
 ```
 
-> ### Supported Languages
->
-> `Alnum` works on almost all languages, except: Chinese, Japanese and Korean.
-> Within these languages, the english alphabet is used instead of the characters
-> from these languages. The language itself is detected using the `Locale`
-> class.
+NOTE: **Supported Languages**
+`Alnum` works on almost all languages, except: Chinese, Japanese and Korean.
+Within these languages, the english alphabet is used instead of the characters from these languages.
+The language itself is detected using the `Locale` class.
 
 ## Alpha
 
@@ -115,12 +113,10 @@ echo $filter->filter('This is (my) content: 123');
 // Returns 'This is my content '
 ```
 
-> ### Supported Languages
->
-> `Alpha` works on almost all languages, except: Chinese, Japanese and Korean.
-> Within these languages, the english alphabet is used instead of the characters
-> from these languages. The language itself is detected using the `Locale`
-> class.
+NOTE: **Supported Languages**
+`Alpha` works on almost all languages, except: Chinese, Japanese and Korean.
+Within these languages, the english alphabet is used instead of the characters from these languages.
+The language itself is detected using the `Locale` class.
 
 ## BaseName
 
@@ -425,9 +421,8 @@ $filter = new Laminas\Filter\Compress([
 ]);
 ```
 
-> ### Default compression Adapter
->
-> When no compression adapter is given, then the **Gz** adapter will be used.
+NOTE: **Default compression Adapter**
+When no compression adapter is given, then the **Gz** adapter will be used.
 
 Decompression is essentially the same usage; we simply use the `Decompress`
 filter instead:
@@ -473,10 +468,8 @@ $compressed = $filter->filter('Uncompressed string');
 In the above example, the uncompressed string is compressed, and is then written
 into the given archive file.
 
-> ### Existing Archives will be overwritten
->
-> The content of any existing file will be overwritten when the given filename
-> of the archive already exists.
+WARNING: **Existing Archives will be overwritten**
+The content of any existing file will be overwritten when the given filename of the archive already exists.
 
 When you want to compress a file, then you must give the name of the file with its path:
 
@@ -506,12 +499,9 @@ $compressed = $filter->filter('C:\temp\somedir');
 // Returns true on success and creates the archive file
 ```
 
-> ### Do not compress large or base Directories
->
-> You should never compress large or base directories like a complete partition.
-> Compressing a complete partition is a very time consuming task which can lead
-> to massive problems on your server when there is not enough space or your
-> script takes too much time.
+NOTE: **Do not compress large or base Directories**
+You should never compress large or base directories like a complete partition.
+Compressing a complete partition is a very time consuming task which can lead to massive problems on your server when there is not enough space or your script takes too much time.
 
 ### Decompressing an Archive
 
@@ -539,10 +529,8 @@ $decompressed = $filter->filter('filename.zip');
 // into the given target directory
 ```
 
-> ### Directories to extract to must exist
->
-> When you want to decompress an archive into a directory, then the target
-> directory must exist.
+NOTE: **Directories to extract to must exist**
+When you want to decompress an archive into a directory, then the target directory must exist.
 
 ### Bz2 Adapter
 
@@ -593,9 +581,8 @@ The Tar Adapter can compress and decompress:
 - Files
 - Directories
 
-> ### Tar does not support Strings
->
-> The Tar Adapter can not handle strings.
+NOTE: **Tar does not support Strings**
+The Tar Adapter can not handle strings.
 
 This adapter makes use of PEAR's `Archive_Tar` component.
 
@@ -612,11 +599,9 @@ example, the related methods for `target` are `getTarget()` and `setTarget()`.
 You can also use the `setOptions()` method which accepts an array of all
 options.
 
-> ### Directory Usage
->
-> When compressing directories with Tar, the complete file path is used. This
-> means that created Tar files will not only have the subdirectory, but the
-> complete path for the compressed file.
+NOTE: **Directory Usage**
+When compressing directories with Tar, the complete file path is used.
+This means that created Tar files will not only have the subdirectory, but the complete path for the compressed file.
 
 ### Zip Adapter
 
@@ -626,10 +611,8 @@ The Zip Adapter can compress and decompress:
 - Files
 - Directories
 
-> ### Zip does not support String Decompression
->
-> The Zip Adapter can not handle decompression to a string; decompression will
-> always be written to a file.
+NOTE: **Zip does not support String Decompression**
+The Zip Adapter can not handle decompression to a string; decompression will always be written to a file.
 
 This adapter makes use of PHP's `Zip` extension.
 
@@ -1274,9 +1257,8 @@ $filter = new Laminas\Filter\StringToLower([
 ]);
 ```
 
-> ### Setting invalid Encodings
->
-> Be aware that you will get an exception when you provide an encoding that is not supported by the `mbstring` extension.
+NOTE: **Setting invalid Encodings**
+Be aware that you will get an exception when you provide an encoding that is not supported by the `mbstring` extension.
 
 ## StringToUpper
 
@@ -1368,15 +1350,12 @@ characters have been removed.
 
 This filter can strip XML and HTML tags from given content.
 
-> ### Laminas\\Filter\\StripTags is potentially insecure
+> WARNING: **This filter is potentially insecure**
 >
-> Be warned that `Laminas\\Filter\\StripTags` should only be used to strip *all*
-> available tags.  Using `Laminas\\Filter\\StripTags` to make your site secure by
-> stripping *some* unwanted tags will lead to unsecure and dangerous code,
-> including potential XSS vectors.
+> Be warned that `Laminas\Filter\StripTags` should only be used to strip *all* available tags.
+> Using `Laminas\Filter\StripTags` to make your site secure by stripping *some* unwanted tags will lead to unsecure and dangerous code, including potential XSS vectors.
 >
-> For a fully secure solution that allows selected filtering of HTML tags, use
-> either Tidy or HtmlPurifier.
+> For a fully secure solution that allows selected filtering of HTML tags, use either Tidy or HtmlPurifier.
 
 ### Supported Options
 
@@ -1424,10 +1403,9 @@ The above will return `A text with a <a href='link.com'>link</a>`;
 it strips all tags but the link. By providing an array, you can specify multiple
 tags at once.
 
-> ### Warning
->
-> Do not use this feature to secure content. This component does not replace the
-> use of a properly configured html filter.
+WARNING: **Warning**
+Do not use this feature to secure content.
+This component does not replace the use of a properly configured html filter.
 
 ### Allowing defined Attributes
 


### PR DESCRIPTION
Admonitions are used to highlight important information in the documentation. They are used to draw attention to specific information, such as warnings, tips, or notes. Admonitions are often used to provide additional context or to explain the implications of a particular action.

## Basic Usage

Start the admonition with one of the types in capital letters followed by a colon. The type corresponds with a specific style.
The type should be followed by the content of the admonition.

```markdown
NOTE: An example of a note.
```

### With Custom Title

```markdown
WARNING: **Plural Helper Does Not Translate**
If you need to handle both plural cases *and* translations, you must use the [`TranslatePlural` helper](https://docs.laminas.dev/laminas-i18n/view-helpers/translate-plural/); `Plural` does not translate.
```

### With Headline and Multiple Paragraphs

``````markdown
> TIP: **IDE Auto-Completion in Templates**
> The `Laminas\I18n\View\HelperTrait` trait can be used to provide auto-completion for modern IDEs. It defines the aliases of the view helpers in a DocBlock as `@method` tags.
>
> ### Usage
>
> In order to allow auto-completion in templates, `$this` variable should be type-hinted via a DocBlock at the top of a template.
> It is recommended that> always the `Laminas\View\Renderer\PhpRenderer` is added as the first type, so that the IDE can auto-suggest the default view helpers from `laminas-view`.
> The `HelperTrait` from `laminas-i18n` can be chained with a pipe symbol (a.k.a. vertical bar) `|`:
>
> ```php
> /**
>  * @var Laminas\View\Renderer\PhpRenderer|Laminas\I18n\View\HelperTrait $this
>  */
> ```
>
> The `HelperTrait` traits can be chained as many as needed, depending on which view helpers from the different Laminas component are used and where the auto-completion is to be made.
``````

