### PR TITLE
Refactor `StripNewlines` filter

### DIFF
--- a/docs/book/v3/standard-filters.md
+++ b/docs/book/v3/standard-filters.md
@@ -1328,8 +1328,10 @@ The above example returns ` This is (my) content`. Notice that only the colon is
 
 ## StripNewlines
 
-This filter modifies a given string and removes all new line characters within
-that string.
+This filter modifies a given string and removes all new line characters within that string.
+
+When provided with an array, all *scalar* elements of the array will be cast to string and have new line characters removed.
+The operation is also recursive, so nested arrays will be processed in the same way.
 
 ### Supported Options
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -899,6 +899,11 @@
       <code><![CDATA[returnUnfilteredDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
+  <file src="test/ScalarOrArrayFilterCallbackTest.php">
+    <PossiblyUnusedMethod>
+      <code><![CDATA[scalarProvider]]></code>
+    </PossiblyUnusedMethod>
+  </file>
   <file src="test/StringPrefixTest.php">
     <MixedArgument>
       <code><![CDATA[$filter('sample')]]></code>
@@ -934,8 +939,7 @@
   </file>
   <file src="test/StripNewlinesTest.php">
     <PossiblyUnusedMethod>
-      <code><![CDATA[returnNonStringScalarValues]]></code>
-      <code><![CDATA[returnUnfilteredDataProvider]]></code>
+      <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StripTagsTest.php">

--- a/src/ScalarOrArrayFilterCallback.php
+++ b/src/ScalarOrArrayFilterCallback.php
@@ -12,6 +12,8 @@ use function is_array;
 use function is_scalar;
 
 /**
+ * This class is internal and as such is not subject to any backwards compatibility guarantees.
+ *
  * @internal
  *
  * @psalm-internal \Laminas

--- a/src/ScalarOrArrayFilterCallback.php
+++ b/src/ScalarOrArrayFilterCallback.php
@@ -29,7 +29,7 @@ final class ScalarOrArrayFilterCallback
      * @param Closure(string): string $callback
      * @return T|string|array<array-key, string|mixed>
      */
-    public static function apply(mixed $value, Closure $callback): mixed
+    public static function applyRecursively(mixed $value, Closure $callback): mixed
     {
         if (is_scalar($value) || $value instanceof Stringable) {
             return $callback((string) $value);
@@ -37,7 +37,7 @@ final class ScalarOrArrayFilterCallback
 
         if (is_array($value)) {
             return array_map(
-                static fn (mixed $value): mixed => self::apply($value, $callback),
+                static fn (mixed $value): mixed => self::applyRecursively($value, $callback),
                 $value,
             );
         }

--- a/src/ScalarOrArrayFilterCallback.php
+++ b/src/ScalarOrArrayFilterCallback.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Laminas\Filter;
+
+use Closure;
+use Stringable;
+
+use function array_map;
+use function is_array;
+use function is_scalar;
+
+/**
+ * @internal
+ *
+ * @psalm-internal \Laminas
+ * @psalm-internal \LaminasTest
+ */
+final class ScalarOrArrayFilterCallback
+{
+    /**
+     * Recursively applies a callback to an array of scalars or scalar input. Non-scalar values are skipped.
+     *
+     * @template T
+     * @param T $value
+     * @param Closure(string): string $callback
+     * @return T|string|array<array-key, string|mixed>
+     */
+    public static function apply(mixed $value, Closure $callback): mixed
+    {
+        if (is_scalar($value) || $value instanceof Stringable) {
+            return $callback((string) $value);
+        }
+
+        if (is_array($value)) {
+            return array_map(
+                static fn (mixed $value): mixed => self::apply($value, $callback),
+                $value,
+            );
+        }
+
+        return $value;
+    }
+}

--- a/src/StripNewlines.php
+++ b/src/StripNewlines.php
@@ -4,35 +4,26 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use Closure;
-
 use function str_replace;
 
-/**
- * @psalm-type Options = array{}
- * @extends AbstractFilter<Options>
- */
-final class StripNewlines extends AbstractFilter
+/** @implements FilterInterface<string|array<array-key, string|mixed>> */
+final class StripNewlines implements FilterInterface
 {
     /**
-     * Defined by Laminas\Filter\FilterInterface
-     *
      * Returns $value without newline control characters
+     *
+     * @inheritDoc
      */
     public function filter(mixed $value): mixed
     {
-        return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
+        return ScalarOrArrayFilterCallback::apply(
             $value,
-            Closure::fromCallable([$this, 'filterNormalizedValue'])
+            static fn(string $value): string => str_replace(["\n", "\r"], '', $value),
         );
     }
 
-    /**
-     * @param  string|string[] $value
-     * @return string|string[]
-     */
-    private function filterNormalizedValue($value)
+    public function __invoke(mixed $value): mixed
     {
-        return str_replace(["\n", "\r"], '', $value);
+        return $this->filter($value);
     }
 }

--- a/src/StripNewlines.php
+++ b/src/StripNewlines.php
@@ -16,7 +16,7 @@ final class StripNewlines implements FilterInterface
      */
     public function filter(mixed $value): mixed
     {
-        return ScalarOrArrayFilterCallback::apply(
+        return ScalarOrArrayFilterCallback::applyRecursively(
             $value,
             static fn(string $value): string => str_replace(["\n", "\r"], '', $value),
         );

--- a/test/ScalarOrArrayFilterCallbackTest.php
+++ b/test/ScalarOrArrayFilterCallbackTest.php
@@ -39,7 +39,7 @@ class ScalarOrArrayFilterCallbackTest extends TestCase
     #[DataProvider('scalarProvider')]
     public function testScalarValuesWillBeFilteredInPlace(mixed $input, mixed $expect): void
     {
-        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+        self::assertSame($expect, ScalarOrArrayFilterCallback::applyRecursively($input, $this->filter));
     }
 
     public function testAssociativeArrayArgument(): void
@@ -62,7 +62,7 @@ class ScalarOrArrayFilterCallbackTest extends TestCase
             'stringable' => 'foo',
         ];
 
-        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+        self::assertSame($expect, ScalarOrArrayFilterCallback::applyRecursively($input, $this->filter));
     }
 
     public function testListArgument(): void
@@ -85,7 +85,7 @@ class ScalarOrArrayFilterCallbackTest extends TestCase
             'foo',
         ];
 
-        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+        self::assertSame($expect, ScalarOrArrayFilterCallback::applyRecursively($input, $this->filter));
     }
 
     public function testArraysAreRecursivelyProcessed(): void
@@ -110,6 +110,6 @@ class ScalarOrArrayFilterCallbackTest extends TestCase
             ],
         ];
 
-        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+        self::assertSame($expect, ScalarOrArrayFilterCallback::applyRecursively($input, $this->filter));
     }
 }

--- a/test/ScalarOrArrayFilterCallbackTest.php
+++ b/test/ScalarOrArrayFilterCallbackTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Filter;
+
+use Closure;
+use Laminas\Filter\ScalarOrArrayFilterCallback;
+use LaminasTest\Filter\TestAsset\StringableObject;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+use function strtolower;
+
+class ScalarOrArrayFilterCallbackTest extends TestCase
+{
+    /** @var Closure(string): string */
+    private Closure $filter;
+
+    protected function setUp(): void
+    {
+        $this->filter = static fn (string $value): string => strtolower($value);
+    }
+
+    public static function scalarProvider(): array
+    {
+        return [
+            'int'          => [100, '100'],
+            'float'        => [1.23, '1.23'],
+            'string'       => ['String', 'string'],
+            'true'         => [true, '1'],
+            'false'        => [false, ''],
+            'empty string' => ['', ''],
+            'null'         => [null, null],
+            'stringable'   => [new StringableObject('Foo'), 'foo'],
+        ];
+    }
+
+    #[DataProvider('scalarProvider')]
+    public function testScalarValuesWillBeFilteredInPlace(mixed $input, mixed $expect): void
+    {
+        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+    }
+
+    public function testAssociativeArrayArgument(): void
+    {
+        $input = [
+            'int'        => 100,
+            'string'     => 'String',
+            'true'       => true,
+            'empty'      => '',
+            'null'       => null,
+            'stringable' => new StringableObject('Foo'),
+        ];
+
+        $expect = [
+            'int'        => '100',
+            'string'     => 'string',
+            'true'       => '1',
+            'empty'      => '',
+            'null'       => null,
+            'stringable' => 'foo',
+        ];
+
+        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+    }
+
+    public function testListArgument(): void
+    {
+        $input = [
+            100,
+            'String',
+            true,
+            '',
+            null,
+            new StringableObject('Foo'),
+        ];
+
+        $expect = [
+            '100',
+            'string',
+            '1',
+            '',
+            null,
+            'foo',
+        ];
+
+        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+    }
+
+    public function testArraysAreRecursivelyProcessed(): void
+    {
+        $input = [
+            'a' => 'A',
+            'b' => [
+                'c' => 'C',
+                'd' => [
+                    'e' => 'E',
+                ],
+            ],
+        ];
+
+        $expect = [
+            'a' => 'a',
+            'b' => [
+                'c' => 'c',
+                'd' => [
+                    'e' => 'e',
+                ],
+            ],
+        ];
+
+        self::assertSame($expect, ScalarOrArrayFilterCallback::apply($input, $this->filter));
+    }
+}

--- a/test/StripNewlinesTest.php
+++ b/test/StripNewlinesTest.php
@@ -4,82 +4,37 @@ declare(strict_types=1);
 
 namespace LaminasTest\Filter;
 
-use Laminas\Filter\StripNewlines as StripNewlinesFilter;
+use Laminas\Filter\StripNewlines;
+use LaminasTest\Filter\TestAsset\StringableObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use stdClass;
-
-use function array_keys;
-use function array_values;
 
 class StripNewlinesTest extends TestCase
 {
-    /**
-     * Ensures that the filter follows expected behavior
-     */
-    public function testBasic(): void
-    {
-        $filter         = new StripNewlinesFilter();
-        $valuesExpected = [
-            ''                                    => '',
-            "\n"                                  => '',
-            "\r"                                  => '',
-            "\r\n"                                => '',
-            '\n'                                  => '\n',
-            '\r'                                  => '\r',
-            '\r\n'                                => '\r\n',
-            "Some text\nthat we have\r\nstuff in" => 'Some textthat we havestuff in',
-        ];
-        foreach ($valuesExpected as $input => $output) {
-            self::assertSame($output, $filter($input));
-        }
-    }
-
-    public function testArrayValues(): void
-    {
-        $filter   = new StripNewlinesFilter();
-        $expected = [
-            "Some text\nthat we have\r\nstuff in" => 'Some textthat we havestuff in',
-            "Some text\n"                         => 'Some text',
-        ];
-        self::assertSame(array_values($expected), $filter(array_keys($expected)));
-    }
-
-    /** @return list<array{0: mixed}> */
-    public static function returnUnfilteredDataProvider(): array
+    /** @return array<string, array{0: mixed, 1: mixed}> */
+    public static function basicDataProvider(): array
     {
         return [
-            [null],
-            [new stdClass()],
+            'Empty String'        => ['', ''],
+            'Null'                => [null, null],
+            'String without CRLF' => ['string', 'string'],
+            'String with CRLF'    => ["Some\nText\r\nHere", 'SomeTextHere'],
+            'Escaped CRLF'        => ['\r\n', '\r\n'],
+            'Stringable'          => [new StringableObject("Hey\nThere"), 'HeyThere'],
+            'Integer'             => [1, '1'],
+            'Float'               => [1.23, '1.23'],
+            'True'                => [true, '1'],
+            'False'               => [false, ''],
+            'Array'               => [['a' => "Hey\rThere", 'b' => null], ['a' => 'HeyThere', 'b' => null]],
+            'Nested Array'        => [['a' => ["Hey\rThere"]], ['a' => ['HeyThere']]],
         ];
     }
 
-    #[DataProvider('returnUnfilteredDataProvider')]
-    public function testReturnUnfiltered(mixed $input): void
+    #[DataProvider('basicDataProvider')]
+    public function testBasicBehaviour(mixed $input, mixed $expect): void
     {
-        $filter = new StripNewlinesFilter();
-
-        self::assertSame($input, $filter($input));
-    }
-
-    /**
-     * @return array<int|float|bool>[]
-     */
-    public static function returnNonStringScalarValues(): array
-    {
-        return [
-            [1],
-            [1.0],
-            [true],
-            [false],
-        ];
-    }
-
-    #[DataProvider('returnNonStringScalarValues')]
-    public function testShouldFilterNonStringScalarValues(float|bool|int $input): void
-    {
-        $filter = new StripNewlinesFilter();
-
-        self::assertSame((string) $input, $filter($input));
+        $filter = new StripNewlines();
+        self::assertSame($expect, $filter->filter($input));
+        self::assertSame($expect, $filter->__invoke($input));
     }
 }

--- a/test/TestAsset/StringableObject.php
+++ b/test/TestAsset/StringableObject.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaminasTest\Filter\TestAsset;
+
+use Stringable;
+
+final class StringableObject implements Stringable
+{
+    /** @param non-empty-string $value */
+    public function __construct(
+        private readonly string $value = 'Value',
+    ) {
+    }
+
+    /** @return non-empty-string */
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| BC Break      | yes
| QA            | yes

### Description

There's not much to change for this filter because it was already pretty minimal, however, inheritance has been removed.

This patch introduces `ScalarOrArrayFilterCallback`.
 
This internal class/static method will be used to replace `AbstractFilter::applyFilterOnlyToStringableValuesAndStringableArrayValues`

Allows independent unit tests and frees filters from inheritance.

Also improves the previous implementation by recursively processing nested array structures.