### PR TITLE
Refactor `StringPrefix` and `StringSuffix` Filters

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -48,6 +48,34 @@ The impact of the removal of these aliases will not affect you if you use a FQCN
 
 ### Changes to Individual Filters
 
+#### `StringPrefix`
+
+The following methods have been removed:
+
+- `setPrefix`
+- `getPrefix`
+
+The constructor now only accepts an associative array of [documented options](../standard-filters.md#stringprefix).
+
+An exception is no longer thrown for a missing prefix option, instead an empty string is used by default.
+This means that the filter will have the effect of simply casting scalar values to string when a prefix option is not provided.
+
+The filter will now recursively process scalar array members. Previously, arrays would be returned unfiltered.
+
+#### `StringSuffix`
+
+The following methods have been removed:
+
+- `setSuffix`
+- `getSuffix`
+
+The constructor now only accepts an associative array of [documented options](../standard-filters.md#stringsuffix).
+
+An exception is no longer thrown for a missing suffix option, instead an empty string is used by default.
+This means that the filter will have the effect of simply casting scalar values to string when a suffix option is not provided.
+
+The filter will now recursively process scalar array members. Previously, arrays would be returned unfiltered.
+
 #### `StringTrim`
 
 The following methods have been removed:

--- a/docs/book/v3/standard-filters.md
+++ b/docs/book/v3/standard-filters.md
@@ -1180,9 +1180,7 @@ $filtered = $filter->filter($path);
 
 ## StringPrefix
 
-- Since 2.9.0
-
-This filter will add the provided prefix to scalar values.
+This filter will add the provided prefix to scalar values or scalar array members.
 
 ### Supported Options
 
@@ -1197,16 +1195,14 @@ $filter = new Laminas\Filter\StringPrefix([
     'prefix' => 'PHP-',
 ]);
 
-echo $filter->filter('MidCentral');
-```
+echo $filter->filter('MidCentral'); // "PHP-MidCentral"
 
-The above results in the string `PHP-MidCentral`.
+$array = $filter->filter(['East', 'West']); // ['PHP-East', 'PHP-West']
+```
 
 ## StringSuffix
 
-- Since 2.9.0
-
-This filter will add the provided suffix to scalar values.
+This filter will add the provided suffix to scalar values or scalar array members.
 
 ### Supported Options
 
@@ -1221,10 +1217,10 @@ $filter = new Laminas\Filter\StringSuffix([
     'suffix' => '-PHP',
 ]);
 
-echo $filter->filter('MidCentral');
-```
+echo $filter->filter('MidCentral'); // "MidCentral-PHP"
 
-The above results in the string `MidCentral-PHP`.
+$array = $filter->filter(['East', 'West']); // ['East-PHP', 'West-PHP']
+```
 
 ## StringToLower
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -550,16 +550,6 @@
       <code><![CDATA[$existsOrOptions !== null]]></code>
     </RedundantConditionGivenDocblockType>
   </file>
-  <file src="src/StringPrefix.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($prefix)]]></code>
-    </DocblockTypeContradiction>
-  </file>
-  <file src="src/StringSuffix.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_string($suffix)]]></code>
-    </DocblockTypeContradiction>
-  </file>
   <file src="src/StripTags.php">
     <MixedArgument>
       <code><![CDATA[$options['allowAttribs']]]></code>
@@ -905,21 +895,13 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StringPrefixTest.php">
-    <MixedArgument>
-      <code><![CDATA[$filter('sample')]]></code>
-      <code><![CDATA[$prefix]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
-      <code><![CDATA[invalidPrefixesDataProvider]]></code>
+      <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StringSuffixTest.php">
-    <MixedArgument>
-      <code><![CDATA[$filter('sample')]]></code>
-      <code><![CDATA[$suffix]]></code>
-    </MixedArgument>
     <PossiblyUnusedMethod>
-      <code><![CDATA[invalidSuffixesDataProvider]]></code>
+      <code><![CDATA[basicDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StringToLowerTest.php">

--- a/src/StringPrefix.php
+++ b/src/StringPrefix.php
@@ -4,84 +4,34 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use function get_debug_type;
-use function is_scalar;
-use function is_string;
 use function sprintf;
 
 /**
  * @psalm-type Options = array{
- *     prefix?: null|string,
+ *     prefix?: non-empty-string|null,
  * }
- * @extends AbstractFilter<Options>
+ * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class StringPrefix extends AbstractFilter
+final class StringPrefix implements FilterInterface
 {
-    /** @var Options */
-    protected $options = [
-        'prefix' => null,
-    ];
+    private readonly string $prefix;
 
-    /**
-     * @param Options|iterable|null $options
-     */
-    public function __construct($options = null)
+    /** @param Options $options */
+    public function __construct(array $options = [])
     {
-        if ($options !== null) {
-            $this->setOptions($options);
-        }
+        $this->prefix = $options['prefix'] ?? '';
     }
 
-    /**
-     * Set the prefix string
-     *
-     * @param  string $prefix
-     * @return self
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setPrefix($prefix)
-    {
-        if (! is_string($prefix)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects "prefix" to be string; received "%s"',
-                __METHOD__,
-                get_debug_type($prefix),
-            ));
-        }
-
-        $this->options['prefix'] = $prefix;
-
-        return $this;
-    }
-
-    /**
-     * Returns the prefix string, which is appended at the beginning of the input value
-     *
-     * @return string
-     */
-    public function getPrefix()
-    {
-        if (! isset($this->options['prefix'])) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects a "prefix" option; none given',
-                self::class
-            ));
-        }
-
-        return $this->options['prefix'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function filter(mixed $value): mixed
     {
-        if (! is_scalar($value)) {
-            return $value;
-        }
+        return ScalarOrArrayFilterCallback::applyRecursively(
+            $value,
+            fn (string $value): string => sprintf('%s%s', $this->prefix, $value),
+        );
+    }
 
-        $value = (string) $value;
-
-        return $this->getPrefix() . $value;
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }

--- a/src/StringSuffix.php
+++ b/src/StringSuffix.php
@@ -4,85 +4,34 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use function get_debug_type;
-use function is_scalar;
-use function is_string;
 use function sprintf;
 
 /**
  * @psalm-type Options = array{
- *     suffix?: null|string,
+ *     suffix?: non-empty-string|null,
  * }
- * @extends AbstractFilter<Options>
+ * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class StringSuffix extends AbstractFilter
+final class StringSuffix implements FilterInterface
 {
-    /** @var Options */
-    protected $options = [
-        'suffix' => null,
-    ];
+    private readonly string $suffix;
 
-    /**
-     * @param Options|iterable|null $options
-     */
-    public function __construct($options = null)
+    /** @param Options $options */
+    public function __construct(array $options = [])
     {
-        if ($options !== null) {
-            $this->setOptions($options);
-        }
+        $this->suffix = $options['suffix'] ?? '';
     }
 
-    /**
-     * Set the suffix string
-     *
-     * @param string $suffix
-     * @return self
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setSuffix($suffix)
-    {
-        if (! is_string($suffix)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects "suffix" to be string; received "%s"',
-                __METHOD__,
-                get_debug_type($suffix),
-            ));
-        }
-
-        $this->options['suffix'] = $suffix;
-
-        return $this;
-    }
-
-    /**
-     * Returns the suffix string, which is appended at the end of the input value
-     *
-     * @return string
-     * @throws Exception\InvalidArgumentException
-     */
-    public function getSuffix()
-    {
-        if (! isset($this->options['suffix'])) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects a "suffix" option; none given',
-                self::class
-            ));
-        }
-
-        return $this->options['suffix'];
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function filter(mixed $value): mixed
     {
-        if (! is_scalar($value)) {
-            return $value;
-        }
+        return ScalarOrArrayFilterCallback::applyRecursively(
+            $value,
+            fn (string $value): string => sprintf('%s%s', $value, $this->suffix),
+        );
+    }
 
-        $value = (string) $value;
-
-        return $value . $this->getSuffix();
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }

--- a/test/StringPrefixTest.php
+++ b/test/StringPrefixTest.php
@@ -4,84 +4,45 @@ declare(strict_types=1);
 
 namespace LaminasTest\Filter;
 
-use Laminas\Filter\Exception\InvalidArgumentException;
-use Laminas\Filter\StringPrefix as StringPrefixFilter;
+use Laminas\Filter\StringPrefix;
+use LaminasTest\Filter\TestAsset\StringableObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
-use stdClass;
 
-use function fopen;
-
-class StringPrefixTest extends TestCase
+final class StringPrefixTest extends TestCase
 {
-    private StringPrefixFilter $filter;
-
-    public function setUp(): void
+    /** @return array<string, array{0: non-empty-string|null, 1: mixed, 2: mixed}> */
+    public static function basicDataProvider(): array
     {
-        $this->filter = new StringPrefixFilter();
-    }
+        $object = (object) ['foo' => 'bar'];
 
-    /**
-     * Ensures that the filter follows expected behavior
-     */
-    public function testBasic(): void
-    {
-        $filter = $this->filter;
-
-        $prefix = 'ABC123';
-        $filter->setPrefix($prefix);
-
-        self::assertStringStartsWith($prefix, $filter('sample'));
-    }
-
-    public function testWithoutPrefix(): void
-    {
-        $filter = $this->filter;
-
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects a "prefix" option; none given');
-        $filter('sample');
-    }
-
-    /**
-     * @return array<string, array{0: mixed}>
-     */
-    public static function invalidPrefixesDataProvider(): array
-    {
         return [
-            'int'                 => [1],
-            'float'               => [1.00],
-            'true'                => [true],
-            'null'                => [null],
-            'empty array'         => [[]],
-            'resource'            => [fopen('php://memory', 'rb+')],
-            'array with callable' => [
-                static function (): void {
-                },
+            'Regular String' => ['PREFIX', 'value', 'PREFIXvalue'],
+            'Integer'        => ['PREFIX', 1, 'PREFIX1'],
+            'Float'          => ['PREFIX', 1.23, 'PREFIX1.23'],
+            'True'           => ['PREFIX', true, 'PREFIX1'],
+            'False'          => ['PREFIX', false, 'PREFIX'],
+            'Null'           => ['PREFIX', null, null],
+            'Empty String'   => ['PREFIX', '', 'PREFIX'],
+            'Array'          => ['PREFIX', ['foo', 'bar'], ['PREFIXfoo', 'PREFIXbar']],
+            'Nested Array'   => [
+                'PREFIX',
+                ['foo', 'bar' => ['baz' => 'bat']],
+                ['PREFIXfoo', 'bar' => ['baz' => 'PREFIXbat']],
             ],
-            'object'              => [new stdClass()],
+            'Stringable'     => ['PREFIX', new StringableObject('Foo'), 'PREFIXFoo'],
+            'Object'         => ['PREFIX', $object, $object],
+            'Empty Prefix'   => [null, 'String', 'String'],
         ];
     }
 
-    #[DataProvider('invalidPrefixesDataProvider')]
-    public function testInvalidPrefixes(mixed $prefix): void
+    /** @param non-empty-string|null $prefix */
+    #[DataProvider('basicDataProvider')]
+    public function testBasicBehaviour(?string $prefix, mixed $input, mixed $expect): void
     {
-        $filter = $this->filter;
+        $filter = new StringPrefix(['prefix' => $prefix]);
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('expects "prefix" to be string');
-
-        $filter->setPrefix($prefix);
-        $filter('sample');
-    }
-
-    public function testNonScalarInput(): void
-    {
-        $filter = $this->filter;
-
-        $prefix = 'ABC123';
-        $filter->setPrefix($prefix);
-
-        self::assertInstanceOf(stdClass::class, $filter(new stdClass()));
+        self::assertSame($expect, $filter->filter($input));
+        self::assertSame($expect, $filter->__invoke($input));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| New Feature   | yes
| QA            | yes

### Description

- Remove inheritance from AbstractFilter
- Remove option getters and setters
- Change behaviour so that arrays and `Stringable` objects are processed.
- Default the suffix/prefix to an empty string
- Simplify tests