### PR TITLE
Deprecate Setters & Getters for `StringPrefix` and `StringSuffix`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1344,6 +1344,9 @@
     <DeprecatedClass>
       <code><![CDATA[AbstractFilter]]></code>
     </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[getPrefix]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($prefix)]]></code>
     </DocblockTypeContradiction>
@@ -1352,6 +1355,9 @@
     <DeprecatedClass>
       <code><![CDATA[AbstractFilter]]></code>
     </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[getSuffix]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($suffix)]]></code>
     </DocblockTypeContradiction>
@@ -1947,6 +1953,11 @@
     </UnusedClosureParam>
   </file>
   <file src="test/StringPrefixTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setPrefix]]></code>
+      <code><![CDATA[setPrefix]]></code>
+      <code><![CDATA[setPrefix]]></code>
+    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$filter('sample')]]></code>
       <code><![CDATA[$prefix]]></code>
@@ -1956,6 +1967,11 @@
     </PossiblyUnusedMethod>
   </file>
   <file src="test/StringSuffixTest.php">
+    <DeprecatedMethod>
+      <code><![CDATA[setSuffix]]></code>
+      <code><![CDATA[setSuffix]]></code>
+      <code><![CDATA[setSuffix]]></code>
+    </DeprecatedMethod>
     <MixedArgument>
       <code><![CDATA[$filter('sample')]]></code>
       <code><![CDATA[$suffix]]></code>

--- a/src/StringPrefix.php
+++ b/src/StringPrefix.php
@@ -36,6 +36,8 @@ class StringPrefix extends AbstractFilter
     /**
      * Set the prefix string
      *
+     * @deprecated Since 2.38.0 All option setters and getters will be removed in version 3.0
+     *
      * @param  string $prefix
      * @return self
      * @throws Exception\InvalidArgumentException
@@ -57,6 +59,8 @@ class StringPrefix extends AbstractFilter
 
     /**
      * Returns the prefix string, which is appended at the beginning of the input value
+     *
+     * @deprecated Since 2.38.0 All option setters and getters will be removed in version 3.0
      *
      * @return string
      */

--- a/src/StringSuffix.php
+++ b/src/StringSuffix.php
@@ -36,6 +36,8 @@ class StringSuffix extends AbstractFilter
     /**
      * Set the suffix string
      *
+     * @deprecated Since 2.38.0 All option setters and getters will be removed in version 3.0
+     *
      * @param string $suffix
      * @return self
      * @throws Exception\InvalidArgumentException
@@ -57,6 +59,8 @@ class StringSuffix extends AbstractFilter
 
     /**
      * Returns the suffix string, which is appended at the end of the input value
+     *
+     * @deprecated Since 2.38.0 All option setters and getters will be removed in version 3.0
      *
      * @return string
      * @throws Exception\InvalidArgumentException


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Ref #169 