### PR TITLE
Deprecate Setters & Getters for `ToNull`

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1431,6 +1431,10 @@
     <DeprecatedClass>
       <code><![CDATA[AbstractFilter]]></code>
     </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[setType]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[$typeOrOptions === '']]></code>
       <code><![CDATA[$typeOrOptions === '']]></code>
@@ -2054,6 +2058,13 @@
     <ArgumentTypeCoercion>
       <code><![CDATA[$type]]></code>
     </ArgumentTypeCoercion>
+    <DeprecatedMethod>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[getType]]></code>
+      <code><![CDATA[setType]]></code>
+    </DeprecatedMethod>
     <InvalidArgument>
       <code><![CDATA[true]]></code>
     </InvalidArgument>

--- a/src/ToNull.php
+++ b/src/ToNull.php
@@ -81,9 +81,11 @@ class ToNull extends AbstractFilter
     /**
      * Set boolean types
      *
+     * @deprecated Since 2.38.0 All option setters and getters will be removed in version 3.0
+     *
      * @param int-mask-of<self::TYPE_*>|value-of<self::CONSTANTS>|list<self::TYPE_*>|null $type
-     * @throws Exception\InvalidArgumentException
      * @return self
+     * @throws Exception\InvalidArgumentException
      */
     public function setType($type = null)
     {
@@ -116,6 +118,8 @@ class ToNull extends AbstractFilter
 
     /**
      * Returns defined boolean types
+     *
+     * @deprecated Since 2.38.0 All option setters and getters will be removed in version 3.0
      *
      * @return int-mask-of<self::TYPE_*>
      */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Ref #172 