### PR TITLE
Refactor `PregReplace` filter

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -59,6 +59,21 @@ The following methods have been removed:
 
 The constructor now only accepts an associative array of [documented options](../standard-filters.md#denylist).
 
+#### `PregReplace`
+
+The following methods have been removed:
+
+- `setPattern`
+- `getPattern`
+- `setReplacement`
+- `getReplacement`
+
+The constructor now only accepts an associative array of [documented options](../standard-filters.md#pregreplace).
+
+Additionally, `$options['pattern']` *must* be provided at construction time or an exception is thrown.
+
+Exceptions for invalid or empty patterns are now thrown during construct rather than when the filter is invoked.
+
 #### `StringPrefix`
 
 The following methods have been removed:

--- a/docs/book/v3/standard-filters.md
+++ b/docs/book/v3/standard-filters.md
@@ -1069,27 +1069,24 @@ echo $filter->filter('1,23456789E-3');
 
 ## PregReplace
 
-`Laminas\Filter\PregReplace` performs a search using regular expressions and replaces all found
-elements.
+`Laminas\Filter\PregReplace` performs a search using regular expressions and replaces all found elements.
 
 ### Supported Options
 
 The following options are supported for `Laminas\Filter\PregReplace`:
 
 - `pattern`: The pattern to search for.
-- `replacement`: The string which to use as a replacement for the matches; this
-  can optionally contain placeholders for matched groups in the search pattern.
+- `replacement`: The string which to use as a replacement for the matches; this can optionally contain placeholders for matched groups in the search pattern.
 
 ### Basic Usage
 
 To use this filter properly, you must give both options listed above.
 
-The `pattern` option has to be given to set the pattern to search for. It can be
-a string for a single pattern, or an array of strings for multiple patterns.
+The `pattern` option has to be given to set the pattern to search for.
+It can be a string for a single pattern, or an array of strings for multiple patterns.
 
-The `replacement` option indicates the string to replace matches with, and can
-contain placeholders for matched groups from the search `pattern`. The value may
-be a string replacement, or an array of string replacements.
+The `replacement` option indicates the string to replace matches with, and can contain placeholders for matched groups from the search `pattern`.
+The value may be a string replacement, or an array of string replacements.
 
 ```php
 $filter = new Laminas\Filter\PregReplace([
@@ -1102,22 +1099,8 @@ $filter->filter($input);
 // returns 'Hi john!'
 ```
 
-You can also use `setPattern()` to set the pattern(s), and `setReplacement()` set
-the replacement(s).
-
-```php
-$filter = new Laminas\Filter\PregReplace();
-$filter
-    ->setPattern(array('bob', 'Hi'))
-    ->setReplacement(array('john', 'Bye'));
-$input = 'Hi bob!';
-
-$filter->filter($input);
-// returns 'Bye john!'
-```
-
 For more complex usage, read the
-[PCRE Pattern chapter of the PHP manual](http://www.php.net/manual/en/reference.pcre.pattern.modifiers.php).
+[PCRE Pattern chapter of the PHP manual](http://www.php.net/manual/reference.pcre.pattern.modifiers.php).
 
 ## RealPath
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -507,22 +507,6 @@
       <code><![CDATA[Module]]></code>
     </UnusedClass>
   </file>
-  <file src="src/PregReplace.php">
-    <DocblockTypeContradiction>
-      <code><![CDATA[! is_array($pattern) && ! is_string($pattern)]]></code>
-      <code><![CDATA[! is_array($replacement) && ! is_string($replacement)]]></code>
-    </DocblockTypeContradiction>
-    <InvalidNullableReturnType>
-      <code><![CDATA[bool]]></code>
-    </InvalidNullableReturnType>
-    <MixedArgument>
-      <code><![CDATA[$args[0]]]></code>
-      <code><![CDATA[$args[1]]]></code>
-    </MixedArgument>
-    <PossiblyUnusedReturnValue>
-      <code><![CDATA[bool]]></code>
-    </PossiblyUnusedReturnValue>
-  </file>
   <file src="src/RealPath.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[$this->options]]></code>
@@ -853,6 +837,7 @@
   </file>
   <file src="test/PregReplaceTest.php">
     <PossiblyUnusedMethod>
+      <code><![CDATA[invalidPatternOptions]]></code>
       <code><![CDATA[returnNonStringScalarValues]]></code>
       <code><![CDATA[returnUnfilteredDataProvider]]></code>
     </PossiblyUnusedMethod>

--- a/src/PregReplace.php
+++ b/src/PregReplace.php
@@ -4,14 +4,12 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use Closure;
-use Traversable;
+use Laminas\Filter\Exception\InvalidArgumentException;
 
-use function func_get_args;
-use function get_debug_type;
+use function array_filter;
+use function array_values;
 use function is_array;
 use function is_string;
-use function iterator_to_array;
 use function preg_match;
 use function preg_replace;
 use function sprintf;
@@ -19,172 +17,77 @@ use function str_contains;
 
 /**
  * @psalm-type Options = array{
- *     pattern: non-empty-string|list<non-empty-string>|null,
- *     replacement: string|list<string>,
+ *     pattern: non-empty-string|list<non-empty-string>,
+ *     replacement?: string|list<string>,
  * }
- * @extends AbstractFilter<Options>
+ * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class PregReplace extends AbstractFilter
+final class PregReplace implements FilterInterface
 {
-    /** @var Options */
-    protected $options = [
-        'pattern'     => null,
-        'replacement' => '',
-    ];
+    /** @var list<non-empty-string>|non-empty-string */
+    private readonly array|string $pattern;
+    /** @var list<string>|string */
+    private readonly array|string $replacement;
 
     /**
-     * Constructor
      * Supported options are
      *     'pattern'     => matching pattern
      *     'replacement' => replace with this
      *
-     * @param  iterable|Options|string|null $options
+     * @param Options $options
      */
-    public function __construct($options = null)
+    public function __construct(array $options)
     {
-        if ($options instanceof Traversable) {
-            $options = iterator_to_array($options);
-        }
-
-        if (! is_array($options) || (! isset($options['pattern']) && ! isset($options['replacement']))) {
-            $args = func_get_args();
-            if (isset($args[0])) {
-                $this->setPattern($args[0]);
-            }
-            if (isset($args[1])) {
-                $this->setReplacement($args[1]);
-            }
-        } else {
-            $this->setOptions($options);
-        }
+        $this->pattern     = $this->validatePattern($options['pattern']);
+        $this->replacement = $options['replacement'] ?? '';
     }
 
-    /**
-     * Set the regex pattern to search for
-     *
-     * @see preg_replace()
-     *
-     * @param  non-empty-string|list<non-empty-string> $pattern - same as the first argument of preg_replace
-     * @return self
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setPattern($pattern)
-    {
-        if (! is_array($pattern) && ! is_string($pattern)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects pattern to be array or string; received "%s"',
-                __METHOD__,
-                get_debug_type($pattern),
-            ));
-        }
-
-        if (is_array($pattern)) {
-            foreach ($pattern as $p) {
-                $this->validatePattern($p);
-            }
-        }
-
-        if (is_string($pattern)) {
-            $this->validatePattern($pattern);
-        }
-
-        $this->options['pattern'] = $pattern;
-        return $this;
-    }
-
-    /**
-     * Get currently set match pattern
-     *
-     * @return non-empty-string|list<non-empty-string>|null
-     */
-    public function getPattern()
-    {
-        return $this->options['pattern'];
-    }
-
-    /**
-     * Set the replacement array/string
-     *
-     * @see preg_replace()
-     *
-     * @param  string|list<string> $replacement - same as the second argument of preg_replace
-     * @return self
-     * @throws Exception\InvalidArgumentException
-     */
-    public function setReplacement($replacement)
-    {
-        if (! is_array($replacement) && ! is_string($replacement)) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                '%s expects replacement to be array or string; received "%s"',
-                __METHOD__,
-                get_debug_type($replacement)
-            ));
-        }
-        $this->options['replacement'] = $replacement;
-        return $this;
-    }
-
-    /**
-     * Get currently set replacement value
-     *
-     * @return string|list<string>
-     */
-    public function getReplacement()
-    {
-        return $this->options['replacement'];
-    }
-
-    /**
-     * Perform regexp replacement as filter
-     *
-     * @throws Exception\RuntimeException
-     */
     public function filter(mixed $value): mixed
     {
-        return self::applyFilterOnlyToStringableValuesAndStringableArrayValues(
+        return ScalarOrArrayFilterCallback::applyRecursively(
             $value,
-            Closure::fromCallable([$this, 'filterNormalizedValue'])
+            fn (string $value): string => preg_replace($this->pattern, $this->replacement, $value),
         );
     }
 
-    /**
-     * @param  string|string[] $value
-     * @return string|string[]
-     */
-    private function filterNormalizedValue($value)
+    public function __invoke(mixed $value): mixed
     {
-        $pattern = $this->options['pattern'] ?? null;
-        if ($pattern === null) {
-            throw new Exception\RuntimeException(sprintf(
-                'Filter %s does not have a valid pattern set',
-                static::class
-            ));
-        }
-
-        /** @var string|string[] $replacement */
-        $replacement = $this->options['replacement'] ?? '';
-
-        return preg_replace($pattern, $replacement, $value);
+        return $this->filter($value);
     }
 
     /**
-     * Validate a pattern and ensure it does not contain the "e" modifier
+     * Validate pattern(s) and ensure they do not contain the "e" modifier
      *
-     * @param  string $pattern
-     * @return bool
-     * @throws Exception\InvalidArgumentException
+     * @param string|list<string>|null $pattern
+     * @return list<non-empty-string>|non-empty-string
+     * @throws InvalidArgumentException
      */
-    protected function validatePattern($pattern)
+    private function validatePattern(string|array|null $pattern): array|string
     {
-        if (! preg_match('/(?<modifier>[imsxeADSUXJu]+)$/', $pattern, $matches)) {
-            return true;
+        $test = array_values(array_filter(
+            is_array($pattern) ? $pattern : [$pattern],
+            static fn (mixed $value): bool => is_string($value) && $value !== '',
+        ));
+
+        if ($test === []) {
+            throw new InvalidArgumentException(
+                'The pattern option must be a non-empty string, or a list of non-empty strings',
+            );
         }
 
-        if (str_contains($matches['modifier'], 'e')) {
-            throw new Exception\InvalidArgumentException(sprintf(
-                'Pattern for a PregReplace filter may not contain the "e" pattern modifier; received "%s"',
-                $pattern
-            ));
+        foreach ($test as $item) {
+            if (! preg_match('/(?<modifier>[imsxeADSUXJu]+)$/', $item, $matches)) {
+                continue;
+            }
+
+            if (str_contains($matches['modifier'], 'e')) {
+                throw new InvalidArgumentException(sprintf(
+                    'Pattern for a PregReplace filter may not contain the "e" pattern modifier; received "%s"',
+                    $item,
+                ));
+            }
         }
+
+        return $test;
     }
 }

--- a/test/FilterPluginManagerCompatibilityTest.php
+++ b/test/FilterPluginManagerCompatibilityTest.php
@@ -7,6 +7,7 @@ namespace LaminasTest\Filter;
 use Generator;
 use Laminas\Filter\Callback;
 use Laminas\Filter\FilterPluginManager;
+use Laminas\Filter\PregReplace;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
@@ -23,6 +24,7 @@ class FilterPluginManagerCompatibilityTest extends TestCase
 {
     private const FILTERS_WITH_REQUIRED_OPTIONS = [
         Callback::class,
+        PregReplace::class,
     ];
 
     protected static function getPluginManager(): FilterPluginManager

--- a/test/InflectorTest.php
+++ b/test/InflectorTest.php
@@ -9,7 +9,6 @@ use Laminas\Filter\Exception;
 use Laminas\Filter\FilterInterface;
 use Laminas\Filter\FilterPluginManager;
 use Laminas\Filter\Inflector as InflectorFilter;
-use Laminas\Filter\PregReplace;
 use Laminas\Filter\StringToLower;
 use Laminas\Filter\StringToUpper;
 use Laminas\Filter\Word\CamelCaseToDash;
@@ -80,7 +79,7 @@ class InflectorTest extends TestCase
         $rules = $this->inflector->getRules();
         self::assertIsArray($rules);
         self::assertSame(0, count($rules));
-        $this->inflector->setFilterRule('controller', PregReplace::class);
+        $this->inflector->setFilterRule('controller', StringToLower::class);
         $rules = $this->inflector->getRules('controller');
         self::assertIsArray($rules);
         self::assertSame(1, count($rules));
@@ -93,7 +92,7 @@ class InflectorTest extends TestCase
         $rules = $this->inflector->getRules();
         self::assertIsArray($rules);
         self::assertSame(0, count($rules));
-        $filter = new PregReplace();
+        $filter = new StringToLower();
         $this->inflector->setFilterRule('controller', $filter);
         $rules = $this->inflector->getRules('controller');
         self::assertIsArray($rules);
@@ -108,7 +107,7 @@ class InflectorTest extends TestCase
         $rules = $this->inflector->getRules();
         self::assertIsArray($rules);
         self::assertSame(0, count($rules));
-        $this->inflector->setFilterRule('controller', [PregReplace::class, TestAsset\Alpha::class]);
+        $this->inflector->setFilterRule('controller', [StringToLower::class, TestAsset\Alpha::class]);
         $rules = $this->inflector->getRules('controller');
         self::assertIsArray($rules);
         self::assertSame(2, count($rules));
@@ -164,7 +163,7 @@ class InflectorTest extends TestCase
         self::assertIsArray($rules);
         self::assertSame(0, count($rules));
         $this->inflector->addRules([
-            ':controller' => [PregReplace::class, TestAsset\Alpha::class],
+            ':controller' => [StringToLower::class, TestAsset\Alpha::class],
             'suffix'      => 'phtml',
         ]);
         $rules = $this->inflector->getRules();
@@ -181,7 +180,7 @@ class InflectorTest extends TestCase
         self::assertIsArray($rules);
         self::assertSame(1, count($rules));
         $this->inflector->setRules([
-            ':controller' => [PregReplace::class, TestAsset\Alpha::class],
+            ':controller' => [StringToLower::class, TestAsset\Alpha::class],
             'suffix'      => 'phtml',
         ]);
         $rules = $this->inflector->getRules();
@@ -426,7 +425,7 @@ class InflectorTest extends TestCase
     {
         $rules = $this->inflector->getRules();
         self::assertSame(0, count($rules));
-        $this->inflector->setFilterRule('controller', PregReplace::class);
+        $this->inflector->setFilterRule('controller', StringToLower::class);
         $rules = $this->inflector->getRules('controller');
         self::assertSame(1, count($rules));
         $this->inflector->addFilterRule('controller', [TestAsset\Alpha::class, StringToLower::class]);

--- a/test/PregReplaceTest.php
+++ b/test/PregReplaceTest.php
@@ -4,64 +4,32 @@ declare(strict_types=1);
 
 namespace LaminasTest\Filter;
 
-use Laminas\Filter\Exception;
+use Laminas\Filter\Exception\InvalidArgumentException;
 use Laminas\Filter\PregReplace as PregReplaceFilter;
+use LaminasTest\Filter\TestAsset\StringableObject;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use stdClass;
 
 class PregReplaceTest extends TestCase
 {
-    private PregReplaceFilter $filter;
-
-    public function setUp(): void
-    {
-        $this->filter = new PregReplaceFilter();
-    }
-
     public function testPassingPatternToConstructorSetsPattern(): void
     {
         $pattern = '#^controller/(?P<action>[a-z_-]+)#';
-        $filter  = new PregReplaceFilter($pattern);
-        self::assertSame($pattern, $filter->getPattern());
-    }
+        $filter  = new PregReplaceFilter([
+            'pattern'     => $pattern,
+            'replacement' => 'foo/bar',
+        ]);
 
-    public function testPassingReplacementToConstructorSetsReplacement(): void
-    {
-        $replace = 'foo/bar';
-        $filter  = new PregReplaceFilter(null, $replace);
-        self::assertSame($replace, $filter->getReplacement());
-    }
-
-    public function testPatternIsNullByDefault(): void
-    {
-        self::assertNull($this->filter->getPattern());
-    }
-
-    public function testPatternAccessorsWork(): void
-    {
-        $pattern = '#^controller/(?P<action>[a-z_-]+)#';
-        $this->filter->setPattern($pattern);
-        self::assertSame($pattern, $this->filter->getPattern());
-    }
-
-    public function testReplacementIsEmptyByDefault(): void
-    {
-        $replacement = $this->filter->getReplacement();
-        self::assertEmpty($replacement);
-    }
-
-    public function testReplacementAccessorsWork(): void
-    {
-        $replacement = 'foo/bar';
-        $this->filter->setReplacement($replacement);
-        self::assertSame($replacement, $this->filter->getReplacement());
+        self::assertSame('foo/bar', $filter->filter('controller/whatever'));
     }
 
     public function testFilterPerformsRegexReplacement(): void
     {
-        $filter = $this->filter;
-        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+        $filter = new PregReplaceFilter([
+            'pattern'     => '#^controller/(?P<action>[a-z_-]+)#',
+            'replacement' => 'foo/bar',
+        ]);
 
         $string   = 'controller/action';
         $filtered = $filter($string);
@@ -71,8 +39,10 @@ class PregReplaceTest extends TestCase
 
     public function testFilterPerformsRegexReplacementWithArray(): void
     {
-        $filter = $this->filter;
-        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+        $filter = new PregReplaceFilter([
+            'pattern'     => '#^controller/(?P<action>[a-z_-]+)#',
+            'replacement' => 'foo/bar',
+        ]);
 
         $input = [
             'controller/action',
@@ -87,22 +57,47 @@ class PregReplaceTest extends TestCase
         ], $filtered);
     }
 
-    public function testFilterThrowsExceptionWhenNoMatchPatternPresent(): void
+    /** @return list<array{0: mixed}> */
+    public static function invalidPatternOptions(): array
     {
-        $filter = $this->filter;
-        $string = 'controller/action';
-        $filter->setReplacement('foo/bar');
-        $this->expectException(Exception\RuntimeException::class);
-        $this->expectExceptionMessage('does not have a valid pattern set');
-        $filter($string);
+        return [
+            [''],
+            [null],
+            [[]],
+        ];
+    }
+
+    #[DataProvider('invalidPatternOptions')]
+    public function testFilterThrowsExceptionWhenNoMatchPatternPresent(mixed $pattern): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        /** @psalm-suppress MixedArgumentTypeCoercion */
+        new PregReplaceFilter([
+            'pattern' => $pattern,
+        ]);
     }
 
     public function testPassingPatternWithExecModifierRaisesException(): void
     {
-        $filter = new PregReplaceFilter();
-        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('"e" pattern modifier');
-        $filter->setPattern('/foo/e');
+
+        new PregReplaceFilter([
+            'pattern' => '/foo/e',
+        ]);
+    }
+
+    public function testAllPatternsAreCheckedForTheEModifier(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('"e" pattern modifier');
+
+        new PregReplaceFilter([
+            'pattern' => [
+                '/^foo',
+                '/foo/e',
+            ],
+        ]);
     }
 
     /** @return list<array{0: mixed}> */
@@ -117,8 +112,10 @@ class PregReplaceTest extends TestCase
     #[DataProvider('returnUnfilteredDataProvider')]
     public function testReturnUnfiltered(mixed $input): void
     {
-        $filter = $this->filter;
-        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+        $filter = new PregReplaceFilter([
+            'pattern'     => '#^controller/(?P<action>[a-z_-]+)#',
+            'replacement' => 'foo/bar',
+        ]);
 
         self::assertSame($input, $filter->filter($input));
     }
@@ -139,9 +136,49 @@ class PregReplaceTest extends TestCase
     #[DataProvider('returnNonStringScalarValues')]
     public function testShouldFilterNonStringScalarValues(float|bool|int $input): void
     {
-        $filter = $this->filter;
-        $filter->setPattern('#^controller/(?P<action>[a-z_-]+)#')->setReplacement('foo/bar');
+        $filter = new PregReplaceFilter([
+            'pattern'     => '#^controller/(?P<action>[a-z_-]+)#',
+            'replacement' => 'foo/bar',
+        ]);
 
         self::assertSame((string) $input, $filter($input));
+    }
+
+    public function testReplacementsAreProcessedForAllArrayMembers(): void
+    {
+        $filter = new PregReplaceFilter([
+            'pattern'     => '/foo/',
+            'replacement' => 'bar',
+        ]);
+
+        $input = [
+            'a' => 'food',
+            'b' => [
+                'c' => 'moof',
+                'd' => 'foobar',
+            ],
+            'c' => new StringableObject('oofoo'),
+        ];
+
+        $expect = [
+            'a' => 'bard',
+            'b' => [
+                'c' => 'moof',
+                'd' => 'barbar',
+            ],
+            'c' => 'oobar',
+        ];
+
+        self::assertSame($expect, $filter->filter($input));
+    }
+
+    public function testReplacementWithBackreferences(): void
+    {
+        $filter = new PregReplaceFilter([
+            'pattern'     => '/(foo)([a-z]+)([0-9]+)/',
+            'replacement' => '$3$1',
+        ]);
+
+        self::assertSame('1234567foo', $filter->filter('foobing1234567'));
     }
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| BC Break      | yes
| QA            | yes

### Description

- Drops getters, setters and inheritance.
- Updates docs and migration guide
- Prevent calls to `PregReplace::__construct` without options in un-related tests
