### PR TITLE
Deprecate AbstractSeparator setSeparator and getSeparator

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1507,6 +1507,10 @@
     <DeprecatedClass>
       <code><![CDATA[AbstractFilter]]></code>
     </DeprecatedClass>
+    <DeprecatedMethod>
+      <code><![CDATA[setSeparator]]></code>
+      <code><![CDATA[setSeparator]]></code>
+    </DeprecatedMethod>
     <DocblockTypeContradiction>
       <code><![CDATA[is_string($separator)]]></code>
     </DocblockTypeContradiction>

--- a/src/Word/AbstractSeparator.php
+++ b/src/Word/AbstractSeparator.php
@@ -40,6 +40,8 @@ abstract class AbstractSeparator extends AbstractFilter
     /**
      * Sets a new separator
      *
+     * @deprecated Since 2.39.0 All option setters and getters will be removed in version 3.0
+     *
      * @param  string $separator Separator
      * @return self
      * @throws Exception\InvalidArgumentException
@@ -55,6 +57,8 @@ abstract class AbstractSeparator extends AbstractFilter
 
     /**
      * Returns the actual set separator
+     *
+     * @deprecated Since 2.39.0 All option setters and getters will be removed in version 3.0
      *
      * @return string
      */


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | yes
| QA            | no

### Description

Deprecate AbstractSeparator setSeparator and getSeparator in line with planned changes for v3 (See #184)