### PR TITLE
Deprecate `FilterProviderInterface`

### DIFF
--- a/src/FilterProviderInterface.php
+++ b/src/FilterProviderInterface.php
@@ -7,6 +7,8 @@ namespace Laminas\Filter;
 /**
  * Implement this interface within Module classes to indicate that your module
  * provides filter configuration for the FilterPluginManager.
+ *
+ * @deprecated Since 2.40.0 This interface will be removed in version 3.0 without replacement
  */
 interface FilterProviderInterface
 {

--- a/src/Module.php
+++ b/src/Module.php
@@ -23,6 +23,8 @@ class Module
     /**
      * Register a specification for the FilterManager with the ServiceListener.
      *
+     * @deprecated Since 2.40.0 This method is not necessary for module manager and will be removed in 3.0
+     *
      * @param ModuleManager $moduleManager
      * @return void
      */


### PR DESCRIPTION
This interface is MVC Module Manager specific and does not belong in this library
