### PR TITLE
Refactor RenameTest

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2055,6 +2055,8 @@
       <code><![CDATA[1234]]></code>
     </InvalidArgument>
     <PossiblyUnusedMethod>
+      <code><![CDATA[returnInvalidFilterInputProvider]]></code>
+      <code><![CDATA[returnValidFilterInputProvider]]></code>
       <code><![CDATA[returnUnfilteredDataProvider]]></code>
     </PossiblyUnusedMethod>
   </file>


### PR DESCRIPTION
- Only remove temp directory after all tests have run
- Use DataProvider for filter config and input variations


|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | yes

### Description

Draft PR to discuss refactoring of RenameTest.

Started looking at this as part of the moving the Rename filter to v3, but this feels like a big enough piece of refactoring in itself to be worth sense checking.

As DataProviders run before any of the test hooks, the creation of the tmp test file is moved to a static method that creates it on first use, and then it's not removed until all the tests in RenameTest have run. Likewise for the sub directory needed for testing moving a file to a target directory.

The cleanup for the indvidual files created by tests has been moved to each test. Could potentially be moved back to tearDown if we're not concerned about the number of redundant calls, and depending on what seems more readable.