### PR TITLE
Refactor StripTags filter to implement FlterInterface

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -258,6 +258,17 @@ The following methods have been removed:
 
 The constructor now only accepts an associative array of [documented options](../standard-filters.md#stringtrim).
 
+#### `StripTags`
+
+The following methods have been removed:
+
+- `getTagsAllowed`
+- `setTagsAllowed`
+- `getAttributesAllowed`
+- `setAttributesAllowed`
+
+The constructor now only accepts an associative array of [documented options](../standard-filters.md#striptags).
+
 #### `ToNull`
 
 The following methods have been removed:

--- a/docs/book/v3/standard-filters.md
+++ b/docs/book/v3/standard-filters.md
@@ -1185,7 +1185,7 @@ The above will return `This contains`, with the rest being stripped.
 example, this can be used to strip all markup except for links:
 
 ```php
-$filter = new Laminas\Filter\StripTags(['allowTags' => 'a']);
+$filter = new Laminas\Filter\StripTags(['allowTags' => ['a']]);
 
 $input  = "A text with <br/> a <a href='link.com'>link</a>";
 print $filter->filter($input);
@@ -1205,8 +1205,8 @@ You can also strip all but an allowed set of attributes from a tag:
 
 ```php
 $filter = new Laminas\Filter\StripTags([
-    'allowTags' => 'img',
-    'allowAttribs' => 'src',
+    'allowTags' => ['img'],
+    'allowAttribs' => ['src'],
 ]);
 
 $input  = "A text with <br/> a <img src='picture.com' width='100'>picture</img>";
@@ -1224,16 +1224,17 @@ will be an allowed tag, pointing to a list of allowed attributes for that
 tag.
 
 ```php
-$allowedElements = [
-    'img' => [
-        'src',
-        'width'
-    ],
-    'a' => [
-        'href'
+$filter = new Laminas\Filter\StripTags([
+    'allowTags' => [
+        'img' => [
+            'src',
+            'width'
+        ],
+        'a' => [
+            'href'
+        ]
     ]
-];
-$filter = new Laminas\Filter\StripTags($allowedElements);
+]);
 
 $input = "A text with <br/> a <img src='picture.com' width='100'>picture</img> click "
     . "<a href='http://picture.com/laminas' id='hereId'>here</a>!";

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -319,29 +319,6 @@
       <code><![CDATA[Module]]></code>
     </UnusedClass>
   </file>
-  <file src="src/StripTags.php">
-    <DeprecatedClass>
-      <code><![CDATA[AbstractFilter]]></code>
-    </DeprecatedClass>
-    <MixedArgument>
-      <code><![CDATA[$options['allowAttribs']]]></code>
-      <code><![CDATA[$options['allowTags']]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$attribute]]></code>
-      <code><![CDATA[$element]]></code>
-      <code><![CDATA[$temp['allowAttribs']]]></code>
-      <code><![CDATA[$temp['allowComments']]]></code>
-      <code><![CDATA[$temp['allowTags']]]></code>
-    </MixedAssignment>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$temp]]></code>
-    </PossiblyUndefinedVariable>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_array($options)]]></code>
-      <code><![CDATA[is_string($attribute)]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="src/Word/SeparatorToCamelCase.php">
     <MissingClosureParamType>
       <code><![CDATA[$matches]]></code>
@@ -448,13 +425,5 @@
       <code><![CDATA[$rule]]></code>
       <code><![CDATA[$target]]></code>
     </UnusedVariable>
-  </file>
-  <file src="test/StripTagsTest.php">
-    <MixedArgument>
-      <code><![CDATA[$filtered]]></code>
-    </MixedArgument>
-    <MixedAssignment>
-      <code><![CDATA[$filtered]]></code>
-    </MixedAssignment>
   </file>
 </files>

--- a/src/StripTags.php
+++ b/src/StripTags.php
@@ -4,12 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use Laminas\Stdlib\ArrayUtils;
-use Traversable;
-
 use function array_key_exists;
-use function array_shift;
-use function func_get_args;
 use function is_array;
 use function is_int;
 use function is_scalar;
@@ -26,19 +21,13 @@ use function trim;
 
 /**
  * @psalm-type Options = array{
- *     tags_allowed?: array<string>|string,
- *     attributes_allowed?: array<string>|string,
- *     ...
+ *     allowTags?: array<string|list<string>>,
+ *     allowAttribs?: list<string>
  * }
- * @extends AbstractFilter<Options>
+ * @implements FilterInterface<string>
  */
-final class StripTags extends AbstractFilter
+final class StripTags implements FilterInterface
 {
-    /**
-     * Unique ID prefix used for allowing comments
-     */
-    public const UNIQUE_ID_PREFIX = '__Laminas_Filter_StripTags__';
-
     /**
      * Array of allowed tags and allowed attributes for each allowed tag
      *
@@ -47,7 +36,7 @@ final class StripTags extends AbstractFilter
      *
      * @var array<string, array<string, null>>
      */
-    protected $tagsAllowed = [];
+    private array $tagsAllowed = [];
 
     /**
      * Array of allowed attributes for all allowed tags
@@ -56,132 +45,15 @@ final class StripTags extends AbstractFilter
      *
      * @var array<string, null>
      */
-    protected $attributesAllowed = [];
+    private array $attributesAllowed = [];
 
     /**
-     * Sets the filter options
-     * Allowed options are
-     *     'allowTags'     => Tags which are allowed
-     *     'allowAttribs'  => Attributes which are allowed
-     *     'allowComments' => Are comments allowed ?
-     *
-     * @param  string|array|Traversable $options
+     * @param Options $options
      */
-    public function __construct($options = null)
+    public function __construct(array $options = [])
     {
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
-        }
-        if (
-            (! is_array($options)) || (is_array($options) && ! array_key_exists('allowTags', $options) &&
-            ! array_key_exists('allowAttribs', $options) && ! array_key_exists('allowComments', $options))
-        ) {
-            $options           = func_get_args();
-            $temp['allowTags'] = array_shift($options);
-            if (! empty($options)) {
-                $temp['allowAttribs'] = array_shift($options);
-            }
-
-            if (! empty($options)) {
-                $temp['allowComments'] = array_shift($options);
-            }
-
-            $options = $temp;
-        }
-
-        if (array_key_exists('allowTags', $options)) {
-            $this->setTagsAllowed($options['allowTags']);
-        }
-
-        if (array_key_exists('allowAttribs', $options)) {
-            $this->setAttributesAllowed($options['allowAttribs']);
-        }
-    }
-
-    /**
-     * Returns the tagsAllowed option
-     *
-     * @return array<string, array<string, null>>
-     */
-    public function getTagsAllowed()
-    {
-        return $this->tagsAllowed;
-    }
-
-    /**
-     * Sets the tagsAllowed option
-     *
-     * @param  array|string $tagsAllowed
-     * @return self Provides a fluent interface
-     */
-    public function setTagsAllowed($tagsAllowed)
-    {
-        if (! is_array($tagsAllowed)) {
-            $tagsAllowed = [$tagsAllowed];
-        }
-
-        foreach ($tagsAllowed as $index => $element) {
-            // If the tag was provided without attributes
-            if (is_int($index) && is_string($element)) {
-                // Canonicalize the tag name
-                $tagName = strtolower($element);
-                // Store the tag as allowed with no attributes
-                $this->tagsAllowed[$tagName] = [];
-            } elseif (is_string($index) && (is_array($element) || is_string($element))) {
-                // Otherwise, if a tag was provided with attributes
-                // Canonicalize the tag name
-                $tagName = strtolower($index);
-                // Canonicalize the attributes
-                if (is_string($element)) {
-                    $element = [$element];
-                }
-                // Store the tag as allowed with the provided attributes
-                $this->tagsAllowed[$tagName] = [];
-                foreach ($element as $attribute) {
-                    if (is_string($attribute)) {
-                        // Canonicalize the attribute name
-                        $attributeName                               = strtolower($attribute);
-                        $this->tagsAllowed[$tagName][$attributeName] = null;
-                    }
-                }
-            }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Returns the attributesAllowed option
-     *
-     * @return array<string, null>
-     */
-    public function getAttributesAllowed()
-    {
-        return $this->attributesAllowed;
-    }
-
-    /**
-     * Sets the attributesAllowed option
-     *
-     * @param  list<string>|string $attributesAllowed
-     * @return self Provides a fluent interface
-     */
-    public function setAttributesAllowed($attributesAllowed)
-    {
-        if (! is_array($attributesAllowed)) {
-            $attributesAllowed = [$attributesAllowed];
-        }
-
-        // Store each attribute as allowed
-        foreach ($attributesAllowed as $attribute) {
-            if (is_string($attribute)) {
-                // Canonicalize the attribute name
-                $attributeName                           = strtolower($attribute);
-                $this->attributesAllowed[$attributeName] = null;
-            }
-        }
-
-        return $this;
+        $this->setTagsAllowed($options['allowTags'] ?? []);
+        $this->setAttributesAllowed($options['allowAttribs'] ?? []);
     }
 
     /**
@@ -228,7 +100,7 @@ final class StripTags extends AbstractFilter
             // If a tag exists in this match, then filter the tag
             $tag = $matches[2][$index];
             if (strlen($tag)) {
-                $tagFiltered = $this->_filterTag($tag);
+                $tagFiltered = $this->filterTag($tag);
             } else {
                 $tagFiltered = '';
             }
@@ -240,13 +112,60 @@ final class StripTags extends AbstractFilter
         return $dataFiltered;
     }
 
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
+    }
+
+    private function setTagsAllowed(array $tagsAllowed): void
+    {
+        foreach ($tagsAllowed as $index => $element) {
+            // If the tag was provided without attributes
+            if (is_int($index) && is_string($element)) {
+                // Canonicalize the tag name
+                $tagName = strtolower($element);
+                // Store the tag as allowed with no attributes
+                $this->tagsAllowed[$tagName] = [];
+            } elseif (is_string($index) && (is_array($element) || is_string($element))) {
+                // Otherwise, if a tag was provided with attributes
+                // Canonicalize the tag name
+                $tagName = strtolower($index);
+                // Canonicalize the attributes
+                if (is_string($element)) {
+                    $element = [$element];
+                }
+                // Store the tag as allowed with the provided attributes
+                $this->tagsAllowed[$tagName] = [];
+                foreach ($element as $attribute) {
+                    if (is_string($attribute)) {
+                        // Canonicalize the attribute name
+                        $attributeName                               = strtolower($attribute);
+                        $this->tagsAllowed[$tagName][$attributeName] = null;
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  list<string> $attributesAllowed
+     */
+    private function setAttributesAllowed(array $attributesAllowed): void
+    {
+        // Store each attribute as allowed
+        foreach ($attributesAllowed as $attribute) {
+            if (is_string($attribute)) {
+                // Canonicalize the attribute name
+                $attributeName                           = strtolower($attribute);
+                $this->attributesAllowed[$attributeName] = null;
+            }
+        }
+    }
+
     /**
      * Filters a single tag against the current option settings
-     *
-     * @param  string $tag
-     * @return string
      */
-    protected function _filterTag($tag) // phpcs:ignore
+    private function filterTag(string $tag): string
     {
         // @codingStandardsIgnoreEnd
         // Parse the tag into:

--- a/src/StripTags.php
+++ b/src/StripTags.php
@@ -21,7 +21,7 @@ use function trim;
 
 /**
  * @psalm-type Options = array{
- *     allowTags?: array<string|list<string>>,
+ *     allowTags?: list<string>|array<string, list<string>>,
  *     allowAttribs?: list<string>
  * }
  * @implements FilterInterface<string>
@@ -60,8 +60,6 @@ final class StripTags implements FilterInterface
      * Defined by Laminas\Filter\FilterInterface
      *
      * If the value provided is non-scalar, the value will remain unfiltered
-     *
-     * @psalm-return ($value is scalar ? string : mixed)
      */
     public function filter(mixed $value): mixed
     {
@@ -117,6 +115,9 @@ final class StripTags implements FilterInterface
         return $this->filter($value);
     }
 
+    /**
+     * @param array<string|list<string>> $tagsAllowed
+     */
     private function setTagsAllowed(array $tagsAllowed): void
     {
         foreach ($tagsAllowed as $index => $element) {
@@ -126,22 +127,16 @@ final class StripTags implements FilterInterface
                 $tagName = strtolower($element);
                 // Store the tag as allowed with no attributes
                 $this->tagsAllowed[$tagName] = [];
-            } elseif (is_string($index) && (is_array($element) || is_string($element))) {
+            } elseif (is_string($index) && is_array($element)) {
                 // Otherwise, if a tag was provided with attributes
                 // Canonicalize the tag name
                 $tagName = strtolower($index);
-                // Canonicalize the attributes
-                if (is_string($element)) {
-                    $element = [$element];
-                }
                 // Store the tag as allowed with the provided attributes
                 $this->tagsAllowed[$tagName] = [];
                 foreach ($element as $attribute) {
-                    if (is_string($attribute)) {
-                        // Canonicalize the attribute name
-                        $attributeName                               = strtolower($attribute);
-                        $this->tagsAllowed[$tagName][$attributeName] = null;
-                    }
+                    // Canonicalize the attribute name
+                    $attributeName                               = strtolower($attribute);
+                    $this->tagsAllowed[$tagName][$attributeName] = null;
                 }
             }
         }
@@ -154,11 +149,9 @@ final class StripTags implements FilterInterface
     {
         // Store each attribute as allowed
         foreach ($attributesAllowed as $attribute) {
-            if (is_string($attribute)) {
-                // Canonicalize the attribute name
-                $attributeName                           = strtolower($attribute);
-                $this->attributesAllowed[$attributeName] = null;
-            }
+            // Canonicalize the attribute name
+            $attributeName                           = strtolower($attribute);
+            $this->attributesAllowed[$attributeName] = null;
         }
     }
 

--- a/test/FilterChainTest.php
+++ b/test/FilterChainTest.php
@@ -124,7 +124,7 @@ class FilterChainTest extends TestCase
             'filters'   => [
                 [
                     'name'     => StripTags::class,
-                    'options'  => ['allowTags' => 'img', 'allowAttribs' => 'id'],
+                    'options'  => ['allowTags' => ['img'], 'allowAttribs' => ['id']],
                     'priority' => 10100,
                 ],
             ],

--- a/test/StripTagsTest.php
+++ b/test/StripTagsTest.php
@@ -123,7 +123,7 @@ class StripTagsTest extends TestCase
     public function testFilterTagAllowedAttributeAllowed(): void
     {
         $filter   = new StripTagsFilter([
-            'allowTags' => ['img' => 'alt'],
+            'allowTags' => ['img' => ['alt']],
         ]);
         $input    = '<IMG ALT="FOO" />';
         $expected = '<img alt="FOO" />';
@@ -138,7 +138,7 @@ class StripTagsTest extends TestCase
     public function testFilterTagAllowedAttributeAllowedGt(): void
     {
         $filter   = new StripTagsFilter([
-            'allowTags' => ['img' => 'alt'],
+            'allowTags' => ['img' => ['alt']],
         ]);
         $input    = '<img alt="$object->property" />';
         $expected = '<img>property" /';
@@ -151,7 +151,7 @@ class StripTagsTest extends TestCase
     public function testFilterTagAllowedAttributeAllowedGtEscaped(): void
     {
         $filter   = new StripTagsFilter([
-            'allowTags' => ['img' => 'alt'],
+            'allowTags' => ['img' => ['alt']],
         ]);
         $input    = '<img alt="$object-&gt;property" />';
         $expected = '<img alt="$object-&gt;property" />';
@@ -242,7 +242,7 @@ class StripTagsTest extends TestCase
     {
         $filter   = new StripTagsFilter([
             'allowTags' => [
-                'a' => 'href',
+                'a' => ['href'],
             ],
         ]);
         $input    = '<a href="Some &gt; Text">';
@@ -259,7 +259,7 @@ class StripTagsTest extends TestCase
     {
         $filter = new StripTagsFilter([
             'allowTags' => [
-                'element' => 'attribute',
+                'element' => ['attribute'],
             ],
         ]);
         $input  = '<element attribute="a=">contents</element>';

--- a/test/StripTagsTest.php
+++ b/test/StripTagsTest.php
@@ -271,7 +271,7 @@ class StripTagsTest extends TestCase
     {
         $filter   = new StripTagsFilter([
             'allowTags' => [
-                'a' => 'href',
+                'a' => ['href'],
             ],
         ]);
         $input    = '<a href="https://getlaminas.org/issues" onclick


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | yes
| QA            | no

### Description
Move StripTags filter also to the implementation via FilterInterface and removed the AbstractFilter