### PR TITLE
Refactor Rename

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -16,65 +16,6 @@
       <code><![CDATA[isOptions]]></code>
     </PossiblyUnusedMethod>
   </file>
-  <file src="src/File/Rename.php">
-    <DeprecatedClass>
-      <code><![CDATA[Filter\AbstractFilter]]></code>
-    </DeprecatedClass>
-    <DocblockTypeContradiction>
-      <code><![CDATA[is_array($options)]]></code>
-      <code><![CDATA[is_array($options)]]></code>
-    </DocblockTypeContradiction>
-    <InvalidReturnStatement>
-      <code><![CDATA[$file]]></code>
-    </InvalidReturnStatement>
-    <MixedArgument>
-      <code><![CDATA[$file['source']]]></code>
-      <code><![CDATA[$file['source']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedArgument>
-    <MixedArgumentTypeCoercion>
-      <code><![CDATA[$options]]></code>
-    </MixedArgumentTypeCoercion>
-    <MixedArrayAccess>
-      <code><![CDATA[$file['source']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-      <code><![CDATA[$file['target']]]></code>
-    </MixedArrayAccess>
-    <MixedArrayAssignment>
-      <code><![CDATA[$uploadData['tmp_name']]]></code>
-    </MixedArrayAssignment>
-    <MixedAssignment>
-      <code><![CDATA[$uploadData['tmp_name']]]></code>
-      <code><![CDATA[$value]]></code>
-      <code><![CDATA[$value]]></code>
-    </MixedAssignment>
-    <MixedReturnStatement>
-      <code><![CDATA[$file['target']]]></code>
-    </MixedReturnStatement>
-    <PossiblyFalseArgument>
-      <code><![CDATA[realpath($file['target'])]]></code>
-    </PossiblyFalseArgument>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$files['source']]]></code>
-      <code><![CDATA[$rename['randomize']]]></code>
-    </PossiblyUndefinedArrayOffset>
-    <PossiblyUndefinedVariable>
-      <code><![CDATA[$uploadData]]></code>
-      <code><![CDATA[$uploadData]]></code>
-    </PossiblyUndefinedVariable>
-    <PropertyTypeCoercion>
-      <code><![CDATA[$this->files]]></code>
-    </PropertyTypeCoercion>
-    <RedundantConditionGivenDocblockType>
-      <code><![CDATA[is_string($file)]]></code>
-    </RedundantConditionGivenDocblockType>
-  </file>
   <file src="src/File/RenameUpload.php">
     <DeprecatedClass>
       <code><![CDATA[AbstractFilter]]></code>
@@ -173,12 +114,6 @@
     <UnusedClass>
       <code><![CDATA[Module]]></code>
     </UnusedClass>
-  </file>
-  <file src="test/File/RenameTest.php">
-    <InvalidArgument>
-      <code><![CDATA[1234]]></code>
-      <code><![CDATA[1234]]></code>
-    </InvalidArgument>
   </file>
   <file src="test/File/RenameUploadTest.php">
     <InvalidArgument>

--- a/src/File/Rename.php
+++ b/src/File/Rename.php
@@ -4,359 +4,183 @@ declare(strict_types=1);
 
 namespace Laminas\Filter\File;
 
-use Laminas\Filter;
 use Laminas\Filter\Exception;
-use Laminas\Stdlib\ArrayUtils;
-use Traversable;
+use Laminas\Filter\FilterInterface;
 
-use function basename;
-use function count;
+use function array_is_list;
 use function file_exists;
-use function is_array;
-use function is_bool;
+use function fnmatch;
 use function is_dir;
-use function is_scalar;
 use function is_string;
+use function is_writable;
 use function pathinfo;
-use function realpath;
 use function rename;
 use function sprintf;
-use function strlen;
 use function uniqid;
 use function unlink;
 
-use const DIRECTORY_SEPARATOR;
-
 /**
- * @psalm-type Options = array{
- *     file?: array{source?: string, target?: string, overwrite?: bool, randomize?: bool},
- *     ...
+ * @psalm-type OptionsSet = array{
+ *     match?: non-empty-string,
+ *     target_directory?: non-empty-string,
+ *     rename_to?: string,
+ *     overwrite?: bool,
+ *     randomize?: bool
  * }
- * @template TOptions of Options
- * @template-extends Filter\AbstractFilter<TOptions>
+ * @psalm-type Options = OptionsSet|list<OptionsSet>
+ * @psalm-type DefaultedOptionsSet = array{
+ *      match: non-empty-string,
+ *      target_directory: non-empty-string,
+ *      rename_to: string,
+ *      overwrite: bool,
+ *      randomize: bool
+ *  }
+ * @implements FilterInterface<string>
  */
-final class Rename extends Filter\AbstractFilter
+final class Rename implements FilterInterface
 {
-    /**
-     * Internal array of array(source, target, overwrite)
-     *
-     * @var list<array{source: string, target: string, overwrite: bool, randomize: bool}>
-     */
-    protected $files = [];
+    /** @var DefaultedOptionsSet[] */
+    private readonly array $options;
 
-    /**
-     * Options argument may be either a string, a Laminas\Config\Config object, or an array.
-     * If an array or Laminas\Config\Config object, it accepts the following keys:
-     * 'source'    => Source filename or directory which will be renamed
-     * 'target'    => Target filename or directory, the new name of the source file
-     * 'overwrite' => Shall existing files be overwritten ?
-     * 'randomize' => Shall target files have a random postfix attached?
-     *
-     * @param  string|array|Traversable $options Target file or directory to be renamed
-     * @throws Exception\InvalidArgumentException
-     */
-    public function __construct($options = [])
+    /** @param Options $options */
+    public function __construct(array $options = [])
     {
-        if ($options instanceof Traversable) {
-            $options = ArrayUtils::iteratorToArray($options);
-        } elseif (is_string($options)) {
-            $options = ['target' => $options];
-        } elseif (! is_array($options)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid options argument provided to filter'
-            );
+        $defaultedOptions = [];
+
+        if (array_is_list($options)) {
+            /** @psalm-var OptionsSet $option */
+            foreach ($options as $option) {
+                $defaultedOptions[] = $this->validateAndDefaultOptions($option);
+            }
+        } else {
+            /** @psalm-var OptionsSet $options */
+            $defaultedOptions[] = $this->validateAndDefaultOptions($options);
         }
 
-        $this->setFile($options);
+        $this->options = $defaultedOptions;
     }
 
     /**
-     * Returns the files to rename and their new name and location
-     *
-     * @return list<array{source: string, target: string, overwrite: bool, randomize: bool}>
+     * @param OptionsSet $options
+     * @return DefaultedOptionsSet
      */
-    public function getFile()
+    private function validateAndDefaultOptions(array $options): array
     {
-        return $this->files;
-    }
+        $target = $options['target_directory'] ?? '*';
 
-    /**
-     * Sets a new file or directory as target, deleting existing ones
-     *
-     * Array accepts the following keys:
-     * 'source'    => Source filename or directory which will be renamed
-     * 'target'    => Target filename or directory, the new name of the sourcefile
-     * 'overwrite' => Shall existing files be overwritten?
-     * 'randomize' => Shall target files have a random postfix attached?
-     *
-     * @param  string|array{source?: string, target?: string, overwrite?: bool, randomize?: bool} $options
-     * @return self
-     */
-    public function setFile($options)
-    {
-        $this->files = [];
-        $this->addFile($options);
+        if ($target !== '*') {
+            if (! is_dir($target)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'The target directory "%s" does not exist',
+                    $target
+                ));
+            }
 
-        return $this;
-    }
-
-    /**
-     * Adds a new file or directory as target to the existing ones
-     *
-     * Array accepts the following keys:
-     * 'source'    => Source filename or directory which will be renamed
-     * 'target'    => Target filename or directory, the new name of the sourcefile
-     * 'overwrite' => Shall existing files be overwritten?
-     * 'randomize' => Shall target files have a random postfix attached?
-     *
-     * @param  string|array{source?: string, target?: string, overwrite?: bool, randomize?: bool} $options $options
-     * @return Rename
-     * @throws Exception\InvalidArgumentException
-     */
-    public function addFile($options)
-    {
-        if (is_string($options)) {
-            $options = ['target' => $options];
-        } elseif (! is_array($options)) {
-            throw new Exception\InvalidArgumentException(
-                'Invalid options to rename filter provided'
-            );
+            if (! is_writable($target)) {
+                throw new Exception\InvalidArgumentException(sprintf(
+                    'The target directory "%s" is not writable',
+                    $target
+                ));
+            }
         }
 
-        $this->_convertOptions($options);
-
-        return $this;
+        return [
+            'match'            => $options['match'] ?? '*',
+            'target_directory' => $target,
+            'rename_to'        => $options['rename_to'] ?? '*',
+            'overwrite'        => $options['overwrite'] ?? false,
+            'randomize'        => $options['randomize'] ?? false,
+        ];
     }
 
     /**
-     * Returns only the new filename without moving it
-     * But existing files will be erased when the overwrite option is true
-     *
-     * @param  string  $value  Full path of file to change
-     * @param  bool $source Return internal information
-     * @return string The new filename which has been set
+     * @param DefaultedOptionsSet $matchingOptions
      * @throws Exception\InvalidArgumentException If the target file already exists.
      */
-    public function getNewName($value, $source = false)
+    private function renameFile(string $sourceFilePath, array $matchingOptions): string
     {
-        $file = $this->_getFileName($value);
-        if (! is_array($file)) {
+        $file = $this->getFileName($sourceFilePath, $matchingOptions);
+
+        if ($file === $sourceFilePath) {
             return $file;
         }
 
-        if ($file['source'] === $file['target']) {
-            return $value;
+        if ($matchingOptions['overwrite'] && file_exists($file)) {
+            unlink($file);
         }
 
-        if (! file_exists($file['source'])) {
-            return $value;
-        }
-
-        if ($file['overwrite'] && file_exists($file['target'])) {
-            unlink($file['target']);
-        }
-
-        if (file_exists($file['target'])) {
+        if (file_exists($file)) {
             throw new Exception\InvalidArgumentException(sprintf(
                 '"File "%s" could not be renamed to "%s"; target file already exists',
-                $value,
-                realpath($file['target'])
+                $sourceFilePath,
+                $file
             ));
         }
 
-        if ($source) {
-            return $file;
-        }
-
-        return $file['target'];
-    }
-
-    /**
-     * Defined by Laminas\Filter\Filter
-     *
-     * Renames the file $value to the new name set before
-     * Returns the file $value, removing all but digit characters
-     *
-     * @param mixed $value Full path of file to change or $_FILES data array
-     * @return mixed|string|array The new filename which has been set
-     * @throws Exception\RuntimeException
-     */
-    public function filter(mixed $value): mixed
-    {
-        if (! is_scalar($value) && ! is_array($value)) {
-            return $value;
-        }
-
-        // An uploaded file? Retrieve the 'tmp_name'
-        $isFileUpload = false;
-        if (is_array($value)) {
-            if (! isset($value['tmp_name'])) {
-                return $value;
-            }
-
-            $isFileUpload = true;
-            $uploadData   = $value;
-            $value        = $value['tmp_name'];
-        }
-
-        $file = $this->getNewName((string) $value, true);
-        if (is_string($file)) {
-            if ($isFileUpload) {
-                return $uploadData;
-            } else {
-                return $file;
-            }
-        }
-
-        $result = rename($file['source'], $file['target']);
+        $result = rename($sourceFilePath, $file);
 
         if ($result !== true) {
             throw new Exception\RuntimeException(
                 sprintf(
                     "File '%s' could not be renamed. "
                     . "An error occurred while processing the file.",
-                    $value
+                    $sourceFilePath
                 )
             );
         }
 
-        if ($isFileUpload) {
-            $uploadData['tmp_name'] = $file['target'];
-            return $uploadData;
-        }
-        return $file['target'];
+        return $file;
     }
 
     /**
-     * Internal method for creating the file array
-     * Supports single and nested arrays
-     *
-     * @param  array $options
-     * @return $this
+     * @throws Exception\RuntimeException
      */
-    // @codingStandardsIgnoreStart
-    protected function _convertOptions($options)
+    public function filter(mixed $value): mixed
     {
-        // @codingStandardsIgnoreEnd
-        $files = [];
-        foreach ($options as $key => $value) {
-            if (is_array($value)) {
-                $this->_convertOptions($value);
-                continue;
-            }
+        if (! is_string($value)) {
+            return $value;
+        }
 
-            switch ($key) {
-                case "source":
-                    $files['source'] = (string) $value;
-                    break;
+        if (! file_exists($value)) {
+            return $value;
+        }
 
-                case 'target':
-                    $files['target'] = (string) $value;
-                    break;
-
-                case 'overwrite':
-                    $files['overwrite'] = (bool) $value;
-                    break;
-
-                case 'randomize':
-                    $files['randomize'] = (bool) $value;
-                    break;
-
-                default:
-                    break;
+        foreach ($this->options as $option) {
+            if (fnmatch($option['match'], $value)) {
+                return $this->renameFile($value, $option);
             }
         }
 
-        if ($files === []) {
-            return $this;
-        }
-
-        if (! is_string($files['source'] ?? null)) {
-            $files['source'] = '*';
-        }
-
-        if (! is_string($files['target'] ?? null)) {
-            $files['target'] = '*';
-        }
-
-        if (! is_bool($files['overwrite'] ?? null)) {
-            $files['overwrite'] = false;
-        }
-
-        if (! is_bool($files['randomize'] ?? null)) {
-            $files['randomize'] = false;
-        }
-
-        $found = false;
-        foreach ($this->files as $key => $value) {
-            if ($value['source'] === $files['source']) {
-                $this->files[$key] = $files;
-                $found             = true;
-            }
-        }
-
-        if (! $found) {
-            $count               = count($this->files);
-            $this->files[$count] = $files;
-        }
-
-        return $this;
+        return $value;
     }
 
     /**
-     * Internal method to resolve the requested source
-     * and return all other related parameters
-     *
-     * @param  string $file Filename to get the information for
-     * @return array|string
+     * @param DefaultedOptionsSet $matchingOptions
      */
-    // @codingStandardsIgnoreStart
-    protected function _getFileName($file)
+    private function getFileName(string $file, array $matchingOptions): string
     {
-        // @codingStandardsIgnoreEnd
-        $rename = [];
-        foreach ($this->files as $value) {
-            if ($value['source'] === '*') {
-                if (! isset($rename['source'])) {
-                    $rename           = $value;
-                    $rename['source'] = $file;
-                }
-            }
+        $fileInfo = pathinfo($file);
 
-            if ($value['source'] === $file) {
-                $rename = $value;
-                break;
-            }
-        }
+        $targetName = $matchingOptions['rename_to'] === '*' ? $fileInfo['basename'] : $matchingOptions['rename_to'];
+        $targetDir  = $matchingOptions['target_directory'] === '*' ?
+            $fileInfo['dirname'] : $matchingOptions['target_directory'];
 
-        if (! isset($rename['source'])) {
-            return $file;
-        }
+        $target = $targetDir . '/' . $targetName;
 
-        if (! isset($rename['target']) || $rename['target'] === '*') {
-            $rename['target'] = $rename['source'];
-        }
-
-        if (is_dir($rename['target'])) {
-            $name = basename($rename['source']);
-            $last = $rename['target'][strlen($rename['target']) - 1];
-            if ($last !== '/' && $last !== '\\') {
-                $rename['target'] .= DIRECTORY_SEPARATOR;
-            }
-
-            $rename['target'] .= $name;
-        }
-
-        if ($rename['randomize']) {
-            $info      = pathinfo($rename['target']);
-            $newTarget = $info['dirname'] . DIRECTORY_SEPARATOR
-                . $info['filename'] . uniqid('_', false);
+        if ($matchingOptions['randomize']) {
+            $info      = pathinfo($target);
+            $newTarget = $info['dirname'] . '/' . $info['filename'] . uniqid('_');
             if (isset($info['extension'])) {
                 $newTarget .= '.' . $info['extension'];
             }
-            $rename['target'] = $newTarget;
+            $target = $newTarget;
         }
 
-        return $rename;
+        return $target;
+    }
+
+    public function __invoke(mixed $value): mixed
+    {
+        return $this->filter($value);
     }
 }

--- a/test/File/RenameTest.php
+++ b/test/File/RenameTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace LaminasTest\Filter\File;
 
-use Laminas\Filter\Exception;
+use Laminas\Filter\Exception\InvalidArgumentException;
 use Laminas\Filter\File\Rename as FileRename;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
@@ -12,7 +12,6 @@ use stdClass;
 
 use function copy;
 use function file_exists;
-use function is_array;
 use function mkdir;
 use function preg_quote;
 use function rmdir;
@@ -23,6 +22,9 @@ use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @psalm-import-type Options from FileRename
+ */
 final class RenameTest extends TestCase
 {
     private const TEST_FILE_NAME = 'test_file.txt';
@@ -81,419 +83,236 @@ final class RenameTest extends TestCase
 
     public static function returnValidFilterInputProvider(): array
     {
-        $oldFile    = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newFile    = self::getTempPath() . '/new_file.xml';
-        $newDir     = self::getTempSubDirectory();
-        $newDirFile = self::getTempSubDirectory() . '/test_file.txt';
+        $oldFilePath  = self::getTempPath() . '/' . self::TEST_FILE_NAME;
+        $newFileName  = 'new_file.xml';
+        $newDirectory = self::getTempSubDirectory();
 
         return [
-            'Configured with target file path and filtering file path'       => [
-                'options'               => $newFile,
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => '*',
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => $newFile,
+            'Rename in place'                           => [
+                'options'              => ['match' => $oldFilePath, 'rename_to' => $newFileName],
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => self::getTempPath() . '/' . $newFileName,
             ],
-            'Configured with target file path and filtering file path array' => [
-                'options'               => $newFile,
-                'input'                 => ['tmp_name' => $oldFile],
-                'expectedGetFileResult' => [
-                    'source'    => '*',
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => ['tmp_name' => $newFile],
+            'Move to new directory'                     => [
+                'options'              => ['match' => $oldFilePath, 'target_directory' => $newDirectory],
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => $newDirectory . '/' . self::TEST_FILE_NAME,
             ],
-            'Configured with array'                                          => [
-                'options'               => ['source' => $oldFile, 'target' => $newFile],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
+            'Move to new directory and rename'          => [
+                'options'              => [
+                    'match'            => $oldFilePath,
+                    'target_directory' => $newDirectory,
+                    'rename_to'        => $newFileName,
                 ],
-                'expectedFilterResult'  => $newFile,
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => $newDirectory . '/' . $newFileName,
             ],
-            'Configured with all options set'                                => [
-                'options'               => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'overwrite' => true,
-                    'randomize' => false,
-                    'unknown'   => false,
-                ],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'overwrite' => true,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => $newFile,
+            'No replacement or move configured'         => [
+                'options'              => [],
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => $oldFilePath,
             ],
-            'Configured with array wrapped in array'                         => [
-                'options'               => [0 => ['source' => $oldFile, 'target' => $newFile]],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => $newFile,
+            'Rename in place with wildcard match'       => [
+                'options'              => ['rename_to' => $newFileName],
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => self::getTempPath() . '/' . $newFileName,
             ],
-            'Only target configured'                                         => [
-                'options'               => ['target' => $newFile],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => '*',
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => $newFile,
+            'Move to new directory with wildcard match' => [
+                'options'              => ['target_directory' => $newDirectory],
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => $newDirectory . '/' . self::TEST_FILE_NAME,
             ],
-            'Configured with target directory and filtering file path'       => [
-                'options'               => $newDir,
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => '*',
-                    'target'    => $newDir,
-                    'overwrite' => false,
-                    'randomize' => false,
+            'Match with single character wild'          => [
+                'options'              => [
+                    'match'     => self::getTempPath() . '/test_fil?.txt',
+                    'rename_to' => $newFileName,
                 ],
-                'expectedFilterResult'  => $newDirFile,
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => self::getTempPath() . '/' . $newFileName,
             ],
-            'Configured with array and filtering file path'                  => [
-                'options'               => ['source' => $oldFile, 'target' => $newDir],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => $oldFile,
-                    'target'    => $newDir,
-                    'overwrite' => false,
-                    'randomize' => false,
+            'Array of options'                          => [
+                'options'              => [
+                    [
+                        'match'            => $oldFilePath,
+                        'target_directory' => $newDirectory,
+                        'rename_to'        => $newFileName,
+                    ],
                 ],
-                'expectedFilterResult'  => $newDirFile,
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => $newDirectory . '/' . $newFileName,
             ],
-            'Configured with array wrapped in array and filtering file path' => [
-                'options'               => [0 => ['source' => $oldFile, 'target' => $newDir]],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => $oldFile,
-                    'target'    => $newDir,
-                    'overwrite' => false,
-                    'randomize' => false,
+            'Array of multiple options with one match'  => [
+                'options'              => [
+                    [
+                        'match'     => self::getTempPath() . '/no_match.txt',
+                        'rename_to' => 'failed_if_this.txt',
+                    ],
+                    [
+                        'match'            => $oldFilePath,
+                        'target_directory' => $newDirectory,
+                        'rename_to'        => $newFileName,
+                    ],
                 ],
-                'expectedFilterResult'  => $newDirFile,
-            ],
-            'Configured with only target and filtering file path'            => [
-                'options'               => ['target' => $newDir],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => '*',
-                    'target'    => $newDir,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => $newDirFile,
+                'input'                => $oldFilePath,
+                'expectedFilterResult' => $newDirectory . '/' . $newFileName,
             ],
         ];
     }
 
-    public static function returnInvalidFilterInputProvider(): array
-    {
-        $oldFile = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newFile = self::getTempPath() . '/new_file.xml';
-
-        return [
-            'Source file non-existent' => [
-                'options'               => $newFile,
-                'input'                 => 'non-existent-file.txt',
-                'expectedGetFileResult' => [
-                    'source'    => '*',
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => 'non-existent-file.txt',
-            ],
-            'Only source configured'   => [
-                'options'               => ['source' => $oldFile],
-                'input'                 => $oldFile,
-                'expectedGetFileResult' => [
-                    'source'    => $oldFile,
-                    'target'    => '*',
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-                'expectedFilterResult'  => $oldFile,
-            ],
-        ];
-    }
-
+    /**
+     * @param Options $options
+     */
     #[DataProvider('returnValidFilterInputProvider')]
-    #[DataProvider('returnInvalidFilterInputProvider')]
     public function testFilterValidPaths(
-        string|array $options,
-        string|array $input,
-        array $expectedGetFileResult,
-        string|array $expectedFilterResult
+        array $options,
+        string $input,
+        string $expectedFilterResult
     ): void {
         self::createSourceFile();
 
         $filter = new FileRename($options);
 
-        self::assertEquals([$expectedGetFileResult], $filter->getFile());
-
         try {
             self::assertSame($expectedFilterResult, $filter->filter($input));
+            self::assertFileExists($expectedFilterResult);
         } finally {
-            /** @var string $fileToRemove */
-            $fileToRemove = is_array($expectedFilterResult) ? $expectedFilterResult['tmp_name'] : $expectedFilterResult;
-
-            if (file_exists($fileToRemove)) {
-                unlink($fileToRemove);
+            if (file_exists($expectedFilterResult)) {
+                unlink($expectedFilterResult);
             }
         }
     }
 
-    public function testAddSameFileAgainAndOverwriteExistingTarget(): void
+    public static function returnInvalidFilterInputProvider(): array
+    {
+        $oldFilePath = self::getTempPath() . '/' . self::TEST_FILE_NAME;
+
+        return [
+            'Source file non-existent' => [
+                'options' => ['rename_to' => 'new_file.xml'],
+                'input'   => 'non-existent-file.txt',
+            ],
+            'Only match configured'    => [
+                'options' => ['match' => $oldFilePath],
+                'input'   => $oldFilePath,
+            ],
+        ];
+    }
+
+    /**
+     * @param Options $options
+     */
+    #[DataProvider('returnInvalidFilterInputProvider')]
+    public function testFilterInvalidPaths(
+        array $options,
+        string $input,
+    ): void {
+        self::createSourceFile();
+
+        $filter = new FileRename($options);
+
+        self::assertSame($input, $filter->filter($input));
+    }
+
+    public function testOverwriteTrue(): void
     {
         self::createSourceFile();
 
-        $oldFile = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newFile = self::getTempPath() . '/new_file.xml';
+        $oldFile         = self::getTempPath() . '/' . self::TEST_FILE_NAME;
+        $newFile         = 'new_file.xml';
+        $expectedNewPath = self::getTempPath() . '/' . $newFile;
 
-        $filter = new FileRename([
-            'source' => $oldFile,
-            'target' => '/to-be-overwritten.xml',
-        ]);
-
-        $filter->addFile([
-            'source' => $oldFile,
-            'target' => $newFile,
-        ]);
-
-        self::assertSame(
-            [
-                0 => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-            ],
-            $filter->getFile()
-        );
+        $filter = new FileRename(['rename_to' => $newFile, 'overwrite' => true]);
 
         try {
-            self::assertSame($newFile, $filter($oldFile));
+            self::assertSame($expectedNewPath, $filter->filter($oldFile));
+            self::assertFileExists($expectedNewPath);
+
+            self::createSourceFile();
+            self::assertSame($expectedNewPath, $filter->filter($oldFile));
+            self::assertFileExists($expectedNewPath);
         } finally {
-            if (file_exists($newFile)) {
-                unlink($newFile);
+            if (file_exists($expectedNewPath)) {
+                unlink($expectedNewPath);
             }
         }
     }
 
-    public function testGetNewName(): void
+    public function testOverwriteFalseThrowsExceptionWithPreExistingTarget(): void
     {
         self::createSourceFile();
 
-        $oldFile = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newDir  = self::getTempSubDirectory();
+        $oldFile         = self::getTempPath() . '/' . self::TEST_FILE_NAME;
+        $newFile         = 'new_file.xml';
+        $expectedNewPath = self::getTempPath() . '/' . $newFile;
 
-        $filter = new FileRename([
-            'source' => $oldFile,
-            'target' => $newDir,
-        ]);
-
-        self::assertSame(
-            [
-                0 => [
-                    'source'    => $oldFile,
-                    'target'    => $newDir,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-            ],
-            $filter->getFile()
-        );
-
-        self::assertSame($newDir . '/' . self::TEST_FILE_NAME, $filter->getNewName($oldFile));
-    }
-
-    public function testGetNewNameExceptionWithExistingFile(): void
-    {
-        self::createSourceFile();
-        $oldFile = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newFile = self::getTempPath() . '/new_file.xml';
-
-        $filter = new FileRename([
-            'source' => $oldFile,
-            'target' => $newFile,
-        ]);
-
-        copy($oldFile, $newFile);
-
-        self::assertSame(
-            [
-                0 => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-            ],
-            $filter->getFile()
-        );
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('could not be renamed');
+        $filter = new FileRename(['rename_to' => $newFile]);
 
         try {
-            self::assertSame($newFile, $filter->getNewName($oldFile));
+            self::assertSame($expectedNewPath, $filter->filter($oldFile));
+            self::assertFileExists($expectedNewPath);
+
+            self::createSourceFile();
+
+            $this->expectException(InvalidArgumentException::class);
+            $this->expectExceptionMessage(
+                sprintf(
+                    '"File "%s" could not be renamed to "%s"; target file already exists',
+                    $oldFile,
+                    $expectedNewPath
+                )
+            );
+
+            $filter->filter($oldFile);
         } finally {
-            if (file_exists($newFile)) {
-                unlink($newFile);
+            if (file_exists($expectedNewPath)) {
+                unlink($expectedNewPath);
             }
         }
-    }
-
-    public function testGetNewNameOverwriteWithExistingFile(): void
-    {
-        self::createSourceFile();
-        $oldFile = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newFile = self::getTempPath() . '/new_file.xml';
-
-        $filter = new FileRename([
-            'source'    => $oldFile,
-            'target'    => $newFile,
-            'overwrite' => true,
-        ]);
-
-        copy($oldFile, $newFile);
-
-        self::assertSame(
-            [
-                0 => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'overwrite' => true,
-                    'randomize' => false,
-                ],
-            ],
-            $filter->getFile()
-        );
-        self::assertSame($newFile, $filter->getNewName($oldFile));
     }
 
     public function testGetRandomizedFile(): void
     {
         self::createSourceFile();
         $oldFile = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newFile = self::getTempPath() . '/new_file.xml';
 
-        $filter = new FileRename([
-            'source'    => $oldFile,
-            'target'    => $newFile,
-            'randomize' => true,
-        ]);
+        $filter = new FileRename(['rename_to' => 'new_file.xml', 'randomize' => true]);
 
-        self::assertSame(
-            [
-                0 => [
-                    'source'    => $oldFile,
-                    'target'    => $newFile,
-                    'randomize' => true,
-                    'overwrite' => false,
-                ],
-            ],
-            $filter->getFile()
-        );
         $fileNoExt = self::getTempPath() . '/new_file';
-        self::assertMatchesRegularExpression(
-            '#' . preg_quote($fileNoExt) . '_.{13}\.xml#',
-            $filter->getNewName($oldFile)
-        );
+
+        try {
+            $result = $filter->filter($oldFile);
+
+            self::assertMatchesRegularExpression(
+                '#' . preg_quote($fileNoExt) . '_.{13}\.xml#',
+                $result
+            );
+        } finally {
+            if (isset($result) && file_exists($result)) {
+                unlink($result);
+            }
+        }
     }
 
     public function testGetRandomizedFileWithoutExtension(): void
     {
         self::createSourceFile();
-
         $oldFile   = self::getTempPath() . '/' . self::TEST_FILE_NAME;
         $fileNoExt = self::getTempPath() . '/new_file';
-        $filter    = new FileRename([
-            'source'    => $oldFile,
-            'target'    => $fileNoExt,
-            'randomize' => true,
-        ]);
 
-        self::assertSame(
-            [
-                0 => [
-                    'source'    => $oldFile,
-                    'target'    => $fileNoExt,
-                    'randomize' => true,
-                    'overwrite' => false,
-                ],
-            ],
-            $filter->getFile()
-        );
-        self::assertMatchesRegularExpression(
-            '#' . preg_quote($fileNoExt) . '_.{13}#',
-            $filter->getNewName($oldFile)
-        );
-    }
+        $filter = new FileRename(['rename_to' => 'new_file', 'randomize' => true]);
 
-    public function testAddFileWithString(): void
-    {
-        self::createSourceFile();
-
-        $oldFile = self::getTempPath() . '/' . self::TEST_FILE_NAME;
-        $newFile = self::getTempPath() . '/new_file.xml';
-
-        $filter = new FileRename($oldFile);
-        $filter->addFile($newFile);
-
-        self::assertSame(
-            [
-                0 => [
-                    'target'    => $newFile,
-                    'source'    => '*',
-                    'overwrite' => false,
-                    'randomize' => false,
-                ],
-            ],
-            $filter->getFile()
-        );
         try {
-            self::assertSame($newFile, $filter($oldFile));
+            $result = $filter->filter($oldFile);
+
+            self::assertMatchesRegularExpression(
+                '#' . preg_quote($fileNoExt) . '_.{13}#',
+                $result
+            );
         } finally {
-            if (file_exists($newFile)) {
-                unlink($newFile);
+            if (isset($result) && file_exists($result)) {
+                unlink($result);
             }
         }
-    }
-
-    public function testAddFileWithInvalidOption(): void
-    {
-        $filter = new FileRename('invalid');
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid options');
-        $filter->addFile(1234);
-    }
-
-    public function testInvalidConstruction(): void
-    {
-        $this->expectException(Exception\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Invalid options');
-        new FileRename(1234);
     }
 
     /** @return list<array{0: mixed}> */
@@ -515,12 +334,34 @@ final class RenameTest extends TestCase
     }
 
     #[DataProvider('returnUnfilteredDataProvider')]
-    public function testReturnUnfiltered(mixed $input): void
+    public function testInvalidFilterInputIsReturnedUnprocessed(mixed $input): void
     {
         self::createSourceFile();
 
-        $filter = new FileRename(self::getTempPath() . '/new_file.xml');
+        $filter = new FileRename(['rename_to' => 'new_file.xml']);
 
         self::assertSame($input, $filter($input));
+    }
+
+    public function testTargetIsNotADirectory(): void
+    {
+        $targetDirectory = self::getTempPath() . '/not-a-directory';
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The target directory "%s" does not exist', $targetDirectory));
+
+        new FileRename(['target_directory' => $targetDirectory]);
+    }
+
+    public function testTargetDirectoryIsNotWritable(): void
+    {
+        $targetDirectory = self::getTempPath() . '/not-writable';
+
+        mkdir($targetDirectory, 0555);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf('The target directory "%s" is not writable', $targetDirectory));
+
+        new FileRename(['target_directory' => $targetDirectory]);
     }
 }


### PR DESCRIPTION

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description

Refactoring for #177 

I had a couple of questions around the intent for v3;
* I'm assuming removal of getFile and setFile, but wanted to check if we're also removing addFile
* Currently the input for addFile can be a string, or array of `target, etc`, or an array of arrays of `target, etc`. Which of these do we want to support going forward?
