### PR TITLE
Drop Support for PHP 8.1, Upgrade Psalm to v6 & PHPUnit to v11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
             "composer/package-versions-deprecated": true
         },
         "platform": {
-            "php": "8.1.99"
+            "php": "8.2.99"
         }
     },
     "extra": {
@@ -32,7 +32,7 @@
         }
     },
     "require": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-mbstring": "*",
         "laminas/laminas-servicemanager": "^4.1.0",
         "laminas/laminas-stdlib": "^3.19.0",
@@ -43,10 +43,10 @@
         "laminas/laminas-diactoros": "^3.5",
         "pear/archive_tar": "^1.5.0",
         "pear/pear": "^1.10.16",
-        "phpunit/phpunit": "^10.5.40",
-        "psalm/plugin-phpunit": "^0.19.0",
+        "phpunit/phpunit": "^11.5.3",
+        "psalm/plugin-phpunit": "^0.19.2",
         "psr/http-factory": "^1.1.0",
-        "vimeo/psalm": "^5.26.1"
+        "vimeo/psalm": "^6.0.0"
     },
     "conflict": {
         "laminas/laminas-validator": "<2.10.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,30 +4,30 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f84772d7b2906b1ef52d7cc40e87eb06",
+    "content-hash": "fc1b70d7aff12a1a709f941e42c93611",
     "packages": [
         {
             "name": "brick/varexporter",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/varexporter.git",
-                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
+                "reference": "84b2a7a91f69aa5d079aec5a0a7256ebf2dceb6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
-                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/84b2a7a91f69aa5d079aec5a0a7256ebf2dceb6b",
+                "reference": "84b2a7a91f69aa5d079aec5a0a7256ebf2dceb6b",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.0",
+                "nikic/php-parser": "^5.0",
                 "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.2",
-                "phpunit/phpunit": "^8.5 || ^9.0",
-                "vimeo/psalm": "5.15.0"
+                "phpunit/phpunit": "^9.3",
+                "psalm/phar": "5.21.1"
             },
             "type": "library",
             "autoload": {
@@ -45,7 +45,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/varexporter/issues",
-                "source": "https://github.com/brick/varexporter/tree/0.4.0"
+                "source": "https://github.com/brick/varexporter/tree/0.5.0"
             },
             "funding": [
                 {
@@ -53,7 +53,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-01T21:10:07+00:00"
+            "time": "2024-05-10T17:15:19+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -203,25 +203,27 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.4",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2"
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/715f4d25e225bc47b293a8b997fe6ce99bf987d2",
-                "reference": "715f4d25e225bc47b293a8b997fe6ce99bf987d2",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
+                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -229,7 +231,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -253,9 +255,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
             },
-            "time": "2024-09-29T15:01:53+00:00"
+            "time": "2024-12-30T11:07:19+00:00"
         },
         {
             "name": "psr/container",
@@ -367,43 +369,36 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.6.4",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d"
+                "reference": "7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
-                "reference": "ded3d9be08f526089eb7ee8d9f16a9768f9dec2d",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9",
+                "reference": "7cf7fef3d667bfe4b2560bc87e67d5387a7bcde9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "amphp/phpunit-util": "^1",
-                "ext-json": "*",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^7 | ^8 | ^9",
-                "react/promise": "^2",
-                "vimeo/psalm": "^3.12"
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.x-dev"
-                }
-            },
             "autoload": {
                 "files": [
-                    "lib/functions.php",
-                    "lib/Internal/functions.php"
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
                 ],
                 "psr-4": {
-                    "Amp\\": "lib"
+                    "Amp\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -411,10 +406,6 @@
                 "MIT"
             ],
             "authors": [
-                {
-                    "name": "Daniel Lowrey",
-                    "email": "rdlowrey@php.net"
-                },
                 {
                     "name": "Aaron Piotrowski",
                     "email": "aaron@trowski.com"
@@ -426,6 +417,10 @@
                 {
                     "name": "Niklas Keller",
                     "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
                 }
             ],
             "description": "A non-blocking concurrency framework for PHP applications.",
@@ -442,9 +437,8 @@
                 "promise"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/amphp",
                 "issues": "https://github.com/amphp/amp/issues",
-                "source": "https://github.com/amphp/amp/tree/v2.6.4"
+                "source": "https://github.com/amphp/amp/tree/v3.1.0"
             },
             "funding": [
                 {
@@ -452,41 +446,45 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-21T18:52:26+00:00"
+            "time": "2025-01-26T16:07:39+00:00"
         },
         {
             "name": "amphp/byte-stream",
-            "version": "v1.8.2",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/byte-stream.git",
-                "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc"
+                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/4f0e968ba3798a423730f567b1b50d3441c16ddc",
-                "reference": "4f0e968ba3798a423730f567b1b50d3441c16ddc",
+                "url": "https://api.github.com/repos/amphp/byte-stream/zipball/daa00f2efdbd71565bf64ffefa89e37542addf93",
+                "reference": "daa00f2efdbd71565bf64ffefa89e37542addf93",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2",
-                "php": ">=7.1"
+                "amphp/amp": "^3",
+                "amphp/parser": "^1.1",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "amphp/sync": "^2",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2.3"
             },
             "require-dev": {
-                "amphp/php-cs-fixer-config": "dev-master",
-                "amphp/phpunit-util": "^1.4",
-                "friendsofphp/php-cs-fixer": "^2.3",
-                "jetbrains/phpstorm-stubs": "^2019.3",
-                "phpunit/phpunit": "^6 || ^7 || ^8",
-                "psalm/phar": "^3.11.4"
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.22.1"
             },
             "type": "library",
             "autoload": {
                 "files": [
-                    "lib/functions.php"
+                    "src/functions.php",
+                    "src/Internal/functions.php"
                 ],
                 "psr-4": {
-                    "Amp\\ByteStream\\": "lib"
+                    "Amp\\ByteStream\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -515,7 +513,7 @@
             ],
             "support": {
                 "issues": "https://github.com/amphp/byte-stream/issues",
-                "source": "https://github.com/amphp/byte-stream/tree/v1.8.2"
+                "source": "https://github.com/amphp/byte-stream/tree/v2.1.1"
             },
             "funding": [
                 {
@@ -523,7 +521,269 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-04-13T18:00:56+00:00"
+            "time": "2024-02-17T04:49:38+00:00"
+        },
+        {
+            "name": "amphp/parser",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/parser.git",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/parser/zipball/3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "reference": "3cf1f8b32a0171d4b1bed93d25617637a77cded7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Parser\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "A generator parser to make streaming parsers simple.",
+            "homepage": "https://github.com/amphp/parser",
+            "keywords": [
+                "async",
+                "non-blocking",
+                "parser",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/parser/issues",
+                "source": "https://github.com/amphp/parser/tree/v1.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-21T19:16:53+00:00"
+        },
+        {
+            "name": "amphp/pipeline",
+            "version": "v1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/pipeline.git",
+                "reference": "97cbf289f4d8877acfe58dd90ed5a4370a43caa4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/pipeline/zipball/97cbf289f4d8877acfe58dd90ed5a4370a43caa4",
+                "reference": "97cbf289f4d8877acfe58dd90ed5a4370a43caa4",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.18"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Amp\\Pipeline\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Asynchronous iterators and operators.",
+            "homepage": "https://amphp.org/pipeline",
+            "keywords": [
+                "amp",
+                "amphp",
+                "async",
+                "io",
+                "iterator",
+                "non-blocking"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/pipeline/issues",
+                "source": "https://github.com/amphp/pipeline/tree/v1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-19T15:42:46+00:00"
+        },
+        {
+            "name": "amphp/serialization",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/serialization.git",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/serialization/zipball/693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "reference": "693e77b2fb0b266c3c7d622317f881de44ae94a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "dev-master",
+                "phpunit/phpunit": "^9 || ^8 || ^7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Serialization\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Serialization tools for IPC and data storage in PHP.",
+            "homepage": "https://github.com/amphp/serialization",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "serialization",
+                "serialize"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/serialization/issues",
+                "source": "https://github.com/amphp/serialization/tree/master"
+            },
+            "time": "2020-03-25T21:39:07+00:00"
+        },
+        {
+            "name": "amphp/sync",
+            "version": "v2.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/sync.git",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/sync/zipball/217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "reference": "217097b785130d77cfcc58ff583cf26cd1770bf1",
+                "shasum": ""
+            },
+            "require": {
+                "amphp/amp": "^3",
+                "amphp/pipeline": "^1",
+                "amphp/serialization": "^1",
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "amphp/phpunit-util": "^3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "5.23"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\Sync\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Stephen Coakley",
+                    "email": "me@stephencoakley.com"
+                }
+            ],
+            "description": "Non-blocking synchronization primitives for PHP based on Amp and Revolt.",
+            "homepage": "https://github.com/amphp/sync",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "mutex",
+                "semaphore",
+                "synchronization"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/sync/issues",
+                "source": "https://github.com/amphp/sync/tree/v2.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-03T19:31:26+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -2069,35 +2329,35 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.16",
+            "version": "11.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+                "reference": "418c59fd080954f8c4aa5631d9502ecda2387118"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
-                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/418c59fd080954f8c4aa5631d9502ecda2387118",
+                "reference": "418c59fd080954f8c4aa5631d9502ecda2387118",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.19.1 || ^5.1.0",
-                "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "sebastian/code-unit-reverse-lookup": "^3.0.0",
-                "sebastian/complexity": "^3.2.0",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/lines-of-code": "^2.0.2",
-                "sebastian/version": "^4.0.1",
+                "nikic/php-parser": "^5.3.1",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.0",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
                 "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.1"
+                "phpunit/phpunit": "^11.5.0"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -2106,7 +2366,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1.x-dev"
+                    "dev-main": "11.0.x-dev"
                 }
             },
             "autoload": {
@@ -2135,7 +2395,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.8"
             },
             "funding": [
                 {
@@ -2143,32 +2403,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-22T04:31:57+00:00"
+            "time": "2024-12-11T12:34:27+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "4.1.0",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
-                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/118cfaaa8bc5aef3287bf315b6060b1174754af6",
+                "reference": "118cfaaa8bc5aef3287bf315b6060b1174754af6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2196,7 +2456,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.0"
             },
             "funding": [
                 {
@@ -2204,28 +2464,28 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T06:24:48+00:00"
+            "time": "2024-08-27T05:02:59+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "4.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
-                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -2233,7 +2493,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -2259,7 +2519,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
             },
             "funding": [
                 {
@@ -2267,32 +2528,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:56:09+00:00"
+            "time": "2024-07-03T05:07:44+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "3.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
-                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2319,7 +2580,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2327,32 +2588,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-08-31T14:07:24+00:00"
+            "time": "2024-07-03T05:08:43+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "6.0.0",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
-                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -2378,7 +2639,8 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
             },
             "funding": [
                 {
@@ -2386,20 +2648,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:57:52+00:00"
+            "time": "2024-07-03T05:09:35+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.40",
+            "version": "11.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c"
+                "reference": "30e319e578a7b5da3543073e30002bf82042f701"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e6ddda95af52f69c1e0c7b4f977cccb58048798c",
-                "reference": "e6ddda95af52f69c1e0c7b4f977cccb58048798c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/30e319e578a7b5da3543073e30002bf82042f701",
+                "reference": "30e319e578a7b5da3543073e30002bf82042f701",
                 "shasum": ""
             },
             "require": {
@@ -2412,23 +2674,23 @@
                 "myclabs/deep-copy": "^1.12.1",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.16",
-                "phpunit/php-file-iterator": "^4.1.0",
-                "phpunit/php-invoker": "^4.0.0",
-                "phpunit/php-text-template": "^3.0.1",
-                "phpunit/php-timer": "^6.0.0",
-                "sebastian/cli-parser": "^2.0.1",
-                "sebastian/code-unit": "^2.0.0",
-                "sebastian/comparator": "^5.0.3",
-                "sebastian/diff": "^5.1.1",
-                "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.2",
-                "sebastian/global-state": "^6.0.2",
-                "sebastian/object-enumerator": "^5.0.0",
-                "sebastian/recursion-context": "^5.0.0",
-                "sebastian/type": "^4.0.0",
-                "sebastian/version": "^4.0.1"
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.8",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.2",
+                "sebastian/comparator": "^6.3.0",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.0",
+                "sebastian/exporter": "^6.3.0",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/type": "^5.1.0",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
             },
             "suggest": {
                 "ext-soap": "To be able to generate mocks based on WSDL files"
@@ -2439,7 +2701,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.5-dev"
+                    "dev-main": "11.5-dev"
                 }
             },
             "autoload": {
@@ -2471,7 +2733,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.40"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.3"
             },
             "funding": [
                 {
@@ -2487,28 +2749,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-21T05:49:06+00:00"
+            "time": "2025-01-13T09:36:00+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
-            "version": "0.19.0",
+            "version": "0.19.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/psalm/psalm-plugin-phpunit.git",
-                "reference": "e344eaaa27871e79c6cb97b9efe52a735f9d1966"
+                "reference": "7b7a5cde988f83ccdbdf3ebaecd88192e01c5eb1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/e344eaaa27871e79c6cb97b9efe52a735f9d1966",
-                "reference": "e344eaaa27871e79c6cb97b9efe52a735f9d1966",
+                "url": "https://api.github.com/repos/psalm/psalm-plugin-phpunit/zipball/7b7a5cde988f83ccdbdf3ebaecd88192e01c5eb1",
+                "reference": "7b7a5cde988f83ccdbdf3ebaecd88192e01c5eb1",
                 "shasum": ""
             },
             "require": {
                 "composer/package-versions-deprecated": "^1.10",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "ext-simplexml": "*",
-                "php": "^7.4 || ^8.0",
-                "vimeo/psalm": "dev-master || ^5@beta || ^5.0"
+                "php": ">=8.1",
+                "vimeo/psalm": "dev-master || ^6"
             },
             "conflict": {
                 "phpunit/phpunit": "<7.5"
@@ -2545,9 +2807,9 @@
             "description": "Psalm plugin for PHPUnit",
             "support": {
                 "issues": "https://github.com/psalm/psalm-plugin-phpunit/issues",
-                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.0"
+                "source": "https://github.com/psalm/psalm-plugin-phpunit/tree/0.19.2"
             },
-            "time": "2024-03-15T10:43:15+00:00"
+            "time": "2025-01-26T11:39:17+00:00"
         },
         {
             "name": "psr/http-factory",
@@ -2655,29 +2917,101 @@
             "time": "2024-09-11T13:17:53+00:00"
         },
         {
-            "name": "sebastian/cli-parser",
-            "version": "2.0.1",
+            "name": "revolt/event-loop",
+            "version": "v1.0.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
-                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/25de49af7223ba039f64da4ae9a28ec2d10d0254",
+                "reference": "25de49af7223ba039f64da4ae9a28ec2d10d0254",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.6"
+            },
+            "time": "2023-11-30T05:34:44+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2701,7 +3035,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
             },
             "funding": [
                 {
@@ -2709,32 +3043,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:12:49+00:00"
+            "time": "2024-07-03T04:41:36+00:00"
         },
         {
             "name": "sebastian/code-unit",
-            "version": "2.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+                "reference": "ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
-                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca",
+                "reference": "ee88b0cdbe74cf8dd3b54940ff17643c0d6543ca",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -2757,7 +3091,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.2"
             },
             "funding": [
                 {
@@ -2765,32 +3100,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:58:43+00:00"
+            "time": "2024-12-12T09:59:06+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
-                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2812,7 +3147,8 @@
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2820,36 +3156,39 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T06:59:15+00:00"
+            "time": "2024-07-03T04:45:54+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "5.0.3",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e"
+                "reference": "d4e47a769525c4dd38cea90e5dcd435ddbbc7115"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
-                "reference": "a18251eb0b7a2dcd2f7aa3d6078b18545ef0558e",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/d4e47a769525c4dd38cea90e5dcd435ddbbc7115",
+                "reference": "d4e47a769525c4dd38cea90e5dcd435ddbbc7115",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/diff": "^5.0",
-                "sebastian/exporter": "^5.0"
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.5"
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.2-dev"
                 }
             },
             "autoload": {
@@ -2889,7 +3228,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.0"
             },
             "funding": [
                 {
@@ -2897,33 +3236,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-18T14:56:07+00:00"
+            "time": "2025-01-06T10:28:19+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "3.2.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
-                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.2-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -2947,7 +3286,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
             },
             "funding": [
                 {
@@ -2955,33 +3294,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:37:17+00:00"
+            "time": "2024-07-03T04:49:50+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "5.1.1",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
-                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0",
-                "symfony/process": "^6.4"
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3014,7 +3353,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
             },
             "funding": [
                 {
@@ -3022,27 +3361,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:15:17+00:00"
+            "time": "2024-07-03T04:53:05+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "6.1.0",
+            "version": "7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+                "reference": "855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
-                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5",
+                "reference": "855f3ae0ab316bbafe1ba4e16e9f3c078d24a0c5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -3050,7 +3389,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.1-dev"
+                    "dev-main": "7.2-dev"
                 }
             },
             "autoload": {
@@ -3078,7 +3417,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.0"
             },
             "funding": [
                 {
@@ -3086,34 +3425,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-23T08:47:14+00:00"
+            "time": "2024-07-03T04:54:44+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.2",
+            "version": "6.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
+                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/3473f61172093b2da7de1fb5782e1f24cc036dc3",
+                "reference": "3473f61172093b2da7de1fb5782e1f24cc036dc3",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.1",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.1-dev"
                 }
             },
             "autoload": {
@@ -3156,7 +3495,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.0"
             },
             "funding": [
                 {
@@ -3164,35 +3503,35 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:17:12+00:00"
+            "time": "2024-12-05T09:17:50+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "6.0.2",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
-                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3218,7 +3557,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
             },
             "funding": [
                 {
@@ -3226,33 +3565,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-02T07:19:19+00:00"
+            "time": "2024-07-03T04:57:36+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "2.0.2",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
-                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.18 || ^5.0",
-                "php": ">=8.1"
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.0-dev"
+                    "dev-main": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3276,7 +3615,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
             },
             "funding": [
                 {
@@ -3284,34 +3623,34 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-12-21T08:38:20+00:00"
+            "time": "2024-07-03T04:58:38+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "5.0.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
-                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "sebastian/object-reflector": "^3.0",
-                "sebastian/recursion-context": "^5.0"
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3333,7 +3672,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -3341,32 +3681,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:08:32+00:00"
+            "time": "2024-07-03T05:00:13+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "3.0.0",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
-                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -3388,7 +3728,8 @@
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
             },
             "funding": [
                 {
@@ -3396,32 +3737,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:06:18+00:00"
+            "time": "2024-07-03T05:01:32+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.0",
+            "version": "6.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
+                "reference": "694d156164372abbd149a4b85ccda2e4670c0e16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/694d156164372abbd149a4b85ccda2e4670c0e16",
+                "reference": "694d156164372abbd149a4b85ccda2e4670c0e16",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3451,7 +3792,8 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.2"
             },
             "funding": [
                 {
@@ -3459,32 +3801,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:05:40+00:00"
+            "time": "2024-07-03T05:10:34+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "4.0.0",
+            "version": "5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+                "reference": "461b9c5da241511a2a0e8f240814fb23ce5c0aac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
-                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/461b9c5da241511a2a0e8f240814fb23ce5c0aac",
+                "reference": "461b9c5da241511a2a0e8f240814fb23ce5c0aac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^11.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.1-dev"
                 }
             },
             "autoload": {
@@ -3507,7 +3849,8 @@
             "homepage": "https://github.com/sebastianbergmann/type",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
-                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.0"
             },
             "funding": [
                 {
@@ -3515,29 +3858,29 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-03T07:10:45+00:00"
+            "time": "2024-09-17T13:12:04+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "4.0.1",
+            "version": "5.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
-                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -3560,7 +3903,8 @@
             "homepage": "https://github.com/sebastianbergmann/version",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
-                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
             },
             "funding": [
                 {
@@ -3568,7 +3912,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-02-07T11:34:05+00:00"
+            "time": "2024-10-09T05:16:32+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -3705,16 +4049,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.2",
+            "version": "3.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079"
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1368f4a58c3c52114b86b1abe8f4098869cb0079",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
                 "shasum": ""
             },
             "require": {
@@ -3779,53 +4123,108 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-12-11T16:04:26+00:00"
+            "time": "2025-01-23T17:04:15+00:00"
         },
         {
-            "name": "symfony/console",
-            "version": "v6.4.17",
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/console.git",
-                "reference": "799445db3f15768ecc382ac5699e6da0520a0a04"
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/799445db3f15768ecc382ac5699e6da0520a0a04",
-                "reference": "799445db3f15768ecc382ac5699e6da0520a0a04",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "reference": "fefcc18c0f5d0efe3ab3152f15857298868dc2c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^5.4|^6.0|^7.0"
+                "symfony/string": "^6.4|^7.0"
             },
             "conflict": {
-                "symfony/dependency-injection": "<5.4",
-                "symfony/dotenv": "<5.4",
-                "symfony/event-dispatcher": "<5.4",
-                "symfony/lock": "<5.4",
-                "symfony/process": "<5.4"
+                "symfony/dependency-injection": "<6.4",
+                "symfony/dotenv": "<6.4",
+                "symfony/event-dispatcher": "<6.4",
+                "symfony/lock": "<6.4",
+                "symfony/process": "<6.4"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/dependency-injection": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
                 "symfony/http-foundation": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/lock": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/process": "^5.4|^6.0|^7.0",
-                "symfony/stopwatch": "^5.4|^6.0|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+                "symfony/lock": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/process": "^6.4|^7.0",
+                "symfony/stopwatch": "^6.4|^7.0",
+                "symfony/var-dumper": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -3859,7 +4258,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.17"
+                "source": "https://github.com/symfony/console/tree/v7.2.1"
             },
             "funding": [
                 {
@@ -3875,7 +4274,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-07T12:07:30+00:00"
+            "time": "2024-12-11T03:49:26+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -3946,25 +4345,25 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.13",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "4856c9cf585d5a0313d8d35afd681a526f038dd3"
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/4856c9cf585d5a0313d8d35afd681a526f038dd3",
-                "reference": "4856c9cf585d5a0313d8d35afd681a526f038dd3",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
+                "reference": "b8dce482de9d7c9fe2891155035a7248ab5c7fdb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-mbstring": "~1.8"
             },
             "require-dev": {
-                "symfony/process": "^5.4|^6.4|^7.0"
+                "symfony/process": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -3992,7 +4391,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.13"
+                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -4008,7 +4407,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-25T15:07:50+00:00"
+            "time": "2024-10-25T15:15:23+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4413,20 +4812,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.15",
+            "version": "v7.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f"
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/446e0d146f991dde3e73f45f2c97a9faad773c82",
+                "reference": "446e0d146f991dde3e73f45f2c97a9faad773c82",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -4436,11 +4835,12 @@
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
-                "symfony/http-client": "^5.4|^6.0|^7.0",
-                "symfony/intl": "^6.2|^7.0",
+                "symfony/emoji": "^7.1",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/http-client": "^6.4|^7.0",
+                "symfony/intl": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^5.4|^6.0|^7.0"
+                "symfony/var-exporter": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -4479,7 +4879,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.15"
+                "source": "https://github.com/symfony/string/tree/v7.2.0"
             },
             "funding": [
                 {
@@ -4495,7 +4895,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T13:31:12+00:00"
+            "time": "2024-11-13T13:31:26+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4549,21 +4949,21 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "5.26.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "d747f6500b38ac4f7dfc5edbcae6e4b637d7add0"
+                "reference": "b8e96bb617bf59382113b1b56cef751f648a7dc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/d747f6500b38ac4f7dfc5edbcae6e4b637d7add0",
-                "reference": "d747f6500b38ac4f7dfc5edbcae6e4b637d7add0",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/b8e96bb617bf59382113b1b56cef751f648a7dc9",
+                "reference": "b8e96bb617bf59382113b1b56cef751f648a7dc9",
                 "shasum": ""
             },
             "require": {
-                "amphp/amp": "^2.4.2",
-                "amphp/byte-stream": "^1.5",
+                "amphp/amp": "^3",
+                "amphp/byte-stream": "^2",
                 "composer-runtime-api": "^2",
                 "composer/semver": "^1.4 || ^2.0 || ^3.0",
                 "composer/xdebug-handler": "^2.0 || ^3.0",
@@ -4576,26 +4976,24 @@
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "felixfbecker/advanced-json-rpc": "^3.1",
-                "felixfbecker/language-server-protocol": "^1.5.2",
+                "felixfbecker/language-server-protocol": "^1.5.3",
                 "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
                 "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-                "nikic/php-parser": "^4.17",
-                "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
+                "nikic/php-parser": "^5.0.0",
+                "php": "~8.1.17 || ~8.2.4 || ~8.3.0 || ~8.4.0",
                 "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
                 "spatie/array-to-xml": "^2.17.0 || ^3.0",
                 "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",
                 "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"
             },
-            "conflict": {
-                "nikic/php-parser": "4.17.0"
-            },
             "provide": {
                 "psalm/psalm": "self.version"
             },
             "require-dev": {
-                "amphp/phpunit-util": "^2.0",
+                "amphp/phpunit-util": "^3",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "brianium/paratest": "^6.9",
+                "dg/bypass-finals": "^1.5",
                 "ext-curl": "*",
                 "mockery/mockery": "^1.5",
                 "nunomaduro/mock-final-classes": "^1.1",
@@ -4603,7 +5001,7 @@
                 "phpstan/phpdoc-parser": "^1.6",
                 "phpunit/phpunit": "^9.6",
                 "psalm/plugin-mockery": "^1.1",
-                "psalm/plugin-phpunit": "^0.18",
+                "psalm/plugin-phpunit": "^0.19",
                 "slevomat/coding-standard": "^8.4",
                 "squizlabs/php_codesniffer": "^3.6",
                 "symfony/process": "^4.4 || ^5.0 || ^6.0 || ^7.0"
@@ -4626,7 +5024,9 @@
                     "dev-2.x": "2.x-dev",
                     "dev-3.x": "3.x-dev",
                     "dev-4.x": "4.x-dev",
-                    "dev-master": "5.x-dev"
+                    "dev-5.x": "5.x-dev",
+                    "dev-6.x": "6.x-dev",
+                    "dev-master": "7.x-dev"
                 }
             },
             "autoload": {
@@ -4655,7 +5055,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2024-09-08T18:53:08+00:00"
+            "time": "2025-01-26T12:03:19+00:00"
         },
         {
             "name": "webimpress/coding-standard",
@@ -4777,12 +5177,12 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0",
+        "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
         "ext-mbstring": "*"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "8.1.99"
+        "php": "8.2.99"
     },
     "plugin-api-version": "2.6.0"
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.26.1@d747f6500b38ac4f7dfc5edbcae6e4b637d7add0">
+<files psalm-version="6.0.0@b8e96bb617bf59382113b1b56cef751f648a7dc9">
   <file src="src/AbstractFilter.php">
     <InvalidPropertyAssignmentValue>
       <code><![CDATA[[]]]></code>
@@ -54,12 +54,12 @@
       <code><![CDATA[$value]]></code>
       <code><![CDATA[$value]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[string]]></code>
-    </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$file['target']]]></code>
     </MixedReturnStatement>
+    <PossiblyFalseArgument>
+      <code><![CDATA[realpath($file['target'])]]></code>
+    </PossiblyFalseArgument>
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$files['source']]]></code>
       <code><![CDATA[$rename['randomize']]]></code>
@@ -125,11 +125,6 @@
       <code><![CDATA[$sourceFile]]></code>
       <code><![CDATA[$sourceFile]]></code>
     </MixedAssignment>
-    <MixedInferredReturnType>
-      <code><![CDATA[UploadedFileInterface]]></code>
-      <code><![CDATA[array<string, string>]]></code>
-      <code><![CDATA[string]]></code>
-    </MixedInferredReturnType>
     <MixedReturnStatement>
       <code><![CDATA[$this->alreadyFiltered[$alreadyFilteredKey]]]></code>
       <code><![CDATA[$this->alreadyFiltered[$fileName]]]></code>
@@ -178,20 +173,6 @@
     <UnusedClass>
       <code><![CDATA[Module]]></code>
     </UnusedClass>
-  </file>
-  <file src="src/Word/SeparatorToCamelCase.php">
-    <MissingClosureParamType>
-      <code><![CDATA[$matches]]></code>
-      <code><![CDATA[$matches]]></code>
-    </MissingClosureParamType>
-    <MixedArgument>
-      <code><![CDATA[$matches[1]]]></code>
-      <code><![CDATA[$matches[2]]]></code>
-    </MixedArgument>
-    <MixedArrayAccess>
-      <code><![CDATA[$matches[1]]]></code>
-      <code><![CDATA[$matches[2]]]></code>
-    </MixedArrayAccess>
   </file>
   <file src="test/DenyListTest.php">
     <MixedArrayAccess>

--- a/src/AllowList.php
+++ b/src/AllowList.php
@@ -16,11 +16,11 @@ use function in_array;
  * }
  * @implements FilterInterface<null>
  */
-final class AllowList implements FilterInterface
+final readonly class AllowList implements FilterInterface
 {
-    private readonly bool $strict;
+    private bool $strict;
     /** @var list<mixed> */
-    private readonly array $list;
+    private array $list;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/BaseName.php
+++ b/src/BaseName.php
@@ -11,7 +11,7 @@ use function is_string;
  * @psalm-immutable
  * @implements FilterInterface<string>
  */
-final class BaseName implements FilterInterface
+final readonly class BaseName implements FilterInterface
 {
     /**
      * Returns basename($value).

--- a/src/Boolean.php
+++ b/src/Boolean.php
@@ -32,7 +32,7 @@ use function strtolower;
  * }
  * @implements FilterInterface<bool>
  */
-final class Boolean implements FilterInterface
+final readonly class Boolean implements FilterInterface
 {
     public const TYPE_BOOLEAN      = 1;
     public const TYPE_INTEGER      = 2;
@@ -61,7 +61,7 @@ final class Boolean implements FilterInterface
     ];
 
     /** @var Options */
-    private readonly array $options;
+    private array $options;
 
     /**
      * @param OptionsArgument $options

--- a/src/Callback.php
+++ b/src/Callback.php
@@ -16,11 +16,11 @@ use function is_callable;
  * }
  * @implements FilterInterface<mixed>
  */
-final class Callback implements FilterInterface
+final readonly class Callback implements FilterInterface
 {
     /** @var Closure(mixed): mixed */
-    private readonly Closure $callback;
-    private readonly array $arguments;
+    private Closure $callback;
+    private array $arguments;
 
     /**
      * @param (callable(mixed): mixed)|Options $options

--- a/src/Compress/Bz2Adapter.php
+++ b/src/Compress/Bz2Adapter.php
@@ -58,8 +58,8 @@ final class Bz2Adapter implements StringCompressionAdapterInterface
     {
         $decompressed = bzdecompress($value);
 
-        if (is_int($decompressed)) {
-            throw new RuntimeException(sprintf('Error during decompression: Bz Error code %d', $decompressed));
+        if (is_int($decompressed) || $decompressed === false) {
+            throw new RuntimeException(sprintf('Error during decompression: Bz Error code %d', (int) $decompressed));
         }
 
         assert($decompressed !== '');

--- a/src/CompressString.php
+++ b/src/CompressString.php
@@ -18,9 +18,9 @@ use function strtolower;
  * }
  * @implements FilterInterface<string>
  */
-final class CompressString implements FilterInterface
+final readonly class CompressString implements FilterInterface
 {
-    private readonly StringCompressionAdapterInterface $adapter;
+    private StringCompressionAdapterInterface $adapter;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/CompressToArchive.php
+++ b/src/CompressToArchive.php
@@ -21,13 +21,13 @@ use function is_string;
  * }
  * @implements FilterInterface<non-empty-string>
  */
-final class CompressToArchive implements FilterInterface
+final readonly class CompressToArchive implements FilterInterface
 {
-    private readonly ArchiveAdapterInterface $adapter;
+    private ArchiveAdapterInterface $adapter;
     /** @var non-empty-string */
-    private readonly string $archive;
+    private string $archive;
     /** @var non-empty-string|null */
-    private readonly string|null $fileName;
+    private string|null $fileName;
 
     /** @param Options $options */
     public function __construct(array $options)

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -9,7 +9,7 @@ use Laminas\ServiceManager\ServiceManager;
 /**
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
-final class ConfigProvider
+final readonly class ConfigProvider
 {
     /**
      * Return configuration for this component.

--- a/src/DataUnitFormatter.php
+++ b/src/DataUnitFormatter.php
@@ -19,7 +19,7 @@ use function sprintf;
  * }
  * @implements FilterInterface<string>
  */
-final class DataUnitFormatter implements FilterInterface
+final readonly class DataUnitFormatter implements FilterInterface
 {
     public const MODE_BINARY  = 'binary';
     public const MODE_DECIMAL = 'decimal';
@@ -43,9 +43,9 @@ final class DataUnitFormatter implements FilterInterface
     ];
 
     /** @var self::MODE_DECIMAL|self::MODE_BINARY */
-    private readonly string $mode;
+    private string $mode;
     /** @var positive-int */
-    private readonly int $precision;
+    private int $precision;
 
     /**
      * @param Options $options

--- a/src/DateSelect.php
+++ b/src/DateSelect.php
@@ -17,10 +17,10 @@ use function sprintf;
  * }
  * @implements FilterInterface<string|null>
  */
-final class DateSelect implements FilterInterface
+final readonly class DateSelect implements FilterInterface
 {
-    private readonly bool $returnNullIfAnyFieldEmpty;
-    private readonly bool $returnNullIfAllFieldsEmpty;
+    private bool $returnNullIfAnyFieldEmpty;
+    private bool $returnNullIfAllFieldsEmpty;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/DateTimeFormatter.php
+++ b/src/DateTimeFormatter.php
@@ -21,17 +21,17 @@ use function is_string;
  * }
  * @implements FilterInterface<string>
  */
-final class DateTimeFormatter implements FilterInterface
+final readonly class DateTimeFormatter implements FilterInterface
 {
     /**
      * A valid format string accepted by date()
      */
-    private readonly string $format;
+    private string $format;
 
     /**
      * A valid timezone string
      */
-    private readonly DateTimeZone $timezone;
+    private DateTimeZone $timezone;
 
     /**
      * @param Options $options

--- a/src/DateTimeSelect.php
+++ b/src/DateTimeSelect.php
@@ -17,10 +17,10 @@ use function sprintf;
  * }
  * @implements FilterInterface<string|null>
  */
-final class DateTimeSelect implements FilterInterface
+final readonly class DateTimeSelect implements FilterInterface
 {
-    private readonly bool $returnNullIfAnyFieldEmpty;
-    private readonly bool $returnNullIfAllFieldsEmpty;
+    private bool $returnNullIfAnyFieldEmpty;
+    private bool $returnNullIfAllFieldsEmpty;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/DecompressArchive.php
+++ b/src/DecompressArchive.php
@@ -22,10 +22,10 @@ use function is_writable;
  * }
  * @implements FilterInterface<non-empty-string>
  */
-final class DecompressArchive implements FilterInterface
+final readonly class DecompressArchive implements FilterInterface
 {
     /** @var non-empty-string */
-    private readonly string $target;
+    private string $target;
     private ArchiveAdapterResolverInterface $matcher;
 
     /** @param Options $options */

--- a/src/DecompressString.php
+++ b/src/DecompressString.php
@@ -17,9 +17,9 @@ use function strtolower;
  * }
  * @implements FilterInterface<string>
  */
-final class DecompressString implements FilterInterface
+final readonly class DecompressString implements FilterInterface
 {
-    private readonly StringCompressionAdapterInterface $adapter;
+    private StringCompressionAdapterInterface $adapter;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/DenyList.php
+++ b/src/DenyList.php
@@ -16,10 +16,10 @@ use function in_array;
  * }
  * @implements FilterInterface<null>
  */
-final class DenyList implements FilterInterface
+final readonly class DenyList implements FilterInterface
 {
-    private readonly array $list;
-    private readonly bool $strict;
+    private array $list;
+    private bool $strict;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/Digits.php
+++ b/src/Digits.php
@@ -10,7 +10,7 @@ use function is_string;
 use function preg_replace;
 
 /** @implements FilterInterface<numeric-string|''> */
-final class Digits implements FilterInterface
+final readonly class Digits implements FilterInterface
 {
     /**
      * Returns the string $value, removing all but digit characters

--- a/src/Dir.php
+++ b/src/Dir.php
@@ -10,7 +10,7 @@ use function is_string;
 /**
  * @implements FilterInterface<string>
  */
-final class Dir implements FilterInterface
+final readonly class Dir implements FilterInterface
 {
     /**
      * Defined by Laminas\Filter\FilterInterface

--- a/src/EncodingOption.php
+++ b/src/EncodingOption.php
@@ -14,7 +14,7 @@ use function sprintf;
 use function strtolower;
 
 /** @internal */
-final class EncodingOption
+final readonly class EncodingOption
 {
     /**
      * Asserts the given string is an encoding supported by ext-mbstring, returning the encoding when valid
@@ -22,7 +22,7 @@ final class EncodingOption
     public static function assert(string $encoding): string
     {
         $encoding  = strtolower($encoding);
-        $available = array_map('strtolower', mb_list_encodings());
+        $available = array_map(strtolower(...), mb_list_encodings());
         if (! in_array($encoding, $available, true)) {
             throw new InvalidArgumentException(sprintf(
                 "Encoding '%s' is not supported by the mbstring extension",

--- a/src/File/FileInformation.php
+++ b/src/File/FileInformation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Filter\File;
 
+use finfo;
 use Laminas\Filter\Exception\RuntimeException;
 use Psr\Http\Message\UploadedFileInterface;
 
@@ -38,6 +39,7 @@ final class FileInformation
     {
         if ($this->mediaType === null) {
             $fileInfo = finfo_open(FILEINFO_MIME_TYPE);
+            assert($fileInfo instanceof finfo);
 
             $mime = $fileInfo->file($this->path);
             assert(is_string($mime));

--- a/src/File/RenameUpload.php
+++ b/src/File/RenameUpload.php
@@ -11,11 +11,13 @@ use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UploadedFileInterface;
 
+use function assert;
 use function basename;
 use function file_exists;
 use function filesize;
 use function is_array;
 use function is_dir;
+use function is_int;
 use function is_string;
 use function move_uploaded_file;
 use function pathinfo;
@@ -457,9 +459,12 @@ class RenameUpload extends AbstractFilter
             ));
         }
 
+        $size = filesize($targetFile);
+        assert(is_int($size));
+
         $this->alreadyFiltered[$alreadyFilteredKey] = $uploadedFileFactory->createUploadedFile(
             $stream,
-            filesize($targetFile),
+            $size,
             UPLOAD_ERR_OK,
             $uploadedFile->getClientFilename(),
             $uploadedFile->getClientMediaType()

--- a/src/FilterChainFactory.php
+++ b/src/FilterChainFactory.php
@@ -10,7 +10,7 @@ use Psr\Container\ContainerInterface;
 use function assert;
 
 /** @psalm-import-type FilterChainConfiguration from FilterChain */
-final class FilterChainFactory implements FactoryInterface
+final readonly class FilterChainFactory implements FactoryInterface
 {
     public function __invoke(ContainerInterface $container, string $requestedName, ?array $options = null): FilterChain
     {

--- a/src/FilterPluginManagerFactory.php
+++ b/src/FilterPluginManagerFactory.php
@@ -12,7 +12,7 @@ use function is_array;
 /**
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
-final class FilterPluginManagerFactory
+final readonly class FilterPluginManagerFactory
 {
     public function __invoke(ContainerInterface $container): FilterPluginManager
     {

--- a/src/ForceUriScheme.php
+++ b/src/ForceUriScheme.php
@@ -18,12 +18,12 @@ use function sprintf;
  * @psalm-type Options = array{scheme: non-empty-string}
  * @implements FilterInterface<string>
  */
-final class ForceUriScheme implements FilterInterface
+final readonly class ForceUriScheme implements FilterInterface
 {
     private const DEFAULT_SCHEME = 'https';
 
     /** @var non-empty-string */
-    private readonly string $scheme;
+    private string $scheme;
 
     /** @param Options $options */
     public function __construct(array $options = ['scheme' => self::DEFAULT_SCHEME])

--- a/src/HtmlEntities.php
+++ b/src/HtmlEntities.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
+use function assert;
 use function function_exists;
 use function htmlentities;
 use function iconv;
@@ -20,22 +21,22 @@ use const ENT_QUOTES;
  * }
  * @implements FilterInterface<string>
  */
-final class HtmlEntities implements FilterInterface
+final readonly class HtmlEntities implements FilterInterface
 {
     /**
      * Corresponds to the second htmlentities() argument
      */
-    private readonly int $quoteStyle;
+    private int $quoteStyle;
 
     /**
      * Corresponds to the third htmlentities() argument
      */
-    private readonly string $encoding;
+    private string $encoding;
 
     /**
      * Corresponds to the forth htmlentities() argument
      */
-    private readonly bool $doubleQuote;
+    private bool $doubleQuote;
 
     /**
      * Sets filter options
@@ -70,7 +71,8 @@ final class HtmlEntities implements FilterInterface
             if (! function_exists('iconv')) {
                 throw new Exception\DomainException('Encoding mismatch has resulted in htmlentities errors');
             }
-            $value    = iconv('', $this->encoding . '//IGNORE', $value);
+            $value = iconv('', $this->encoding . '//IGNORE', $value);
+            assert(is_string($value));
             $filtered = htmlentities($value, $this->quoteStyle, $this->encoding, $this->doubleQuote);
             if (strlen($filtered) === 0) {
                 throw new Exception\DomainException('Encoding mismatch has resulted in htmlentities errors');

--- a/src/ImmutableFilterChain.php
+++ b/src/ImmutableFilterChain.php
@@ -22,14 +22,14 @@ use Psr\Container\ContainerExceptionInterface;
  * }
  * @implements FilterChainInterface<mixed>
  */
-final class ImmutableFilterChain implements FilterChainInterface
+final readonly class ImmutableFilterChain implements FilterChainInterface
 {
     /** @var PriorityQueue<InstanceType, int> */
-    private readonly PriorityQueue $filters;
+    private PriorityQueue $filters;
 
     /** @param PriorityQueue<InstanceType, int>|null $filters */
     private function __construct(
-        private readonly FilterPluginManager $pluginManager,
+        private FilterPluginManager $pluginManager,
         PriorityQueue|null $filters,
     ) {
         /** @var PriorityQueue<InstanceType, int> $default */

--- a/src/ImmutableFilterChainFactory.php
+++ b/src/ImmutableFilterChainFactory.php
@@ -10,7 +10,7 @@ use Psr\Container\ContainerInterface;
 use function assert;
 
 /** @psalm-import-type ChainSpec from ImmutableFilterChain */
-final class ImmutableFilterChainFactory implements FactoryInterface
+final readonly class ImmutableFilterChainFactory implements FactoryInterface
 {
     public function __invoke(
         ContainerInterface $container,

--- a/src/Inflector.php
+++ b/src/Inflector.php
@@ -35,19 +35,19 @@ use function str_starts_with;
  * }
  * @implements FilterInterface<string>
  */
-final class Inflector implements FilterInterface
+final readonly class Inflector implements FilterInterface
 {
     /** @var non-empty-string */
-    private readonly string $target;
-    private readonly bool $throwTargetExceptionsOn;
+    private string $target;
+    private bool $throwTargetExceptionsOn;
     /** @var non-empty-string */
-    private readonly string $targetReplacementIdentifier;
+    private string $targetReplacementIdentifier;
     /** @var array<string, string|list<InstanceType>> */
-    private readonly array $rules;
+    private array $rules;
 
     /** @param Options $options */
     public function __construct(
-        private readonly FilterPluginManager $pluginManager,
+        private FilterPluginManager $pluginManager,
         array $options,
     ) {
         $target = $options['target'] ?? null;
@@ -153,6 +153,7 @@ final class Inflector implements FilterInterface
         // all of the values of processedParts would have been str_replace('\\', '\\\\', ..)'d
         // to disable preg_replace backreferences
         $inflectedTarget = preg_replace(array_keys($processedParts), array_values($processedParts), $this->target);
+        assert($inflectedTarget !== null);
 
         if (
             $this->throwTargetExceptionsOn

--- a/src/InflectorFactory.php
+++ b/src/InflectorFactory.php
@@ -10,7 +10,7 @@ use Psr\Container\ContainerInterface;
 use function assert;
 
 /** @psalm-import-type Options from Inflector */
-final class InflectorFactory implements FactoryInterface
+final readonly class InflectorFactory implements FactoryInterface
 {
     /** @param array<array-key, mixed> $options */
     public function __invoke(

--- a/src/MonthSelect.php
+++ b/src/MonthSelect.php
@@ -18,10 +18,10 @@ use const FILTER_VALIDATE_INT;
  * }
  * @implements FilterInterface<string|null>
  */
-final class MonthSelect implements FilterInterface
+final readonly class MonthSelect implements FilterInterface
 {
-    private readonly bool $returnNullIfAnyFieldEmpty;
-    private readonly bool $returnNullIfAllFieldsEmpty;
+    private bool $returnNullIfAnyFieldEmpty;
+    private bool $returnNullIfAllFieldsEmpty;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/PregReplace.php
+++ b/src/PregReplace.php
@@ -8,6 +8,7 @@ use Laminas\Filter\Exception\InvalidArgumentException;
 
 use function array_filter;
 use function array_values;
+use function assert;
 use function is_array;
 use function is_string;
 use function preg_match;
@@ -22,12 +23,12 @@ use function str_contains;
  * }
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class PregReplace implements FilterInterface
+final readonly class PregReplace implements FilterInterface
 {
     /** @var list<non-empty-string>|non-empty-string */
-    private readonly array|string $pattern;
+    private array|string $pattern;
     /** @var list<string>|string */
-    private readonly array|string $replacement;
+    private array|string $replacement;
 
     /**
      * Supported options are
@@ -46,7 +47,12 @@ final class PregReplace implements FilterInterface
     {
         return ScalarOrArrayFilterCallback::applyRecursively(
             $value,
-            fn (string $value): string => preg_replace($this->pattern, $this->replacement, $value),
+            function (string $value): string {
+                $result = preg_replace($this->pattern, $this->replacement, $value);
+                assert(is_string($result));
+
+                return $result;
+            },
         );
     }
 

--- a/src/RealPath.php
+++ b/src/RealPath.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Laminas\Filter;
 
 use function array_pop;
+use function assert;
 use function explode;
 use function file_exists;
 use function getcwd;
@@ -21,9 +22,9 @@ use const DIRECTORY_SEPARATOR;
  * }
  * @implements FilterInterface<string>
  */
-final class RealPath implements FilterInterface
+final readonly class RealPath implements FilterInterface
 {
-    private readonly bool $pathMustExist;
+    private bool $pathMustExist;
 
     /** @param Options $options */
     public function __construct(array $options = [])
@@ -50,7 +51,10 @@ final class RealPath implements FilterInterface
         $path = $value;
 
         if (! str_starts_with($path, DIRECTORY_SEPARATOR)) {
-            $path = getcwd() . DIRECTORY_SEPARATOR . $path;
+            $cwd = getcwd();
+            assert(is_string($cwd));
+
+            $path = $cwd . DIRECTORY_SEPARATOR . $path;
         }
 
         $stack = [];

--- a/src/ScalarOrArrayFilterCallback.php
+++ b/src/ScalarOrArrayFilterCallback.php
@@ -19,7 +19,7 @@ use function is_scalar;
  * @psalm-internal \Laminas
  * @psalm-internal \LaminasTest
  */
-final class ScalarOrArrayFilterCallback
+final readonly class ScalarOrArrayFilterCallback
 {
     /**
      * Recursively applies a callback to an array of scalars or scalar input. Non-scalar values are skipped.

--- a/src/StringPrefix.php
+++ b/src/StringPrefix.php
@@ -12,9 +12,9 @@ use function sprintf;
  * }
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class StringPrefix implements FilterInterface
+final readonly class StringPrefix implements FilterInterface
 {
-    private readonly string $prefix;
+    private string $prefix;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/StringSuffix.php
+++ b/src/StringSuffix.php
@@ -12,9 +12,9 @@ use function sprintf;
  * }
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class StringSuffix implements FilterInterface
+final readonly class StringSuffix implements FilterInterface
 {
-    private readonly string $suffix;
+    private string $suffix;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/StringToLower.php
+++ b/src/StringToLower.php
@@ -11,9 +11,9 @@ use function mb_strtolower;
  * @psalm-type Options = array{encoding?: string}
  * @implements FilterInterface<string>
  */
-final class StringToLower implements FilterInterface
+final readonly class StringToLower implements FilterInterface
 {
-    private readonly string $encoding;
+    private string $encoding;
 
     /**
      * @param Options $options

--- a/src/StringToUpper.php
+++ b/src/StringToUpper.php
@@ -11,9 +11,9 @@ use function mb_strtoupper;
  * @psalm-type Options = array{encoding?: string}
  * @implements FilterInterface<string>
  */
-final class StringToUpper implements FilterInterface
+final readonly class StringToUpper implements FilterInterface
 {
-    private readonly string $encoding;
+    private string $encoding;
 
     /**
      * @param Options $options

--- a/src/StringTrim.php
+++ b/src/StringTrim.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
+use function assert;
 use function is_string;
 use function preg_replace;
 
@@ -13,9 +14,9 @@ use function preg_replace;
  * }
  * @implements FilterInterface<string>
  */
-final class StringTrim implements FilterInterface
+final readonly class StringTrim implements FilterInterface
 {
-    private readonly string $charlist;
+    private string $charlist;
 
     /** @param Options $options */
     public function __construct(array $options = [])
@@ -48,10 +49,14 @@ final class StringTrim implements FilterInterface
             ['\\\\\\0', '\\', '\/'],
             $this->charlist,
         );
+        assert(is_string($chars));
 
         $pattern = '/^[' . $chars . ']+|[' . $chars . ']+$/usSD';
 
-        return preg_replace($pattern, '', $value);
+        $value = preg_replace($pattern, '', $value);
+        assert(is_string($value));
+
+        return $value;
     }
 
     public function __invoke(mixed $value): mixed

--- a/src/StripNewlines.php
+++ b/src/StripNewlines.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter;
 use function str_replace;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-final class StripNewlines implements FilterInterface
+final readonly class StripNewlines implements FilterInterface
 {
     /**
      * Returns $value without newline control characters

--- a/src/StripTags.php
+++ b/src/StripTags.php
@@ -33,7 +33,7 @@ use const CASE_LOWER;
  * }
  * @implements FilterInterface<string>
  */
-final class StripTags implements FilterInterface
+final readonly class StripTags implements FilterInterface
 {
     /**
      * Array of allowed tags and allowed attributes for each allowed tag
@@ -43,7 +43,7 @@ final class StripTags implements FilterInterface
      *
      * @var array<string, list<string>>
      */
-    private readonly array $tagsAllowed;
+    private array $tagsAllowed;
 
     /**
      * Array of allowed attributes for all allowed tags
@@ -52,7 +52,7 @@ final class StripTags implements FilterInterface
      *
      * @var list<string>
      */
-    private readonly array $attributesAllowed;
+    private array $attributesAllowed;
 
     /**
      * @param Options $options

--- a/src/ToFloat.php
+++ b/src/ToFloat.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter;
 use function is_scalar;
 
 /** @implements FilterInterface<float> */
-final class ToFloat implements FilterInterface
+final readonly class ToFloat implements FilterInterface
 {
     /**
      * Casts scalar values to float

--- a/src/ToInt.php
+++ b/src/ToInt.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter;
 use function is_scalar;
 
 /** @implements FilterInterface<int> */
-final class ToInt implements FilterInterface
+final readonly class ToInt implements FilterInterface
 {
     /**
      * Casts scalar values to integer

--- a/src/ToNull.php
+++ b/src/ToNull.php
@@ -19,7 +19,7 @@ use function sprintf;
  * }
  * @implements FilterInterface<null>
  */
-final class ToNull implements FilterInterface
+final readonly class ToNull implements FilterInterface
 {
     public const TYPE_BOOLEAN     = 1;
     public const TYPE_INTEGER     = 2;
@@ -40,7 +40,7 @@ final class ToNull implements FilterInterface
     ];
 
     /** @var int-mask-of<self::TYPE_*> */
-    private readonly int $type;
+    private int $type;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/ToString.php
+++ b/src/ToString.php
@@ -9,7 +9,7 @@ use Stringable;
 use function is_scalar;
 
 /** @implements FilterInterface<string> */
-final class ToString implements FilterInterface
+final readonly class ToString implements FilterInterface
 {
     /**
      * Returns (string) $value

--- a/src/UpperCaseWords.php
+++ b/src/UpperCaseWords.php
@@ -13,9 +13,9 @@ use const MB_CASE_TITLE;
  * @psalm-type Options = array{encoding?: string}
  * @implements FilterInterface<string>
  */
-final class UpperCaseWords implements FilterInterface
+final readonly class UpperCaseWords implements FilterInterface
 {
-    private readonly string $encoding;
+    private string $encoding;
 
     /**
      * @param Options $options

--- a/src/Word/CamelCaseToDash.php
+++ b/src/Word/CamelCaseToDash.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-final class CamelCaseToDash implements FilterInterface
+final readonly class CamelCaseToDash implements FilterInterface
 {
     public function filter(mixed $value): mixed
     {

--- a/src/Word/CamelCaseToSeparator.php
+++ b/src/Word/CamelCaseToSeparator.php
@@ -7,7 +7,9 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 use Laminas\Filter\ScalarOrArrayFilterCallback;
 
+use function assert;
 use function implode;
+use function is_array;
 use function preg_split;
 
 use const PREG_SPLIT_DELIM_CAPTURE;
@@ -20,9 +22,9 @@ use const PREG_SPLIT_NO_EMPTY;
  * @template TOptions of Options
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class CamelCaseToSeparator implements FilterInterface
+final readonly class CamelCaseToSeparator implements FilterInterface
 {
-    private readonly string $separator;
+    private string $separator;
 
     /** @param Options $options */
     public function __construct(array $options = [])
@@ -37,24 +39,29 @@ final class CamelCaseToSeparator implements FilterInterface
 
     public function filter(mixed $value): mixed
     {
-        $pattern = <<<REGEXP
-        /
-        (
-            (?:\p{Lu}\p{Ll}+) # Upper followed by lower
-            |
-            (?:\p{Lu}+(?!\p{Ll})) # Upper not followed by lower
-            |
-            (?:\p{N}+) # Runs of numbers
-        )
-        /ux
-        REGEXP;
-
         return ScalarOrArrayFilterCallback::applyRecursively(
             $value,
-            fn (string $input): string => implode(
-                $this->separator,
-                preg_split($pattern, $input, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY),
-            )
+            function (string $input): string {
+                $pattern = <<<REGEXP
+                /
+                (
+                    (?:\p{Lu}\p{Ll}+) # Upper followed by lower
+                    |
+                    (?:\p{Lu}+(?!\p{Ll})) # Upper not followed by lower
+                    |
+                    (?:\p{N}+) # Runs of numbers
+                )
+                /ux
+                REGEXP;
+
+                $parts = preg_split($pattern, $input, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
+                assert(is_array($parts));
+
+                return implode(
+                    $this->separator,
+                    $parts,
+                );
+            },
         );
     }
 }

--- a/src/Word/CamelCaseToUnderscore.php
+++ b/src/Word/CamelCaseToUnderscore.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-final class CamelCaseToUnderscore implements FilterInterface
+final readonly class CamelCaseToUnderscore implements FilterInterface
 {
     public function filter(mixed $value): mixed
     {

--- a/src/Word/DashToCamelCase.php
+++ b/src/Word/DashToCamelCase.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-final class DashToCamelCase implements FilterInterface
+final readonly class DashToCamelCase implements FilterInterface
 {
     public function filter(mixed $value): mixed
     {

--- a/src/Word/DashToSeparator.php
+++ b/src/Word/DashToSeparator.php
@@ -17,9 +17,9 @@ use function str_replace;
  * @template TOptions of Options
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class DashToSeparator implements FilterInterface
+final readonly class DashToSeparator implements FilterInterface
 {
-    private readonly string $separator;
+    private string $separator;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/Word/DashToUnderscore.php
+++ b/src/Word/DashToUnderscore.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-final class DashToUnderscore implements FilterInterface
+final readonly class DashToUnderscore implements FilterInterface
 {
     public function filter(mixed $value): mixed
     {

--- a/src/Word/SeparatorToCamelCase.php
+++ b/src/Word/SeparatorToCamelCase.php
@@ -7,6 +7,7 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 use Laminas\Filter\ScalarOrArrayFilterCallback;
 
+use function assert;
 use function mb_strtoupper;
 use function preg_quote;
 use function preg_replace_callback;
@@ -17,9 +18,9 @@ use function preg_replace_callback;
  * }
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class SeparatorToCamelCase implements FilterInterface
+final readonly class SeparatorToCamelCase implements FilterInterface
 {
-    private readonly string $separator;
+    private string $separator;
 
     /** @param Options $options */
     public function __construct(array $options = [])
@@ -37,8 +38,8 @@ final class SeparatorToCamelCase implements FilterInterface
             '#(^\P{Z}{1})#u',
         ];
         $replacements = [
-            static fn($matches): string => mb_strtoupper($matches[2], 'UTF-8'),
-            static fn($matches): string => mb_strtoupper($matches[1], 'UTF-8'),
+            static fn(array $matches): string => mb_strtoupper((string) $matches[2], 'UTF-8'),
+            static fn(array $matches): string => mb_strtoupper((string) $matches[1], 'UTF-8'),
         ];
 
         return ScalarOrArrayFilterCallback::applyRecursively(
@@ -46,7 +47,10 @@ final class SeparatorToCamelCase implements FilterInterface
             function (string $input) use ($patterns, $replacements): string {
                 $filtered = $input;
                 foreach ($patterns as $index => $pattern) {
-                    $filtered = preg_replace_callback($pattern, $replacements[$index], $filtered);
+                    $value = preg_replace_callback($pattern, $replacements[$index], $filtered);
+                    assert($value !== null);
+
+                    $filtered = $value;
                 }
                 return $filtered;
             }

--- a/src/Word/SeparatorToDash.php
+++ b/src/Word/SeparatorToDash.php
@@ -13,9 +13,9 @@ use Laminas\Filter\FilterInterface;
  * @template TOptions of Options
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class SeparatorToDash implements FilterInterface
+final readonly class SeparatorToDash implements FilterInterface
 {
-    private readonly string $separator;
+    private string $separator;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/Word/SeparatorToSeparator.php
+++ b/src/Word/SeparatorToSeparator.php
@@ -7,6 +7,8 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 use Laminas\Filter\ScalarOrArrayFilterCallback;
 
+use function assert;
+use function is_string;
 use function preg_quote;
 use function preg_replace;
 
@@ -18,10 +20,10 @@ use function preg_replace;
  * @template TOptions of Options
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class SeparatorToSeparator implements FilterInterface
+final readonly class SeparatorToSeparator implements FilterInterface
 {
-    private readonly string $searchSeparator;
-    private readonly string $replacementSeparator;
+    private string $searchSeparator;
+    private string $replacementSeparator;
 
     /** @param Options $options */
     public function __construct(array $options = [])
@@ -34,11 +36,16 @@ final class SeparatorToSeparator implements FilterInterface
     {
         return ScalarOrArrayFilterCallback::applyRecursively(
             $value,
-            fn (string $input): string => preg_replace(
-                '#' . preg_quote($this->searchSeparator, '#') . '#',
-                $this->replacementSeparator,
-                $input
-            )
+            function (string $input): string {
+                $result = preg_replace(
+                    '#' . preg_quote($this->searchSeparator, '#') . '#',
+                    $this->replacementSeparator,
+                    $input
+                );
+                assert(is_string($result));
+
+                return $result;
+            },
         );
     }
 

--- a/src/Word/UnderscoreToCamelCase.php
+++ b/src/Word/UnderscoreToCamelCase.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-class UnderscoreToCamelCase implements FilterInterface
+final readonly class UnderscoreToCamelCase implements FilterInterface
 {
     public function filter(mixed $value): mixed
     {

--- a/src/Word/UnderscoreToDash.php
+++ b/src/Word/UnderscoreToDash.php
@@ -7,7 +7,7 @@ namespace Laminas\Filter\Word;
 use Laminas\Filter\FilterInterface;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-final class UnderscoreToDash implements FilterInterface
+final readonly class UnderscoreToDash implements FilterInterface
 {
     public function filter(mixed $value): mixed
     {

--- a/src/Word/UnderscoreToSeparator.php
+++ b/src/Word/UnderscoreToSeparator.php
@@ -13,9 +13,9 @@ use Laminas\Filter\FilterInterface;
  * @template TOptions of Options
  * @implements FilterInterface<string|array<array-key, string|mixed>>
  */
-final class UnderscoreToSeparator implements FilterInterface
+final readonly class UnderscoreToSeparator implements FilterInterface
 {
-    private readonly string $separator;
+    private string $separator;
 
     /** @param Options $options */
     public function __construct(array $options = [])

--- a/src/Word/UnderscoreToStudlyCase.php
+++ b/src/Word/UnderscoreToStudlyCase.php
@@ -14,7 +14,7 @@ use function mb_strtolower;
 use function mb_substr;
 
 /** @implements FilterInterface<string|array<array-key, string|mixed>> */
-final class UnderscoreToStudlyCase implements FilterInterface
+final readonly class UnderscoreToStudlyCase implements FilterInterface
 {
     public function filter(mixed $value): mixed
     {

--- a/test/Compress/TarAdapterTest.php
+++ b/test/Compress/TarAdapterTest.php
@@ -118,7 +118,10 @@ class TarAdapterTest extends TestCase
         $expectFile = $this->dir . '/File1.txt';
 
         self::assertFileExists($expectFile);
-        self::assertSame('File 1', trim(file_get_contents($expectFile)));
+        $contents = file_get_contents($expectFile);
+        self::assertIsString($contents);
+
+        self::assertSame('File 1', trim($contents));
     }
 
     public function testCompressFileThatDoesNotExist(): void

--- a/test/CompressToArchiveTest.php
+++ b/test/CompressToArchiveTest.php
@@ -128,9 +128,11 @@ class CompressToArchiveTest extends TestCase
     {
         $filter = new CompressToArchive($options);
         $path   = __DIR__ . '/Compress/fixtures/directory-to-compress/File1.txt';
+        $size   = filesize($path);
+        self::assertIsInt($size);
         $upload = new UploadedFile(
             $path,
-            filesize($path),
+            $size,
             UPLOAD_ERR_OK,
             'Foo.txt',
             'text/plain',

--- a/test/DecompressArchiveTest.php
+++ b/test/DecompressArchiveTest.php
@@ -92,10 +92,12 @@ class DecompressArchiveTest extends TestCase
     public function testThatPsr7UploadsWillBeDecompressed(string $value, string $expectFile): void
     {
         $filter = new DecompressArchive(['target' => $this->target]);
+        $size   = filesize($value);
+        self::assertIsInt($size);
 
         $upload = new UploadedFile(
             $value,
-            filesize($value),
+            $size,
             UPLOAD_ERR_OK,
             'Foo.txt',
             'text/plain',

--- a/test/File/FileInformationTest.php
+++ b/test/File/FileInformationTest.php
@@ -54,10 +54,12 @@ class FileInformationTest extends TestCase
     public function testExpectedValuesForUploadedFile(): void
     {
         $path = __DIR__ . '/fixtures/File1.txt';
+        $size = filesize($path);
+        self::assertIsInt($size);
 
         $upload = new UploadedFile(
             $path,
-            filesize($path),
+            $size,
             UPLOAD_ERR_OK,
             'Foo.txt',
             'text/plain',

--- a/test/File/LowerCaseTest.php
+++ b/test/File/LowerCaseTest.php
@@ -45,18 +45,26 @@ class LowerCaseTest extends TestCase
 
     public function testInstanceCreationAndNormalWorkflow(): void
     {
-        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('This is a File', $contents);
         $filter = new FileLowerCase();
         $filter($this->testFile);
-        self::assertStringContainsString('this is a file', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('this is a file', $contents);
     }
 
     public function testNormalWorkflowWithFilesArray(): void
     {
-        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('This is a File', $contents);
         $filter = new FileLowerCase();
         $filter(['tmp_name' => $this->testFile]);
-        self::assertStringContainsString('this is a file', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('this is a file', $contents);
     }
 
     public function testFileNotFoundException(): void
@@ -69,10 +77,14 @@ class LowerCaseTest extends TestCase
 
     public function testCheckSettingOfEncodingInInstance(): void
     {
-        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('This is a File', $contents);
         $filter = new FileLowerCase(['encoding' => 'ISO-8859-1']);
         $filter($this->testFile);
-        self::assertStringContainsString('this is a file', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('this is a file', $contents);
     }
 
     public static function returnUnfilteredDataProvider(): array

--- a/test/File/RenameUploadTest.php
+++ b/test/File/RenameUploadTest.php
@@ -91,7 +91,10 @@ class RenameUploadTest extends TestCase
             return;
         }
 
-        foreach (glob($dir . DIRECTORY_SEPARATOR . '*') as $file) {
+        $files = glob($dir . DIRECTORY_SEPARATOR . '*');
+        self::assertIsIterable($files);
+
+        foreach ($files as $file) {
             if (is_file($file)) {
                 unlink($file);
                 continue;

--- a/test/File/UpperCaseTest.php
+++ b/test/File/UpperCaseTest.php
@@ -58,18 +58,26 @@ class UpperCaseTest extends TestCase
 
     public function testInstanceCreationAndNormalWorkflow(): void
     {
-        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('This is a File', $contents);
         $filter = new FileUpperCase();
         $filter($this->testFile);
-        self::assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('THIS IS A FILE', $contents);
     }
 
     public function testNormalWorkflowWithFilesArray(): void
     {
-        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('This is a File', $contents);
         $filter = new FileUpperCase();
         $filter(['tmp_name' => $this->testFile]);
-        self::assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
+        $contents = file_get_contents($this->testFile);
+        self::assertIsString($contents);
+        self::assertStringContainsString('THIS IS A FILE', $contents);
     }
 
     public function testFileNotFoundException(): void
@@ -82,10 +90,14 @@ class UpperCaseTest extends TestCase
 
     public function testCheckSettingOfEncodingInInstance(): void
     {
-        self::assertStringContainsString('This is a File', file_get_contents($this->testFile));
+        $content = file_get_contents($this->testFile);
+        self::assertIsString($content);
+        self::assertStringContainsString('This is a File', $content);
         $filter = new FileUpperCase(['encoding' => 'ISO-8859-1']);
         $filter($this->testFile);
-        self::assertStringContainsString('THIS IS A FILE', file_get_contents($this->testFile));
+        $content = file_get_contents($this->testFile);
+        self::assertIsString($content);
+        self::assertStringContainsString('THIS IS A FILE', $content);
     }
 
     public static function returnUnfilteredDataProvider(): array

--- a/test/RealPathTest.php
+++ b/test/RealPathTest.php
@@ -63,7 +63,9 @@ class RealPathTest extends TestCase
         $path = './nonexistent';
 
         if (str_contains(PHP_OS, 'BSD')) {
-            self::assertSame(getcwd() . '/nonexistent', $filter($path));
+            $cwd = getcwd();
+            self::assertIsString($cwd);
+            self::assertSame($cwd . '/nonexistent', $filter($path));
         } else {
             self::assertSame($path, $filter($path));
         }
@@ -71,12 +73,15 @@ class RealPathTest extends TestCase
 
     public static function returnNonExistentPathDataProvider(): array
     {
+        $cwd = getcwd();
+        self::assertIsString($cwd);
+
         return [
             ['/nonexistent/absolute/path', '/nonexistent/absolute/path'],
             ['/nonexistent/absolute/extra///slashes', '/nonexistent/absolute/extra/slashes'],
-            ['./nonexistent/relative/path', getcwd() . '/nonexistent/relative/path'],
-            ['./dropped/parts/../../path', getcwd() . '/path'],
-            ['../relative/from/parent', dirname(getcwd()) . '/relative/from/parent'],
+            ['./nonexistent/relative/path', $cwd . '/nonexistent/relative/path'],
+            ['./dropped/parts/../../path', $cwd . '/path'],
+            ['../relative/from/parent', dirname($cwd) . '/relative/from/parent'],
         ];
     }
 

--- a/test/StringTrimTest.php
+++ b/test/StringTrimTest.php
@@ -9,6 +9,8 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 use PHPUnit\Framework\TestCase;
 
+use function assert;
+use function is_string;
 use function mb_chr;
 use function str_repeat;
 
@@ -17,14 +19,21 @@ class StringTrimTest extends TestCase
     /** @return array<string, array{0: mixed, 1: mixed}> */
     public static function defaultBehaviourDataProvider(): array
     {
+        $mbChr = static function (int $code): string {
+            $value = mb_chr($code);
+            assert(is_string($value));
+
+            return $value;
+        };
+
         return [
             'Ascii, no whitespace'    => ['string', 'string'],
             'Empty String'            => ['', ''],
             'Only Ascii whitespace'   => ["   \n\t   ", ''],
-            'Only Unicode whitespace' => [str_repeat(mb_chr(0x2029), 10), ''],
-            'Narrow Spaces'           => [mb_chr(0x202F) . 'Foo' . mb_chr(0x202F), 'Foo'],
-            'Em Spaces'               => [mb_chr(0x2003) . 'Foo' . mb_chr(0x2003), 'Foo'],
-            'Thin Spaces'             => [mb_chr(0x2009) . 'Foo' . mb_chr(0x2009), 'Foo'],
+            'Only Unicode whitespace' => [str_repeat($mbChr(0x2029), 10), ''],
+            'Narrow Spaces'           => [$mbChr(0x202F) . 'Foo' . $mbChr(0x202F), 'Foo'],
+            'Em Spaces'               => [$mbChr(0x2003) . 'Foo' . $mbChr(0x2003), 'Foo'],
+            'Thin Spaces'             => [$mbChr(0x2009) . 'Foo' . $mbChr(0x2009), 'Foo'],
             'ZF-7183'                 => ['Зенд', 'Зенд'],
             'ZF-170'                  => ['Расчет', 'Расчет'],
             'ZF-7902'                 => ['/', '/'],


### PR DESCRIPTION
- Marks _(nearly)_ all filter classes as readonly
- Fixes a number of new Psalm issues, mainly concerned with null/false return types from built-ins
