### PR TITLE
Improve the `ToString` filter to cast array members to strings recursively

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -365,6 +365,12 @@ The following methods have been removed:
 
 The constructor now only accepts an associative array of [documented options](../standard-filters.md#tonull).
 
+#### `ToString`
+
+This filter now also casts array values to strings recursively.
+
+[Basic Usage](../standard-filters.md#tostring)
+
 #### `UnderscoreToSeparator`
 
 The constructor now only accepts an associative array of [documented options](../word.md#underscoretoseparator).

--- a/docs/book/v3/standard-filters.md
+++ b/docs/book/v3/standard-filters.md
@@ -862,6 +862,8 @@ It is best practice is to use the `TYPE_*` constants rather than the human-reada
 ## ToString
 
 The `ToString` filter casts `Stringable` objects or scalar values to `string`.
+If an array is received, member values are cast to a string recursively.
+
 This filter has no runtime options.
 
 ### Basic Usage
@@ -870,14 +872,16 @@ This filter has no runtime options.
 $filter = new \Laminas\Filter\ToString();
 
 $filter->filter(123); // "123"
+$filter->filter(['id' => 100, 'roles' => null]); // ['id' => "100", 'roles' => null]
 ```
 
-Non-scalar input will be returned un-filtered:
+Non-scalar or null input will be returned un-filtered:
 
 ```php
 $filter = new \Laminas\Filter\ToString();
 
-$filter->filter(['muppet' => 'Kermit']); // ['muppet' => 'Kermit']
+$filter->filter(null); // null
+$filter->filter(new \stdClass()); // \stdClass object
 ```
 
 ## PregReplace

--- a/src/ToString.php
+++ b/src/ToString.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 namespace Laminas\Filter;
 
-use Stringable;
-
-use function is_scalar;
-
-/** @implements FilterInterface<string> */
+/** @implements FilterInterface<mixed> */
 final class ToString implements FilterInterface
 {
     /**
@@ -18,14 +14,10 @@ final class ToString implements FilterInterface
      */
     public function filter(mixed $value): mixed
     {
-        if (
-            ! is_scalar($value)
-            && ! $value instanceof Stringable
-        ) {
-            return $value;
-        }
-
-        return (string) $value;
+        return ScalarOrArrayFilterCallback::applyRecursively(
+            $value,
+            fn (string $value): string => $value,
+        );
     }
 
     public function __invoke(mixed $value): mixed

--- a/test/ToStringTest.php
+++ b/test/ToStringTest.php
@@ -12,20 +12,25 @@ use stdClass;
 
 final class ToStringTest extends TestCase
 {
-    /** @return list<array{0: mixed, 1: string}> */
+    /** @return list<array{0: mixed, 1: mixed}> */
     public static function returnBasicDataProvider(): array
     {
         return [
             [0, '0'],
             ['string', 'string'],
             [false, ''],
+            [true, '1'],
             [-1.1, '-1.1'],
             [new StringClass('test'), 'test'],
+            [
+                [0, 'string', false, -1.1, new StringClass('test'), [true, null]],
+                ['0', 'string', '', '-1.1', 'test', ['1', null]],
+            ],
         ];
     }
 
     #[DataProvider('returnBasicDataProvider')]
-    public function testBasic(mixed $input, string $output): void
+    public function testBasic(mixed $input, mixed $output): void
     {
         $filter = new ToString();
 
@@ -33,7 +38,7 @@ final class ToStringTest extends TestCase
     }
 
     #[DataProvider('returnBasicDataProvider')]
-    public function testInvoke(mixed $input, string $output): void
+    public function testInvoke(mixed $input, mixed $output): void
     {
         $filter = new ToString();
 
@@ -46,12 +51,6 @@ final class ToStringTest extends TestCase
         return [
             [null],
             [new stdClass()],
-            [
-                [
-                    'foo',
-                    false,
-                ],
-            ],
         ];
     }
 


### PR DESCRIPTION
According to https://github.com/laminas/laminas-filter/issues/177 this should be the last Task:
- `ToString` needs to apply recursively to arrays to be more useful + docs need updating
