### PR TITLE
Minor Docs Improvements

### DIFF
--- a/docs/book/v3/migration/v2-to-v3.md
+++ b/docs/book/v3/migration/v2-to-v3.md
@@ -3,6 +3,21 @@
 laminas-filter version 3 makes a number of changes that may affect your application.
 This document details those changes, and provides suggestions on how to update your application to work with version 3.
 
+## New Features
+
+### Service Manager v4 Support
+
+Laminas Filter now supports [Service Manager v4](https://docs.laminas.dev/laminas-servicemanager/).
+This will restrict installation of `laminas-filter` in projects that have other dependencies still constrained to version 3 of service manager, such as version 2.x of `laminas-inputfilter`.
+
+### New Filters
+
+- [`ToEnum`](../standard-filters.md#toenum)
+- [`ImmutableFilterChain`](../filter-chains.md)
+- [`CompressString` and `DecompressString`](../standard-filters.md#compressstring-and-decompressstring)
+- [`CompressToArchive`](../standard-filters.md#compresstoarchive)
+- [`DecompressArchive`](../standard-filters.md#decompressarchive)
+
 ## Signature and Behaviour Changes
 
 ### FilterInterface

--- a/src/FilterChain.php
+++ b/src/FilterChain.php
@@ -13,7 +13,7 @@ use Traversable;
 use function count;
 
 /**
- * @psalm-type InstanceType = FilterInterface|callable(mixed): mixed
+ * @psalm-type InstanceType = FilterInterface|(callable(mixed): mixed)
  * @psalm-type FilterChainConfiguration = array{
  *    filters?: list<array{
  *        name: string|class-string<FilterInterface>,
@@ -21,7 +21,7 @@ use function count;
  *        priority?: int,
  *    }>,
  *    callbacks?: list<array{
- *        callback: FilterInterface|callable(mixed): mixed,
+ *        callback: FilterInterface|(callable(mixed): mixed),
  *        priority?: int,
  *    }>
  * }

--- a/src/FilterChainInterface.php
+++ b/src/FilterChainInterface.php
@@ -9,7 +9,7 @@ use Psr\Container\ContainerExceptionInterface;
 /**
  * @template TFilteredValue
  * @extends FilterInterface<TFilteredValue>
- * @psalm-type InstanceType = FilterInterface|callable(mixed): mixed
+ * @psalm-type InstanceType = FilterInterface|(callable(mixed): mixed)
  */
 interface FilterChainInterface extends FilterInterface
 {

--- a/src/FilterPluginManager.php
+++ b/src/FilterPluginManager.php
@@ -20,7 +20,7 @@ use function sprintf;
  *
  * Enforces that filters retrieved are either callbacks or instances of FilterInterface.
  *
- * @psalm-type InstanceType = FilterInterface|callable(mixed): mixed
+ * @psalm-type InstanceType = FilterInterface|(callable(mixed): mixed)
  * @extends AbstractPluginManager<InstanceType>
  * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */

--- a/src/ImmutableFilterChain.php
+++ b/src/ImmutableFilterChain.php
@@ -8,7 +8,7 @@ use Laminas\Stdlib\PriorityQueue;
 use Psr\Container\ContainerExceptionInterface;
 
 /**
- * @psalm-type InstanceType = FilterInterface|callable(mixed): mixed
+ * @psalm-type InstanceType = FilterInterface|(callable(mixed): mixed)
  * @psalm-type ChainSpec = array{
  *     filters?: list<array{
  *         name: string|class-string<FilterInterface>,
@@ -16,7 +16,7 @@ use Psr\Container\ContainerExceptionInterface;
  *         priority?: int|null,
  *     }>,
  *     callbacks?: list<array{
- *         callback: FilterInterface|callable(mixed): mixed,
+ *         callback: FilterInterface|(callable(mixed): mixed),
  *         priority?: int|null,
  *     }>,
  * }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Add parenthesis around callable types in doc blocks, this helps IDEs better understand the type aliases.

Adds a "New Features" section to the migration guide