### PR TITLE
Allow filter chains to be constructed with instances in the specification

### DIFF
--- a/src/FilterChain.php
+++ b/src/FilterChain.php
@@ -11,6 +11,7 @@ use Psr\Container\ContainerExceptionInterface;
 use Traversable;
 
 use function count;
+use function is_callable;
 
 /**
  * @psalm-type InstanceType = FilterInterface|(callable(mixed): mixed)
@@ -19,7 +20,7 @@ use function count;
  *        name: string|class-string<FilterInterface>,
  *        options?: array<string, mixed>,
  *        priority?: int,
- *    }>,
+ *    }|InstanceType>,
  *    callbacks?: list<array{
  *        callback: FilterInterface|(callable(mixed): mixed),
  *        priority?: int,
@@ -55,6 +56,11 @@ final class FilterChain implements FilterChainInterface, Countable, IteratorAggr
 
         $filters = $options['filters'] ?? [];
         foreach ($filters as $spec) {
+            if (is_callable($spec) || $spec instanceof FilterInterface) {
+                $this->attach($spec);
+                continue;
+            }
+
             $this->attachByName(
                 $spec['name'],
                 $spec['options'] ?? [],

--- a/test/FilterChainTest.php
+++ b/test/FilterChainTest.php
@@ -225,4 +225,17 @@ final class FilterChainTest extends TestCase
 
         self::assertSame('foo', $chain->__invoke('FOO'));
     }
+
+    public function testFilterChainSpecAcceptsFilterInstances(): void
+    {
+        $filter = new StringTrim();
+        $chain  = new FilterChain($this->plugins, [
+            'filters' => [
+                $filter,
+            ],
+        ]);
+
+        $filters = iterator_to_array($chain);
+        self::assertSame([0 => $filter], $filters);
+    }
 }


### PR DESCRIPTION
We should be able to create a filter chain with something like:

```php
$chain = new FilterChain($pluginManager, [
    'filters' => [
        [ /** Spec Array */ ],
        new StringTrim(),
    ],
]);
```

This patch allows instances to given in the spec array and updates the documented types to suit

Relevant to:

https://github.com/laminas/laminas-inputfilter/pull/149