### PR TITLE
Fix filters registered under `services` cannot be found (no factory)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,13 +46,13 @@
         "ext-bz2": "*",
         "ext-zlib": "*",
         "ext-zip": "*",
-        "laminas/laminas-coding-standard": "^3.0.1",
+        "laminas/laminas-coding-standard": "^3.1.0",
         "laminas/laminas-diactoros": "^3.6",
-        "pear/archive_tar": "^1.5.0",
+        "pear/archive_tar": "^1.6.0",
         "pear/pear": "^1.10.16",
-        "phpunit/phpunit": "^10.5.46",
+        "phpunit/phpunit": "^10.5.51",
         "psalm/plugin-phpunit": "^0.19.5",
-        "vimeo/psalm": "^6.10.3"
+        "vimeo/psalm": "^6.13.1"
     },
     "suggest": {
         "laminas/laminas-i18n": "Laminas\\I18n component for filters depending on i18n functionality",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d0b8e3d4f587eba00e25c391989a5e04",
+    "content-hash": "8c7bd52262d5cee9be89c92978f36568",
     "packages": [
         {
             "name": "brick/varexporter",
@@ -201,16 +201,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.6.0",
+            "version": "v5.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56"
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/221b0d0fdf1369c71047ad1d18bb5880017bbc56",
-                "reference": "221b0d0fdf1369c71047ad1d18bb5880017bbc56",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
+                "reference": "f103601b29efebd7ff4a1ca7b3eeea9e3336a2a2",
                 "shasum": ""
             },
             "require": {
@@ -229,7 +229,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
@@ -253,9 +253,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.6.1"
             },
-            "time": "2025-07-27T20:03:57+00:00"
+            "time": "2025-08-13T20:13:15+00:00"
         },
         {
             "name": "psr/container",
@@ -3324,16 +3324,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.48",
+            "version": "10.5.51",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541"
+                "reference": "ace160e31aaa317a99c411410c40c502b4be42a4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
-                "reference": "6e0a2bc39f6fae7617989d690d76c48e6d2eb541",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/ace160e31aaa317a99c411410c40c502b4be42a4",
+                "reference": "ace160e31aaa317a99c411410c40c502b4be42a4",
                 "shasum": ""
             },
             "require": {
@@ -3343,7 +3343,7 @@
                 "ext-mbstring": "*",
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
-                "myclabs/deep-copy": "^1.13.3",
+                "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
@@ -3360,7 +3360,7 @@
                 "sebastian/exporter": "^5.1.2",
                 "sebastian/global-state": "^6.0.2",
                 "sebastian/object-enumerator": "^5.0.0",
-                "sebastian/recursion-context": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
                 "sebastian/type": "^4.0.0",
                 "sebastian/version": "^4.0.1"
             },
@@ -3405,7 +3405,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.48"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.51"
             },
             "funding": [
                 {
@@ -3429,7 +3429,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-11T04:07:17+00:00"
+            "time": "2025-08-12T07:31:25+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4357,23 +4357,23 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "5.0.0",
+            "version": "5.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712"
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/05909fb5bc7df4c52992396d0116aed689f93712",
-                "reference": "05909fb5bc7df4c52992396d0116aed689f93712",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -4408,15 +4408,28 @@
             "homepage": "https://github.com/sebastianbergmann/recursion-context",
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.0"
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2023-02-03T07:05:40+00:00"
+            "time": "2025-08-10T07:50:56+00:00"
         },
         {
             "name": "sebastian/type",
@@ -5599,16 +5612,16 @@
         },
         {
             "name": "vimeo/psalm",
-            "version": "6.13.0",
+            "version": "6.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/vimeo/psalm.git",
-                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c"
+                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/vimeo/psalm/zipball/70cdf647255a1362b426bb0f522a85817b8c791c",
-                "reference": "70cdf647255a1362b426bb0f522a85817b8c791c",
+                "url": "https://api.github.com/repos/vimeo/psalm/zipball/1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
+                "reference": "1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51",
                 "shasum": ""
             },
             "require": {
@@ -5713,7 +5726,7 @@
                 "issues": "https://github.com/vimeo/psalm/issues",
                 "source": "https://github.com/vimeo/psalm"
             },
-            "time": "2025-07-14T09:59:17+00:00"
+            "time": "2025-08-06T10:10:28+00:00"
         },
         {
             "name": "webimpress/coding-standard",

--- a/src/FilterChain.php
+++ b/src/FilterChain.php
@@ -84,8 +84,13 @@ final class FilterChain implements FilterChainInterface, Countable, IteratorAggr
 
     public function attachByName(string $name, array $options = [], int $priority = self::DEFAULT_PRIORITY): self
     {
-        /** @psalm-var FilterInterface $filter */
-        $filter = $this->plugins->build($name, $options);
+        if ($options === []) {
+            /** @psalm-var FilterInterface $filter */
+            $filter = $this->plugins->get($name);
+        } else {
+            /** @psalm-var FilterInterface $filter */
+            $filter = $this->plugins->build($name, $options);
+        }
 
         return $this->attach($filter, $priority);
     }

--- a/src/ImmutableFilterChain.php
+++ b/src/ImmutableFilterChain.php
@@ -96,8 +96,14 @@ final class ImmutableFilterChain implements FilterChainInterface
 
     public function attachByName(string $name, array $options = [], int $priority = self::DEFAULT_PRIORITY): self
     {
-        /** @psalm-var FilterInterface $filter */
-        $filter  = $this->pluginManager->build($name, $options);
+        if ($options === []) {
+            /** @psalm-var FilterInterface $filter */
+            $filter = $this->pluginManager->get($name);
+        } else {
+            /** @psalm-var FilterInterface $filter */
+            $filter = $this->pluginManager->build($name, $options);
+        }
+
         $filters = clone $this->filters;
         $filters->insert($filter, $priority);
 

--- a/test/FilterChainTest.php
+++ b/test/FilterChainTest.php
@@ -23,6 +23,7 @@ use function trim;
 
 /**
  * @psalm-import-type FilterChainConfiguration from FilterChain
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
  */
 final class FilterChainTest extends TestCase
 {
@@ -30,7 +31,13 @@ final class FilterChainTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->plugins = new FilterPluginManager(new ServiceManager());
+        $this->plugins = self::pluginManagerWithConfig();
+    }
+
+    /** @param ServiceManagerConfiguration $config */
+    private static function pluginManagerWithConfig(array $config = []): FilterPluginManager
+    {
+        return new FilterPluginManager(new ServiceManager(), $config);
     }
 
     public function testEmptyFilterChainReturnsOriginalValue(): void
@@ -237,5 +244,25 @@ final class FilterChainTest extends TestCase
 
         $filters = iterator_to_array($chain);
         self::assertSame([0 => $filter], $filters);
+    }
+
+    public function testServiceManagerServicesCanBeUsedInChains(): void
+    {
+        $closure = static fn (mixed $value): mixed => $value;
+        $plugins = self::pluginManagerWithConfig([
+            'services' => [
+                'custom' => $closure,
+            ],
+        ]);
+
+        $chain = iterator_to_array(new FilterChain($plugins, [
+            'filters' => [
+                ['name' => StringTrim::class],
+                ['name' => 'custom'],
+            ],
+        ]), false);
+
+        self::assertCount(2, $chain);
+        self::assertSame($closure, $chain[1]);
     }
 }

--- a/test/ImmutableFilterChainTest.php
+++ b/test/ImmutableFilterChainTest.php
@@ -8,21 +8,32 @@ use Laminas\Filter\FilterPluginManager;
 use Laminas\Filter\ImmutableFilterChain;
 use Laminas\Filter\StringPrefix;
 use Laminas\Filter\StringToLower;
+use Laminas\Filter\StringTrim;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase;
 
 use function implode;
 use function str_replace;
 use function str_split;
+use function strrev;
 
-/** @psalm-import-type InstanceType from ImmutableFilterChain */
+/**
+ * @psalm-import-type InstanceType from ImmutableFilterChain
+ * @psalm-import-type ServiceManagerConfiguration from ServiceManager
+ */
 final class ImmutableFilterChainTest extends TestCase
 {
     private FilterPluginManager $plugins;
 
     protected function setUp(): void
     {
-        $this->plugins = new FilterPluginManager(new ServiceManager());
+        $this->plugins = self::pluginManagerWithConfig();
+    }
+
+    /** @param ServiceManagerConfiguration $config */
+    private static function pluginManagerWithConfig(array $config = []): FilterPluginManager
+    {
+        return new FilterPluginManager(new ServiceManager(), $config);
     }
 
     public function testThatFiltersWillBeRetrievedFromThePluginManager(): void
@@ -144,5 +155,23 @@ final class ImmutableFilterChainTest extends TestCase
         $chain = ImmutableFilterChain::fromArray($spec, $this->plugins);
 
         self::assertSame('Foofoo', $chain->filter('Foo'));
+    }
+
+    public function testServiceManagerServicesCanBeUsedInChains(): void
+    {
+        $plugins = self::pluginManagerWithConfig([
+            'services' => [
+                'custom' => static fn (string $value): string => strrev($value),
+            ],
+        ]);
+
+        $chain = ImmutableFilterChain::fromArray([
+            'filters' => [
+                ['name' => StringTrim::class],
+                ['name' => 'custom'],
+            ],
+        ], $plugins);
+
+        self::assertSame('oof', $chain->filter('  foo  '));
     }
 }


### PR DESCRIPTION
Because `get()` no longer supports options (to be compliant with psr-container), filter chain used `build()` to retrieve all filter instances.

This is problematic when the user has configured a filter instance under `services`, because `build()` of-course does not fetch from `services`.

The fix here is to call `get()` when no options are given.